### PR TITLE
Initial commit of early Widget trait with example. Includes Button, Toggle and Slider.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,35 @@
 
 name = "conrod"
 version = "0.0.0"
-authors = ["Your Name <your@email.com>"]
-tags = []
+authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
+
+[dependencies.piston]
+
+git = "https://github.com/PistonDevelopers/piston"
+
+[dependencies.sdl2_game_window]
+
+git = "https://github.com/mitchmindtree/sdl2_game_window.git"
+
+[dependencies.graphics]
+
+git = "https://github.com/PistonDevelopers/rust-graphics.git"
+
+[dependencies.opengl_graphics]
+
+git = "https://github.com/PistonDevelopers/opengl_graphics.git"
+
+[dependencies.vecmath]
+
+git = "https://github.com/PistonDevelopers/vecmath"
 
 [[lib]]
 
 name = "conrod"
-path = "src/lib.rs"
+path = "./src/lib.rs"
+
+[[bin]]
+
+name = "conrodtest"
+path = "./examples/main.rs"
 

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -1,0 +1,70 @@
+
+use std::default::Default;
+use conrod::{
+    Button,
+    Slider,
+    Point,
+    Widget,
+    Down,
+    Right,
+    Color,
+    Toggle,
+    WidgetData,
+};
+
+pub struct Canvas {
+    widget_data: WidgetData,
+    button: Button,
+    toggle: Toggle,
+    slider: Slider<int>,
+}
+
+impl Canvas {
+
+    /// Create a new UI Widget Canvas.
+    pub fn new() -> Canvas {
+        let button: Button = Default::default();
+        let toggle = Toggle::new(Right(100u), // Relative Position to previous child.
+                                 75u, // Width
+                                 75u, // Height
+                                 6u, // Border
+                                 Color::new(0.65f32, 0.3f32, 0.7f32, 1f32), // Color
+                                 false); // Initial toggle state
+        let slider = Slider::new(Down(175u), // Relative Position to previous child.
+                                 40u, // Width
+                                 200u, // Height
+                                 3u, // Border
+                                 Color::new(0.5f32, 0.6f32, 0.8f32, 1f32), // Color
+                                 0, // Minimum slider value
+                                 128, // Maximum slider value
+                                 80); // Initial slider value
+        let mut canvas = Canvas {
+            widget_data: Default::default(),
+            button: button,
+            slider: slider,
+            toggle: toggle,
+        };
+        canvas.set_abs_pos(Point::new(50i, 50, 0));
+        canvas
+    }
+
+}
+
+impl Widget for Canvas {
+
+    impl_get_widget_data!(widget_data)
+
+    fn get_children(&self) -> Vec<&Widget> {
+        vec![&self.button as &Widget,
+             &self.toggle as &Widget,
+             &self.slider as &Widget]
+    }
+
+    fn get_children_mut(&mut self) -> Vec<&mut Widget> {
+        vec![&mut self.button as &mut Widget,
+             &mut self.toggle as &mut Widget,
+             &mut self.slider as &mut Widget]
+    }
+
+}
+

--- a/examples/graph.rs
+++ b/examples/graph.rs
@@ -1,4 +1,0 @@
-fn main() {
-	println!("Hello!");
-}
-

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,0 +1,90 @@
+
+#![feature(phase)]
+
+#[phase(plugin, link)]
+extern crate conrod;
+extern crate graphics;
+extern crate piston;
+extern crate sdl2_game_window;
+extern crate opengl_graphics;
+
+use canvas::Canvas;
+use sdl2_game_window::GameWindowSDL2;
+use opengl_graphics::Gl;
+use piston::{
+    Game,
+    GameEvent,
+    GameWindowSettings,
+    GameIterator,
+    GameIteratorSettings,
+    RenderArgs,
+    Render,
+};
+pub use widget = conrod::widget;
+use conrod::{
+    Widget,
+};
+use graphics::{
+    Context,
+    AddColor,
+    Draw,
+};
+
+mod canvas;
+
+fn main() {
+
+    // Create a SDL2 window.
+    let mut window = GameWindowSDL2::new(
+        GameWindowSettings {
+            title: "Hello Conrod".to_string(),
+            size: [600, 600],
+            fullscreen: false,
+            exit_on_esc: true
+        }
+    );
+
+    // Some settings for how the game should be run.
+    let game_iter_settings = GameIteratorSettings {
+        updates_per_second: 180,
+        max_frames_per_second: 60
+    };
+
+    // Create GameIterator to begin the event iteration loop.
+    let mut game_iter = GameIterator::new(&mut window, &game_iter_settings);
+    // Create OpenGL instance.
+    let mut gl = Gl::new();
+    // Create UI app.
+    let mut canvas = Canvas::new();
+
+    loop {
+        match game_iter.next() {
+            None => break,
+            Some(mut e) => handle_event(&mut e, &mut canvas, &mut gl),
+        }
+    }
+
+}
+
+/// Match the game event.
+fn handle_event(event: &mut GameEvent,
+                canvas: &mut Canvas,
+                gl: &mut Gl) {
+    canvas.event(event);
+    match *event {
+        Render(ref mut args) => {
+            draw_background(args, gl);
+            canvas.draw(args, gl)
+        },
+        _ => (),
+    }
+}
+
+/// Draw the window background.
+fn draw_background(args: &RenderArgs, gl: &mut Gl) {
+    // Set up a context to draw into.
+    let context = &Context::abs(args.width as f64, args.height as f64);
+    // Draw the background.
+    context.rgba(0.075,0.05,0.1,1.0).draw(gl);
+}
+

--- a/src/button.rs
+++ b/src/button.rs
@@ -1,0 +1,84 @@
+
+use piston::{
+    MouseReleaseArgs,
+};
+use piston::mouse;
+use widget;
+use widget::{
+    Widget,
+    RelativePosition,
+    Highlighted,
+    Clicked,
+};
+use std::default::Default;
+use graphics::AddRectangle;
+use color::Color;
+use point::Point;
+use rectangle::Rectangle;
+
+/// Button type widget.
+#[deriving(Show, Clone)]
+pub struct Button {
+    widget_data: widget::Data,
+    rect: Rectangle,
+}
+
+impl Button {
+
+    /// Constructor for Button widget.
+    pub fn new(pos: RelativePosition, width: uint, height: uint, color: Color, border: uint) -> Button {
+        Button {
+            widget_data: widget::Data::new(pos),
+            rect: Rectangle::new(pos, width, height, color, border),
+        }
+    }
+
+}
+
+impl Default for Button {
+
+    /// Default constructor for Button widget.
+    fn default() -> Button {
+        Button {
+            widget_data: Default::default(),
+            rect: Default::default(),
+        }
+    }
+
+}
+
+impl Widget for Button {
+
+    impl_get_widget_data!(widget_data)
+
+    /// Return the dimensions as a tuple holding width and height.
+    fn get_dimensions(&self) -> (uint, uint) { self.rect.get_dimensions() }
+
+    /// Return a reference to the rectangle as a widget child.
+    fn get_children(&self) -> Vec<&Widget> {
+        vec![&self.rect as &Widget]
+    }
+
+    /// Return all children widgets.
+    fn get_children_mut(&mut self) -> Vec<&mut Widget> {
+        vec![&mut self.rect as &mut Widget]
+    }
+
+    /// Return whether or not the widget has been hit by a mouse_press.
+    fn is_over(&self, mouse_pos: Point<int>) -> bool {
+        self.rect.is_over(mouse_pos)
+    }
+
+    /// Mouse released.
+    fn mouse_release_update_draw_state(&mut self, args: &MouseReleaseArgs) {
+        match (args.button, self.get_draw_state()) {
+            (mouse::Left, Clicked) => {
+                // TRIGGER EVENT HERE.
+                self.set_draw_state(Highlighted);
+            },
+            _ => (),
+        }
+    }
+
+}
+

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,80 @@
+
+use std::default::Default;
+use utils::clampf32;
+
+/// A basic color struct for general color use
+/// made of red, green, blue and alpha elements.
+#[deriving(Show, Clone, Encodable, Decodable)]
+pub struct Color {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+impl Color {
+
+    /// Basic constructor for a Color struct.
+    pub fn new(r: f32, g: f32, b: f32, a: f32) -> Color {
+        Color { r: r, g: g, b: b, a: a }
+    }
+
+    /// Basic constructor for a Black Color struct.
+    pub fn black() -> Color {
+        Color { r: 0f32, g: 0f32, b: 0f32, a: 1f32 }
+    }
+
+    /// Return color as a vector.
+    pub fn as_vec(&self) -> Vec<f32> {
+        vec![self.r, self.g, self.b, self.a]
+    }
+
+    /// Return color as a tuple.
+    pub fn as_tuple(&self) -> (f32, f32, f32, f32) {
+        (self.r, self.g, self.b, self.a)
+    }
+
+    /// Clamp the Color's values between 0f32 and 1f32.
+    fn clamp(c: Color) -> Color {
+        Color::new(clampf32(c.r), clampf32(c.g), clampf32(c.b), clampf32(c.a))
+    }
+
+    /// Return a highlighted version of the current Color.
+    pub fn highlighted(&self) -> Color {
+        let r = clampf32((1f32 - self.r) * 0.5f32 * self.r + self.r);
+        let g = clampf32((1f32 - self.g) * 0.1f32 * self.g + self.g);
+        let b = clampf32((1f32 - self.b) * 0.1f32 * self.b + self.b);
+        let a = clampf32((1f32 - self.a) * 0.5f32 + self.a);
+        Color::new(r, g, b, a)
+    }
+
+    /// Return a clicked version of the current Color.
+    pub fn clicked(&self) -> Color {
+        let r = clampf32((1f32 - self.r) * 0.75f32 + self.r);
+        let g = clampf32((1f32 - self.g) * 0.25f32 + self.g);
+        let b = clampf32((1f32 - self.b) * 0.25f32 + self.b);
+        let a = clampf32((1f32 - self.a) * 0.75f32 + self.a);
+        Color::new(r, g, b, a)
+    }
+
+}
+
+impl Default for Color {
+    /// Default constructor for a Color struct.
+    fn default() -> Color {
+        Color { r: 0.5, g: 0.8, b: 0.6, a: 0.5 }
+    }
+}
+
+impl Add<Color, Color> for Color {
+    fn add(&self, rhs: &Color) -> Color {
+        Color::clamp(Color::new(self.r + rhs.r, self.g + rhs.g, self.b + rhs.b, self.a + rhs.a))
+    }
+}
+
+impl Sub<Color, Color> for Color {
+    fn sub(&self, rhs: &Color) -> Color {
+        Color::clamp(Color::new(self.r - rhs.r, self.g - rhs.g, self.b - rhs.b, self.a - rhs.a))
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,35 @@
-#![crate_name = "conrod"]
-#![deny(missing_doc)]
 
-//! Documentation goes here.
+#![feature(macro_rules, phase)]
+
+extern crate graphics;
+extern crate piston;
+extern crate sdl2_game_window;
+extern crate opengl_graphics;
+extern crate vecmath;
+extern crate serialize;
+
+pub use Button = button::Button;
+pub use Slider = slider::Slider;
+pub use Widget = widget::Widget;
+pub use WidgetData = widget::Data;
+pub use Color = color::Color;
+pub use Point = point::Point;
+pub use Rectangle = rectangle::Rectangle;
+pub use Specific = widget::Specific;
+pub use Toggle = toggle::Toggle;
+pub use Up = widget::Up;
+pub use Down = widget::Down;
+pub use Left = widget::Left;
+pub use Right = widget::Right;
+
+pub mod macro;
+
+pub mod button;
+pub mod color;
+pub mod point;
+pub mod rectangle;
+pub mod slider;
+pub mod toggle;
+pub mod widget;
+pub mod utils;
 

--- a/src/macro.rs
+++ b/src/macro.rs
@@ -1,0 +1,15 @@
+
+#![macro_escape]
+
+/// Simplification of the `get_widget_data` methods from the Widget trait.
+#[macro_export]
+macro_rules! impl_get_widget_data(
+    ($data:ident) => (
+        /// Return a reference to the widget data.
+        fn get_widget_data(&self) -> &::widget::Data { &self.$data }
+        /// Return a reference to the widget data.
+        fn get_widget_data_mut(&mut self) -> &mut ::widget::Data { &mut self.$data }
+    )
+)
+
+

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,0 +1,63 @@
+
+use std::default::Default;
+
+/// General use 3D spatial point. Although only
+/// 2D widgets exist at the moment, this allows
+/// for the possibility of 3D widgets in the
+/// future.
+#[deriving(Show, Clone)]
+pub struct Point<T> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
+impl<T: Num + Copy> Point<T> {
+
+    /// Constructor for a point.
+    pub fn new(x: T, y: T, z: T) -> Point<T> {
+        Point{ x: x, y: y, z: z }
+    }
+
+    /// Return the point as a vector.
+    pub fn as_vec(&self) -> Vec<T> {
+        vec![self.x, self.y, self.z]
+    }
+
+    /// Return the point as a tuple.
+    pub fn as_tuple(&self) -> (T, T, T) {
+        (self.x, self.y, self.z)
+    }
+
+}
+
+impl<T: Num + Copy + Default> Default for Point<T> {
+    fn default() -> Point<T> {
+        Point::new(Default::default(), Default::default(), Default::default())
+    }
+}
+
+impl<T: Num + Copy> Add<Point<T>, Point<T>> for Point<T> {
+    fn add(&self, rhs: &Point<T>) -> Point<T> {
+        Point::new(self.x + rhs.x, self.y + rhs.y, self.z + rhs.z)
+    }
+}
+
+impl<T: Num + Copy> Sub<Point<T>, Point<T>> for Point<T> {
+    fn sub(&self, rhs: &Point<T>) -> Point<T> {
+        Point::new(self.x - rhs.x, self.y - rhs.y, self.z - rhs.z)
+    }
+}
+
+impl<T: Num + Copy> Mul<Point<T>, Point<T>> for Point<T> {
+    fn mul(&self, rhs: &Point<T>) -> Point<T> {
+        Point::new(self.x * rhs.x, self.y * rhs.y, self.z * rhs.z)
+    }
+}
+
+impl<T: Num + Copy> Div<Point<T>, Point<T>> for Point<T> {
+    fn div(&self, rhs: &Point<T>) -> Point<T> {
+        Point::new(self.x / rhs.x, self.y / rhs.y, self.z / rhs.z)
+    }
+}
+

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,0 +1,119 @@
+
+use widget;
+use widget::{
+    RelativePosition,
+    Widget,
+    Clicked,
+    Highlighted,
+    Normal,
+};
+use piston::{
+    RenderArgs,
+};
+use opengl_graphics::Gl;
+use graphics::{
+    Context,
+    AddRectangle,
+    AddColor,
+    Draw,
+};
+use point::Point;
+use color::Color;
+use std::default::Default;
+
+/// Rectangle used for constructing 2D rectangular widgets.
+/// Rectangle can be treated as a child widget when used
+/// to construct other widgets. I.e. A `Slider` is made up
+/// of two Rectangles; one for the frame, and one for the
+/// slider itself.
+#[deriving(Show, Clone)]
+pub struct Rectangle {
+    widget_data: widget::Data,
+    pub width: uint,
+    pub height: uint,
+    pub color: Color,
+    border: uint,
+}
+
+impl Rectangle {
+
+    /// Constructor for a widget rectangle.
+    pub fn new(pos: RelativePosition,
+               width: uint,
+               height: uint,
+               color: Color,
+               border: uint) -> Rectangle {
+        Rectangle {
+            widget_data: widget::Data::new(pos),
+            width: width,
+            height: height,
+            color: color,
+            border: border,
+        }
+    }
+
+    /// Draw the button border.
+    fn draw_border(&self, context: &Context, _args: &RenderArgs, gl: &mut Gl) {
+        let (r, g, b, a) = (0.0, 0.0, 0.0, 1.0);
+        let pos = self.get_abs_pos();
+        context
+            .rect(pos.x as f64, pos.y as f64, self.width as f64, self.height as f64)
+            .rgba(r, g, b, a)
+            .draw(gl);
+    }
+
+    /// Draw the button while considering border for dimensions and position.
+    fn draw_normal(&self, context: &Context, _args: &RenderArgs, gl: &mut Gl) {
+        let bw = self.border as f64;
+        let hbw = bw / 2f64;
+        let (r, g, b, a) = match self.get_draw_state() {
+            Normal => self.color.as_tuple(),
+            Highlighted => self.color.highlighted().as_tuple(),
+            Clicked => self.color.clicked().as_tuple(),
+        };
+        let pos = self.get_abs_pos();
+        context
+            .rect(pos.x as f64 + hbw, pos.y as f64 + hbw, self.width as f64 - bw, self.height as f64 - bw)
+            .rgba(r, g, b, a)
+            .draw(gl);
+    }
+
+}
+
+impl Default for Rectangle {
+    
+    /// Default constructor for a widget Rectangle.
+    fn default() -> Rectangle {
+        Rectangle {
+            widget_data: Default::default(),
+            width: 100u,
+            height: 50u,
+            color: Default::default(),
+            border: 7u,
+        }
+    }
+
+}
+
+impl Widget for Rectangle {
+
+    impl_get_widget_data!(widget_data)
+
+    /// Return the dimensions as a tuple holding width and height.
+    fn get_dimensions(&self) -> (uint, uint) { (self.width, self.height) }
+
+    /// Return whether or not the widget has been hit by a mouse_press.
+    fn is_over(&self, mouse_pos: Point<int>) -> bool {
+        let p = mouse_pos - self.get_abs_pos();
+        if p.x > 0 && p.y > 0 && p.x < self.width as int && p.y < self.height as int { true }
+        else { false }
+    }
+
+    /// Draw the rectangle.
+    fn draw(&mut self, args: &RenderArgs, gl: &mut Gl) {
+        let context = &Context::abs(args.width as f64, args.height as f64);
+        self.draw_border(context, args, gl);
+        self.draw_normal(context, args, gl);
+    }
+
+}

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -1,0 +1,168 @@
+
+use widget;
+use widget::{
+    Clicked,
+    Highlighted,
+    Normal,
+    Widget,
+    RelativePosition,
+    Relative,
+};
+use piston::{
+    MouseMoveArgs,
+    MousePressArgs,
+};
+use rectangle::Rectangle;
+use point::Point;
+use color::Color;
+use utils::clamp;
+use std::default::Default;
+
+/// A generic slider user-interface widget. It will
+/// automatically convert itself between horizontal
+/// and vertical depending on the dimensions given.
+#[deriving(Show, Clone)]
+pub struct Slider<T> {
+    widget_data: widget::Data,
+    frame: Rectangle,
+    rect: Rectangle,
+    border: uint,
+    min: T,
+    max: T,
+    value: T,
+    last_pos: Point<int>,
+}
+
+impl<T: Num + Copy + FromPrimitive + ToPrimitive> Slider<T> {
+
+    /// Constructor for a Slider widget.
+    pub fn new(pos: RelativePosition,
+               width: uint,
+               height: uint,
+               border: uint,
+               color: Color,
+               min: T,
+               max: T,
+               value: T) -> Slider<T> {
+        let perc = Slider::percentage(value, min, max);
+        let slider_rect = match width >= height {
+            true => { // Horizontal Slider...
+                Rectangle::new(Relative(Point::new(border as int, border as int, 0)),
+                               ((width - 2u * border) as f32 * perc) as uint,
+                               height - 2u * border, color, 0u)
+            },
+            false => { // Vertical Slider...
+                let perc_alt = ::std::num::abs(perc - 1f32);
+                let y = border as int + (perc_alt * (height - 2u * border) as f32) as int;
+                Rectangle::new(Relative(Point::new(border as int, y, 0)),
+                               width - 2u * border,
+                               ((height - 2u * border) as f32 * perc) as uint,
+                               color, 0u)
+            },
+        };
+        Slider {
+            widget_data: widget::Data::new(pos),
+            frame: Rectangle::new(Relative(Point::new(0, 0, 0)), width, height, Color::black(), 0u),
+            rect: slider_rect,
+            border: border,
+            min: min,
+            max: max,
+            value: value,
+            last_pos: Default::default(),
+        }
+    }
+
+    /// Get value percentage between max and min.
+    fn percentage(value: T, min: T, max: T) -> f32 {
+        let v = value.to_f32().unwrap();
+        let mn = min.to_f32().unwrap();
+        let mx = max.to_f32().unwrap();
+        (v - mn) / (mx - mn)
+    }
+
+    /// Adjust the slider to the given point.
+    fn adjust_slider(&mut self, p: Point<int>) {
+        match self.get_draw_state() {
+            Clicked => {
+                match self.frame.width > self.frame.height {
+                    true => {
+                        // Horizontal Slider.
+                        let width = (p - self.get_abs_pos()).x - self.border as int;
+                        let frame_width = self.frame.width;
+                        let border = self.border;
+                        self.rect.width = clamp(width, 0, frame_width as int - border as int * 2) as uint;
+                        self.adjust_value(width as f32 / (frame_width as int - border as int * 2) as f32);
+                    },
+                    false => {
+                        // Vertical Slider.
+                        let y_min = self.get_abs_pos().y + self.border as int;
+                        let y_max = self.get_abs_pos().y + self.frame.height as int - self.border as int;
+                        let new_y = clamp(p.y, y_min, y_max);
+                        let height = (self.get_abs_pos().y + self.frame.height as int - self.border as int) - new_y;
+                        self.rect.height = height as uint;
+                        let x = self.rect.get_abs_pos().x;
+                        self.rect.set_abs_pos(Point::new(x, new_y, 0));
+                        self.adjust_value((new_y - y_min) as f32 / (y_max - y_min) as f32);
+                    }
+                }
+            },
+            _ => (),
+        }
+    }
+
+    /// Adjust the value to the given percentage.
+    fn adjust_value(&mut self, perc: f32) {
+        self.value = FromPrimitive::from_f32((self.max - self.min).to_f32().unwrap() * perc).unwrap();
+    }
+
+}
+
+impl<T: Num + Copy + FromPrimitive + ToPrimitive> Widget for Slider<T> {
+
+    impl_get_widget_data!(widget_data)
+
+    /// Return the dimensions as a tuple holding width and height.
+    fn get_dimensions(&self) -> (uint, uint) { self.frame.get_dimensions() }
+
+    /// Return a reference to the rectangle as a widget child.
+    fn get_children(&self) -> Vec<&Widget> {
+        vec![&self.frame as &Widget, &self.rect as &Widget]
+    }
+
+    /// Return all children widgets.
+    fn get_children_mut(&mut self) -> Vec<&mut Widget> {
+        vec![&mut self.frame as &mut Widget, &mut self.rect as &mut Widget]
+    }
+
+    /// Return whether or not the widget has been hit by a mouse_press.
+    fn is_over(&self, mouse_pos: Point<int>) -> bool {
+        self.frame.is_over(mouse_pos)
+    }
+
+    /// Mouse move event.
+    fn mouse_move(&mut self, args: &MouseMoveArgs) {
+        self.mouse_move_update_draw_state(args);
+        self.mouse_move_children(args);
+        let p = Point::new(args.x as int, args.y as int, 0);
+        self.adjust_slider(p);
+        match self.get_draw_state() {
+            Highlighted | Clicked => { self.last_pos = p; },
+            Normal => (),
+        };
+    }
+
+    /// Mouse Press event.
+    fn mouse_press(&mut self, args: &MousePressArgs) {
+        self.mouse_press_update_draw_state(args);
+        self.mouse_press_children(args);
+        match self.get_draw_state() {
+            Highlighted | Clicked => {
+                let p = self.last_pos;
+                self.adjust_slider(p)
+            },
+            _ => ()
+        }
+    }
+
+}
+

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,0 +1,107 @@
+
+use piston::{
+    MouseReleaseArgs,
+};
+use piston::mouse;
+use widget;
+use widget::{
+    Widget,
+    RelativePosition,
+    Highlighted,
+    Clicked,
+};
+use std::default::Default;
+use graphics::AddRectangle;
+use color::Color;
+use point::Point;
+use rectangle::Rectangle;
+
+/// A simple `Toggle` type widget which will always
+/// remain in one of two states: `true` (on) or
+/// `false` (off).
+#[deriving(Show, Clone)]
+pub struct Toggle {
+    widget_data: widget::Data,
+    rect: Rectangle,
+    color: Color,
+    value: bool,
+}
+
+impl Toggle {
+
+    /// Constructor for Button widget.
+    pub fn new(pos: RelativePosition,
+               width: uint,
+               height: uint,
+               border: uint,
+               color: Color,
+               value: bool) -> Toggle {
+        let r_color = match value {
+            true => color,
+            false => Color::new(color.r * 0.1f32, color.g * 0.1f32, color.b * 0.1f32, color.a),
+        };
+        Toggle {
+            widget_data: widget::Data::new(pos),
+            rect: Rectangle::new(pos, width, height, r_color, border),
+            color: color,
+            value: value,
+        }
+    }
+
+}
+
+impl Default for Toggle {
+
+    /// Default constructor for Button widget.
+    fn default() -> Toggle {
+        Toggle {
+            widget_data: Default::default(),
+            rect: Default::default(),
+            color: Default::default(),
+            value: false,
+        }
+    }
+
+}
+
+impl Widget for Toggle {
+
+    impl_get_widget_data!(widget_data)
+
+    /// Return the dimensions as a tuple holding width and height.
+    fn get_dimensions(&self) -> (uint, uint) { self.rect.get_dimensions() }
+
+    /// Return a reference to the rectangle as a widget child.
+    fn get_children(&self) -> Vec<&Widget> {
+        vec![&self.rect as &Widget]
+    }
+
+    /// Return all children widgets.
+    fn get_children_mut(&mut self) -> Vec<&mut Widget> {
+        vec![&mut self.rect as &mut Widget]
+    }
+
+    /// Return whether or not the widget has been hit by a mouse_press.
+    fn is_over(&self, mouse_pos: Point<int>) -> bool {
+        self.rect.is_over(mouse_pos)
+    }
+
+    /// Mouse released.
+    fn mouse_release_update_draw_state(&mut self, args: &MouseReleaseArgs) {
+        match (args.button, self.get_draw_state()) {
+            (mouse::Left, Clicked) => {
+                // Toggle value.
+                self.value = if self.value == true { false } else { true };
+                // Toggle rectangle color.
+                self.rect.color = match self.value {
+                    true => self.color,
+                    false => Color::new(self.color.r * 0.1f32, self.color.g * 0.1f32, self.color.b * 0.1f32, self.color.a),
+                };
+                self.set_draw_state(Highlighted);
+            },
+            _ => (),
+        }
+    }
+
+}
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+
+/// Clamp a value between a given min and max.
+pub fn clamp<T: Num + Primitive>(n: T, min: T, max: T) -> T {
+    if n < min { min } else if n > max { max } else { n }
+}
+
+/// Clamp a f32 between 0f32 and 1f32.
+pub fn clampf32(f: f32) -> f32 { if f < 0f32 { 0f32 } else if f > 1f32 { 1f32 } else { f } }
+
+

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,0 +1,345 @@
+
+use piston::{
+    Game,
+    GameEvent,
+    RenderArgs,
+    UpdateArgs,
+    KeyPressArgs,
+    KeyReleaseArgs,
+    MousePressArgs,
+    MouseReleaseArgs,
+    MouseMoveArgs,
+    MouseRelativeMoveArgs,
+    MouseScrollArgs,
+    Render,
+    Update,
+    KeyPress,
+    KeyRelease,
+    MousePress,
+    MouseRelease,
+    MouseMove,
+    MouseRelativeMove,
+    MouseScroll,
+};
+use piston::mouse;
+use opengl_graphics::Gl;
+use point::Point;
+use std::default::Default;
+
+/// State of the widget.
+#[deriving(Show, Clone)]
+pub enum DrawState {
+    Normal,
+    Highlighted,
+    Clicked,
+}
+
+/// Location at which the widget will be added
+/// to it's parent after the previous child. The
+/// `uint` in the four directional variants specifies the
+/// padding between this widget and the previous.
+/// The `Relative` variant specifies a location relative
+/// to the location of the previous widget.
+/// The `Specific` variant specifies an exact location
+/// for the Widget if this is preferred.
+#[deriving(Show, Clone)]
+pub enum RelativePosition {
+    Up(uint),
+    Down(uint),
+    Left(uint),
+    Right(uint),
+    Relative(Point<int>),
+    Specific(Point<int>),
+}
+
+impl RelativePosition {
+    /// Returns an absolute position as a `Point` determined by using
+    /// the RelativePosition in association with a previous `Point`.
+    fn as_point(&self, prev: Point<int>) -> Point<int> {
+        match self {
+            &Up(pad) => prev + Point::new(0, -(pad as int), 0),
+            &Down(pad) => prev + Point::new(0, pad as int, 0),
+            &Left(pad) => prev + Point::new(-(pad as int), 0, 0),
+            &Right(pad) => prev + Point::new(pad as int, 0, 0),
+            &Relative(p) => prev + p,
+            &Specific(p) => p,
+        }
+    }
+}
+
+/// Essential data for widget types. One of these must
+/// be implemented for each type that implements
+/// `Widget` and a reference to the Data must be returned
+/// via the `get_widget_data` methods. A macro has been
+/// provided to simplify implementation. I.e.:
+///
+/// pub struct MyWidget {
+///     widget_data: widget::Data,
+/// }
+///
+/// impl Widget for MyWidget {
+///     impl_get_widget_data!(widget_data)
+/// }
+///
+/// - `rel_pos` (Relative Position) indicates where the widget
+/// will be positioned compared to it's previous sibling.
+/// - `abs_pos` (Absolute Position) indicates the exact
+/// location at which the widget exists. This is normally
+/// determined and set by the parent widget using the `rel_pos`.
+/// - `draw_state` describes the current visible state of the
+/// widget.
+#[deriving(Show, Clone)]
+pub struct Data {
+    rel_pos: RelativePosition,
+    pub abs_pos: Point<int>,
+    draw_state: DrawState,
+}
+
+impl Data {
+    /// Basic constructor for Widget Data.
+    pub fn new(pos: RelativePosition) -> Data {
+        Data {
+            rel_pos: pos,
+            abs_pos: Default::default(),
+            draw_state: Normal,
+        }
+    }
+}
+
+impl Default for Data {
+    /// Default constructor for Widget Data.
+    fn default() -> Data {
+        Data {
+            rel_pos: Down(0u),
+            abs_pos: Default::default(),
+            draw_state: Normal,
+        }
+    }
+}
+
+/// The base trait for all UI Widget types. The Widget system
+/// currently takes the form of a hierarchical node structure,
+/// where each Widget may be constructed of a series of 'children'
+/// Widgets.
+pub trait Widget {
+
+    /// Return a reference to the widget data.
+    fn get_widget_data(&self) -> &Data;
+
+    /// Return a reference to the widget data.
+    fn get_widget_data_mut(&mut self) -> &mut Data;
+
+    /// Return the dimensions as a tuple holding width and height.
+    fn get_dimensions(&self) -> (uint, uint) { (0u, 0u) }
+
+    /// Return all children widgets.
+    fn get_children(&self) -> Vec<&Widget> { Vec::new() }
+
+    /// Return all children widgets.
+    fn get_children_mut(&mut self) -> Vec<&mut Widget> { Vec::new() }
+
+    /// Return the current draw state of the widget.
+    fn get_draw_state(&self) -> DrawState { self.get_widget_data().draw_state }
+
+    /// Set the current draw state for the widget.
+    fn set_draw_state(&mut self, state: DrawState) {
+        self.get_widget_data_mut().draw_state = state;
+    }
+
+    /// Get relative position of the widget.
+    fn get_rel_pos(&self) -> RelativePosition {
+        self.get_widget_data().rel_pos
+    }
+
+    /// Set relative position of the widget.
+    fn set_rel_pos(&mut self, pos: RelativePosition) {
+        self.get_widget_data_mut().rel_pos = pos;
+    }
+
+    /// Return the absolute position.
+    fn get_abs_pos(&self) -> Point<int> { self.get_widget_data().abs_pos }
+
+    /// Set the absolute position. Once set for this widget, the `abs_pos` will
+    /// then be refreshed for all children widgets too.
+    fn set_abs_pos(&mut self, pos: Point<int>) {
+        self.get_widget_data_mut().abs_pos = pos;
+        self.set_abs_pos_children(pos);
+    }
+
+    /// Set the absolute position for each child using their relative positions.
+    fn set_abs_pos_children(&mut self, pos: Point<int>) {
+        let mut prev = pos;
+        self.get_children_mut().mut_iter().all(|child| {
+            let next = child.get_rel_pos().as_point(prev);
+            child.set_abs_pos(next);
+            prev = next;
+            true
+        });
+    }
+
+    /// Get the number of children widgets.
+    fn get_num_children(&self) -> uint { self.get_children().len() }
+
+    /// Return whether or not the widget has been hit by a mouse_press.
+    fn is_over(&self, _mouse_pos: Point<int>) -> bool { false }
+
+    /// Return whether or not the widget has been clicked.
+    fn is_clicked(&self, args: &MousePressArgs) -> bool {
+        match (args.button, self.get_draw_state()) {
+            (mouse::Left, Highlighted) => true,
+            _ => false,
+        }
+    }
+
+    /// Handle a Piston Game event. This allows for easy
+    /// integration with the GameIterator. The `draw` method
+    /// has been excluded in case the user would prefer to
+    /// retain control over the order of rendering. `draw` also
+    /// currently requires an `&mut Gl` arg, which is not
+    /// integrated into the `Render` event.
+    fn event(&mut self, event: &mut GameEvent) {
+        match *event {
+            Render(_) => (), // Call 'draw' manually.
+            Update(ref mut args) => self.update(args),
+            KeyPress(ref args) => self.key_press(args),
+            KeyRelease(ref args) => self.key_release(args),
+            MousePress(ref args) => self.mouse_press(args),
+            MouseRelease(ref args) => self.mouse_release(args),
+            MouseMove(ref args) => self.mouse_move(args),
+            MouseRelativeMove(ref args) => self.mouse_relative_move(args),
+            MouseScroll(ref args) => self.mouse_scroll(args),
+        }
+    }
+
+    /// Setup the widget.
+    fn load(&mut self) {
+        self.load_children();
+    }
+
+    /// Setup the widget's children.
+    fn load_children(&mut self) {
+        self.get_children_mut().mut_iter().all(|child| { child.load(); true });
+    }
+
+    /// Draw the widget at the given location.
+    fn draw(&mut self, args: &RenderArgs, gl: &mut Gl) {
+        self.draw_children(args, gl); 
+    }
+
+    /// Draw the widget and all of it's children to screen.
+    fn draw_children(&mut self, args: &RenderArgs, gl: &mut Gl) {
+        self.get_children_mut().mut_iter().all(|child| { child.draw(args, gl); true });
+    }
+
+    /// Update the widget.
+    fn update(&mut self, args: &UpdateArgs) {
+        self.update_children(args);
+    }
+
+    /// Update all of the widget's children.
+    fn update_children(&mut self, args: &UpdateArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.update(args); true });
+    }
+
+    /// Call key_press for the widget.
+    fn key_press(&mut self, args: &KeyPressArgs) {
+        self.key_press_children(args);
+    }
+
+    /// Call key_press for the widget's children.
+    fn key_press_children(&mut self, args: &KeyPressArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.key_press(args); true });
+    }
+
+    /// Call key_release for the widget.
+    fn key_release(&mut self, args: &KeyReleaseArgs) {
+        self.key_release_children(args);
+    }
+
+    /// Call key_release for the widget's children.
+    fn key_release_children(&mut self, args: &KeyReleaseArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.key_release(args); true });
+    }
+
+    /// Call mouse_press for the widget.
+    fn mouse_press(&mut self, args: &MousePressArgs) {
+        self.mouse_press_update_draw_state(args);
+        self.mouse_press_children(args);
+    }
+
+    /// Call mouse_press for the widget's children.
+    fn mouse_press_children(&mut self, args: &MousePressArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.mouse_press(args); true });
+    }
+
+    /// Call mouse_release for the widget.
+    fn mouse_release(&mut self, args: &MouseReleaseArgs) {
+        self.mouse_release_update_draw_state(args);
+        self.mouse_release_children(args);
+    }
+
+    /// Call mouse_release for the widget's children.
+    fn mouse_release_children(&mut self, args: &MouseReleaseArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.mouse_release(args); true });
+    }
+
+    /// Call mouse move for the widget.
+    fn mouse_move(&mut self, args: &MouseMoveArgs) {
+        self.mouse_move_update_draw_state(args);
+        self.mouse_move_children(args);
+    }
+
+    /// Call mouse_move for the widget's children.
+    fn mouse_move_children(&mut self, args: &MouseMoveArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.mouse_move(args); true });
+    }
+
+    /// Call mouse_relative_move for the widget.
+    fn mouse_relative_move(&mut self, args: &MouseRelativeMoveArgs) {
+        self.mouse_relative_move_children(args);
+    }
+
+    /// Call mouse_relative_move for the widget's children.
+    fn mouse_relative_move_children(&mut self, args: &MouseRelativeMoveArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.mouse_relative_move(args); true });
+    }
+
+    /// Call mouse_scroll for widget.
+    fn mouse_scroll(&mut self, args: &MouseScrollArgs) {
+        self.mouse_scroll_children(args);
+    }
+
+    /// Call mouse_scroll for the widget's children.
+    fn mouse_scroll_children(&mut self, args: &MouseScrollArgs) {
+        self.get_children_mut().mut_iter().all(|child| { child.mouse_scroll(args); true });
+    }
+
+    /// Check the draw state upon mouse_press and update if necessary.
+    fn mouse_press_update_draw_state(&mut self, args: &MousePressArgs) {
+       if self.is_clicked(args) {
+           self.set_draw_state(Clicked);
+       }
+    }
+
+    /// Check the draw state upon mouse_release and update if necessary.
+    fn mouse_release_update_draw_state(&mut self, args: &MouseReleaseArgs) {
+        match (args.button, self.get_draw_state()) {
+            (mouse::Left, Clicked) => {
+                self.set_draw_state(Highlighted);
+            },
+            _ => (),
+        }
+    }
+
+    /// Check the draw state upon mouse_move and update if necessary.
+    fn mouse_move_update_draw_state(&mut self, args: &MouseMoveArgs) {
+        let p = Point::new(args.x as int, args.y as int, 0);
+        match (self.is_over(p), self.get_draw_state()) {
+            (true, Normal) | (true, Highlighted) => self.set_draw_state(Highlighted),
+            (true, Clicked) => self.set_draw_state(Clicked),
+            _ => self.set_draw_state(Normal),
+        }
+    }
+
+}
+


### PR DESCRIPTION
Conrod has been lying dormant for a while now, so I thought I'd try and kick it off a little by starting to lay down some of the `Widget` framework. The `Widget` system currently works with a node-like structure, where each `Widget` can be made of a series of other child `Widget`s. I've implemented three basic `Widget`s to demonstrate this implementation - `Button`, `Toggle` and `Slider`. I've added an example where you can play with these and check out their aesthetics, however none of them are plugged into anything yet so don't expect anything too exciting when you move the slider / flick the toggle.

The next major TO-DOs that come to mind are:
1. Creating a `Listener` system, where a user can define `Listener` methods that will get called each time a `Widget` has been interacted with.
2. Labels / Text / Font . I'm not sure how best to approach this or what the general plans are for Piston in this area. I had a go at using the freetype-rs example a day or two ago, however it currently segfaults upon close. I'm unsure if there are plans to fix this or if there are other plans for implementing a more general unicode for example?

Bugs:
- The `RelativePosition` enum doesn't work quite as expected in some cases but I'll have a closer look tonight and see if I can fix it.

This approach to a widget system is quite an imperative approach though also hopefully familiar. I'm totally open to suggestions and critique - the main thing I hope to achieve with this PR is to get some movement happening on conrod and Piston UI in general :-)
