### PR TITLE
Added number_dialer, fixes #67, #65, #46 and #47 and more

### DIFF
--- a/examples/all_widgets/all_widgets.rs
+++ b/examples/all_widgets/all_widgets.rs
@@ -28,6 +28,7 @@ use conrod::{
     slider,
     Color,
     Point,
+    Frame,
 };
 use conrod::label::{
     Label,
@@ -60,10 +61,14 @@ fn main() {
     let mut game_iter = GameIterator::new(&mut window, &game_iter_settings);
     // Create OpenGL instance.
     let mut gl = Gl::new();
-    // Create the UIContext.
-    let mut uic = UIContext::new();
+    // Create the UIContext and specify the name of a font that's in our "assets" directory.
+    let mut uic = UIContext::new("Dense-Regular.otf");
+
+    // TODO: Put the following vars all in an 'app' struct or something and pass
+    // as a mut reference to struct instead.
+
     // Background color (for demonstration of button and sliders).
-    let mut bg_color = Color::new(0.05f32, 0.025f32, 0.1f32, 1f32);
+    let mut bg_color = Color::new(0.2, 0.35, 0.45, 1.0);
     // Should the button be shown (for demonstration of button).
     let mut show_button = false;
     // The label that will be drawn to the Toggle.
@@ -71,7 +76,9 @@ fn main() {
     // The number of pixels between the left side of the window and the title.
     let mut title_padding = 50f64;
     // The height of the vertical sliders (we will play with this using a number_dialer).
-    let mut v_slider_height = 200f64;
+    let mut v_slider_height = 185f64;
+    // The widget frame width (we'll use this to demo Framing and number_dialer).
+    let mut frame_width = 6f64;
 
     // Main program loop begins.
     loop {
@@ -84,7 +91,8 @@ fn main() {
                                         &mut show_button,
                                         &mut toggle_label,
                                         &mut title_padding,
-                                        &mut v_slider_height),
+                                        &mut v_slider_height,
+                                        &mut frame_width),
         }
     }
 
@@ -98,7 +106,8 @@ fn handle_event(event: &mut GameEvent,
                 show_button: &mut bool,
                 toggle_label: &mut String,
                 title_padding: &mut f64,
-                v_slider_height: &mut f64) {
+                v_slider_height: &mut f64,
+                frame_width: &mut f64) {
     uic.event(event);
     match *event {
         Render(ref mut args) => {
@@ -110,7 +119,8 @@ fn handle_event(event: &mut GameEvent,
                     show_button,
                     toggle_label,
                     title_padding,
-                    v_slider_height);
+                    v_slider_height,
+                    frame_width);
         },
         _ => (),
     }
@@ -136,7 +146,8 @@ fn draw_ui(args: &RenderArgs,
            show_button: &mut bool,
            toggle_label: &mut String,
            title_padding: &mut f64,
-           v_slider_height: &mut f64) {
+           v_slider_height: &mut f64,
+           frame_width: &mut f64) {
 
     // Label example.
     label::draw(args, // RenderArgs.
@@ -144,7 +155,7 @@ fn draw_ui(args: &RenderArgs,
                 uic, // UIContext.
                 Point::new(*title_padding, 30f64, 0f64), // Screen position.
                 48u32, // Font size.
-                Color::white(),
+                bg_color.plain_contrast(),
                 "Widgets Demonstration");
 
     if *show_button {
@@ -156,7 +167,7 @@ fn draw_ui(args: &RenderArgs,
                      Point::new(50f64, 115f64, 0f64), // Screen position.
                      90f64, // Width.
                      60f64, // Height.
-                     6f64, // Border.
+                     Frame(*frame_width, Color::black()), // Widget Frame.
                      Color::new(0.4f32, 0.75f32, 0.6f32, 1f32), // Button Color.
                      Label("PRESS", 24u32, Color::black()), // Label for button.
                      || { // Button "callback" event.
@@ -180,7 +191,7 @@ fn draw_ui(args: &RenderArgs,
                      Point::new(50.0f64, 115.0, 0.0), // Screen position.
                      200f64, // Width.
                      50f64, // Height.
-                     6f64, // Border.
+                     Frame(*frame_width, Color::black()), // Widget Frame.
                      Color::new(0.5, 0.3, 0.6, 1.0), // Rectangle color.
                      //NoLabel,
                      Label(label.as_slice(), 24u32, Color::white()),
@@ -204,7 +215,7 @@ fn draw_ui(args: &RenderArgs,
                  Point::new(50f64, 200f64, 0f64), // Screen position.
                  75f64, // Width.
                  75f64, // Height.
-                 6f64, // Border.
+                 Frame(*frame_width, Color::black()), // Widget Frame.
                  Color::new(0.6f32, 0.25f32, 0.75f32, 1f32), // Button Color.
                  Label(label.as_slice(), 24u32, Color::white()),
                  *show_button, // bool.
@@ -250,7 +261,7 @@ fn draw_ui(args: &RenderArgs,
                      Point::new(50f64 + i as f64 * 60f64, 300f64, 0f64), // Position.
                      35f64, // Width.
                      *v_slider_height, // Height.
-                     6f64, // Border.
+                     Frame(*frame_width, Color::black()), // Widget Frame.
                      color, // Slider color.
                      //NoLabel,
                      Label(label.as_slice(), 24u32, Color::white()),
@@ -274,15 +285,35 @@ fn draw_ui(args: &RenderArgs,
                         6u64, // UIID.
                         Point::new(350.0, 115.0, 0.0), // Position.
                         24u32, // Number Dialer font size.
+                        Frame(*frame_width, Color::black()), // Widget Frame
                         bg_color.invert(), // Number Dialer Color.
-                        Label("Height (pixels)", 24u32, *bg_color),
+                        Label("Height (pixels)", 24u32, bg_color.invert().plain_contrast()),
                         *v_slider_height, // Initial value.
                         25f64, // Minimum value.
-                        225f64, // Maximum value.
+                        250f64, // Maximum value.
                         1u8, // Precision (number of digits to show after decimal point).
                         |new_height| { // Callback closure.
         *v_slider_height = new_height;
     });
+
+    // Number Dialer example.
+    number_dialer::draw(args, // RenderArgs.
+                        gl, // OpenGL instance.
+                        uic, // UIContext.
+                        7u64, // UIID.
+                        Point::new(350.0, 195.0, 0.0), // Position.
+                        24u32, // Number Dialer font size.
+                        Frame(4.0, bg_color.plain_contrast()), // Widget Frame
+                        bg_color.invert().plain_contrast(), // Number Dialer Color.
+                        Label("Frame (pixels)", 24u32, bg_color.plain_contrast()),
+                        *frame_width, // Initial value.
+                        0f64, // Minimum value.
+                        15f64, // Maximum value.
+                        2u8, // Precision (number of digits to show after decimal point).
+                        |new_width| { // Callback closure.
+        *frame_width = new_width;
+    });
+
 
 }
 

--- a/src/button.rs
+++ b/src/button.rs
@@ -5,6 +5,7 @@ use color::Color;
 use point::Point;
 use rectangle;
 use rectangle::RectangleState;
+use frame::Framing;
 use widget::{
     Button,
 };
@@ -19,20 +20,20 @@ use mouse_state::{
 };
 use label;
 use label::{
-    IsLabel,
+    Labeling,
     NoLabel,
     Label,
 };
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]
-pub enum ButtonState {
+pub enum State {
     Normal,
     Highlighted,
     Clicked,
 }
 
-impl ButtonState {
+impl State {
     /// Return the associated Rectangle state.
     fn as_rectangle_state(&self) -> RectangleState {
         match self {
@@ -43,7 +44,7 @@ impl ButtonState {
     }
 }
 
-widget_fns!(Button, ButtonState, Button(Normal))
+widget_fns!(Button, State, Button(Normal))
 
 /// Draw the button. When successfully pressed,
 /// the given `callback` function will be called.
@@ -54,16 +55,16 @@ pub fn draw(args: &RenderArgs,
             pos: Point<f64>,
             width: f64,
             height: f64,
-            border: f64,
+            frame: Framing,
             color: Color,
-            label: IsLabel,
+            label: Labeling,
             callback: ||) {
     let state = get_state(uic, ui_id);
     let mouse = uic.get_mouse_state();
     let is_over = rectangle::is_over(pos, mouse.pos, width, height);
     let new_state = check_state(is_over, state, mouse);
     let rect_state = new_state.as_rectangle_state();
-    rectangle::draw(args, gl, rect_state, pos, width, height, border, color);
+    rectangle::draw(args, gl, rect_state, pos, width, height, frame, color);
     match label {
         NoLabel => (),
         Label(text, size, text_color) => {
@@ -83,12 +84,13 @@ pub fn draw(args: &RenderArgs,
 
 /// Check the current state of the button.
 fn check_state(is_over: bool,
-               prev: ButtonState,
-               mouse: MouseState) -> ButtonState {
+               prev: State,
+               mouse: MouseState) -> State {
     match (is_over, prev, mouse) {
         (true, Normal, MouseState { left: Down, .. }) => Normal,
         (true, _, MouseState { left: Down, .. }) => Clicked,
         (true, _, MouseState { left: Up, .. }) => Highlighted,
+        (false, Clicked, MouseState { left: Down, .. }) => Clicked,
         _ => Normal,
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -137,6 +137,14 @@ impl Color {
         Color::new(r, g, b, self.a())
     }
 
+    /// Return either black or white, depending which contrasts
+    /// the Color the most. This will be useful for determining
+    /// a readable color for text on any given background Color.
+    pub fn plain_contrast(&self) -> Color {
+        if (self.r() + self.g() + self.b()) > 1.5f32 { Color::black() }
+        else { Color::white() }
+    }
+
 }
 
 impl Clone for Color {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,0 +1,11 @@
+
+use color::Color;
+
+/// To be used as a parameter for defining the aesthetic
+/// of the widget frame.
+pub enum Framing {
+    /// Frame width and color.
+    Frame(f64, Color),
+    NoFrame,
+}
+

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -25,10 +25,10 @@ pub struct GlyphCache {
 impl GlyphCache {
 
     /// Constructor for a GlyphCache.
-    pub fn new() -> GlyphCache {
+    pub fn new(font_file: &str) -> GlyphCache {
         let freetype = freetype::Library::init().unwrap();
         let asset_store = AssetStore::from_folder("../assets");
-        let font = asset_store.path("Dense-Regular.otf").unwrap();
+        let font = asset_store.path(font_file).unwrap();
         let face = freetype.new_face(font.as_str().unwrap(), 0).unwrap();
         GlyphCache {
             face: face,

--- a/src/label.rs
+++ b/src/label.rs
@@ -19,9 +19,9 @@ use point::Point;
 pub type FontSize = u32;
 
 /// An enum for passing in label information to widget arguments.
-pub enum IsLabel<'a> {
-    NoLabel,
+pub enum Labeling<'a> {
     Label(&'a str, FontSize, Color),
+    NoLabel,
 }
 
 /// Draw a label using the freetype font rendering backend.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,17 @@ extern crate opengl_graphics;
 extern crate serialize;
 extern crate freetype;
 
-pub use Widget = widget::Widget;
-pub use Color = color::Color;
-pub use Point = point::Point;
-pub use UIContext = ui_context::UIContext;
+pub use widget::Widget;
+pub use color::Color;
+pub use point::Point;
+pub use ui_context::UIContext;
+pub use frame::{Framing, Frame, NoFrame};
 
 pub mod macros;
 
 pub mod button;
 pub mod color;
+pub mod frame;
 pub mod glyph_cache;
 pub mod label;
 pub mod mouse_state;

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -1,13 +1,22 @@
 
-use std::from_str::FromStr;
 use opengl_graphics::Gl;
 use piston::RenderArgs;
 use color::Color;
+use graphics::{
+    Context,
+    AddColor,
+    AddRectangle,
+    AddImage,
+    Draw,
+    RelativeTransform2d,
+};
 use point::Point;
 use rectangle;
-use rectangle::RectangleState;
 use widget::NumberDialer;
-use utils::clamp;
+use utils::{
+    clamp,
+    compare_f64s,
+};
 use ui_context::{
     UIID,
     UIContext,
@@ -20,44 +29,56 @@ use mouse_state::{
 use label;
 use label::{
     FontSize,
-    IsLabel,
+    Labeling,
     NoLabel,
     Label,
 };
+use frame::{
+    Framing,
+    Frame,
+    NoFrame,
+};
+
+/// Represents the specific elements that the
+/// NumberDialer is made up of. This is used to
+/// specify which element is Highlighted or Clicked
+/// when storing State.
+#[deriving(Show, PartialEq)]
+pub enum Element {
+    Rect,
+    LabelGlyphs,
+    /// Represents a value glyph slot at `uint` index
+    /// as well as the last mouse.pos.y for comparison
+    /// in determining new value.
+    ValueGlyph(uint, f64)
+}
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]
-pub enum NumberDialerState {
+pub enum State {
     Normal,
-    Highlighted,
-    Clicked,
+    Highlighted(Element),
+    Clicked(Element),
 }
 
-impl NumberDialerState {
-    /// Return the associated Rectangle state.
-    fn as_rectangle_state(&self) -> RectangleState {
-        match self {
-            &Normal => rectangle::Normal,
-            &Highlighted => rectangle::Highlighted,
-            &Clicked => rectangle::Clicked,
-        }
-    }
-}
+widget_fns!(NumberDialer, State, NumberDialer(Normal))
 
-widget_fns!(NumberDialer, NumberDialerState, NumberDialer(Normal))
+/// Six pixels between rect edge and value string.
+static RECT_PADDING: f64 = 6.0;
 
 /// Draw the number_dialer. When successfully pressed,
 /// or if the value is changed, the given `callback`
 /// function will be called.
-pub fn draw<T: Num + Copy + Primitive + FromPrimitive + ToPrimitive + ToString + FromStr>
+pub fn draw<T: Num + Copy + Primitive + FromPrimitive + ToPrimitive + ToString>
     (args: &RenderArgs,
      gl: &mut Gl,
      uic: &mut UIContext,
      ui_id: UIID,
      pos: Point<f64>,
      font_size: FontSize,
+     frame: Framing,
      color: Color,
-     label: IsLabel,
+     label: Labeling,
      value: T,
      min: T,
      max: T,
@@ -66,36 +87,84 @@ pub fn draw<T: Num + Copy + Primitive + FromPrimitive + ToPrimitive + ToString +
     let val = clamp(value, min, max);
     let state = get_state(uic, ui_id);
     let mouse = uic.get_mouse_state();
-    let val_string = create_string(val, precision);
-    //println!("{}", string.as_slice());
-    
+    let frame_w = match frame { Frame(frame_w, _) => frame_w, NoFrame => 0.0 };
+    let (label_string, label_w, label_h) = label_string_and_dimensions(uic, label);
+    let val_string_len = max.to_string().len() + if precision == 0 { 0u }
+                                                 else { 1u + precision as uint };
+    let mut val_string = create_val_string(val, val_string_len, precision);
+    let (val_string_w, val_string_h) = val_string_dimensions(font_size, label, &val_string);
+    let (rect_w, rect_h) = (val_string_w + label_w + RECT_PADDING * 2.0 + frame_w * 2.0,
+                            val_string_h + RECT_PADDING * 2.0 + frame_w * 2.0);
+    let is_over_elem = is_over(pos, frame_w, mouse.pos,
+                               rect_w, rect_h,
+                               label_w, label_h,
+                               val_string_w, val_string_h,
+                               val_string.len());
+    let new_state = get_new_state(is_over_elem, state, mouse);
 
+    // Draw the widget rectangle.
+    rectangle::draw(args, gl, rectangle::Normal, pos, rect_w, rect_h, frame, color);
 
+    // If there's a label, draw it.
+    let l_pos = pos + Point::new(RECT_PADDING + frame_w, RECT_PADDING + frame_w, 0.0);
+    let (val_string_color, val_string_size) = match label {
+        NoLabel => (color.plain_contrast(), font_size),
+        Label(_, l_size, l_color) => {
+            label::draw(args, gl, uic, l_pos, l_size, l_color, label_string.as_slice());
+            (l_color, l_size)
+        },
+    };
 
-    
-    // TODO
-    // determine rect dimensions.
-    // draw rect.
-    // draw string.
-    // if being interacted with, determine which glyph captures the mouse.
-    // determine new value by comparing previous state with new state.
+    // Determine new value from the initial state and the new state.
+    let new_val = match (state, new_state) {
+        (Clicked(elem), Clicked(new_elem)) => {
+            match (elem, new_elem) {
+                (ValueGlyph(idx, y), ValueGlyph(_, new_y)) => {
+                    get_new_value(val, min, max, idx, compare_f64s(new_y, y), &val_string)
+                },
+                _ => val,
+            }
+        },
+        _ => val,
+    };
+
+    // If the value has changed, create a new string for val_string.
+    if val != new_val { val_string = create_val_string(new_val, val_string_len, precision) }
+
+    // Draw the value string.
+    let val_string_pos = l_pos + Point::new(label_w, 0.0, 0.0);
+    draw_value_string(args, gl, uic, new_state, color, rect_h, frame_w,
+                      value_glyph_slot_width(val_string_size),
+                      value_glyph_slot_height(rect_h, frame_w),
+                      val_string_pos,
+                      val_string_size,
+                      val_string_color,
+                      val_string.as_slice());
+    set_state(uic, ui_id, new_state);
+
+    // Call the `callback` with the new value if the mouse is pressed/released
+    // on the widget or if the value has changed.
+    if value != new_val || match (state, new_state) {
+        (Highlighted(_), Clicked(_)) | (Clicked(_), Highlighted(_)) => true,
+        _ => false,
+    } { callback(new_val) };
+
 }
 
 /// Create the string to be drawn from the given values
 /// and precision. Combine this with the label string if
 /// one is given.
-fn create_string<T: ToString>(val: T, precision: u8) -> String {
+fn create_val_string<T: ToString>(val: T, len: uint, precision: u8) -> String {
     let mut val_string = val.to_string();
+    // First check we have the correct number of decimal places.
     match (val_string.as_slice().chars().position(|ch| ch == '.'), precision) {
-        (None, 0u8) => val_string,
+        (None, 0u8) => (),
         (None, _) => {
             val_string.push_char('.');
             val_string.grow(precision as uint, '0');
-            val_string
         },
         (Some(idx), 0u8) => {
             val_string.truncate(idx);
-            val_string
         },
         (Some(idx), _) => {
             let (len, desired_len) = (val_string.len(), idx + precision as uint + 1u);
@@ -104,23 +173,201 @@ fn create_string<T: ToString>(val: T, precision: u8) -> String {
                 Equal => (),
                 Less => val_string.grow(desired_len - len, '0'),
             }
-            val_string
+        },
+    }
+    // Now check that the total length matches. We already know that
+    // the decimal end of the string is correct, so if the lengths
+    // don't match we know we must prepend the difference as '0's.
+    match val_string.len().cmp(&len) {
+        Less => String::from_char(len - val_string.len(), '0').append(val_string.as_slice()),
+        _ => val_string,
+    }
+}
+
+/// Return the dimensions of a value glyph slot.
+fn value_glyph_slot_width(size: FontSize) -> f64 {
+    (size as f64 * 0.75).round() as f64
+}
+
+/// Return the height of a value glyph slot.
+fn value_glyph_slot_height(rect_height: f64, frame_w: f64) -> f64 {
+    rect_height - frame_w * 2.0
+}
+
+/// Return the dimensions of the label.
+fn label_string_and_dimensions(uic: &mut UIContext, label: Labeling) -> (String, f64, f64) {
+    match label {
+        NoLabel => (String::new(), 0f64, 0f64),
+        Label(ref text, size, _) => {
+            let string = text.to_string().append(": ");
+            let label_width = label::width(uic, size, string.as_slice());
+            (string, label_width, size as f64)
         },
     }
 }
 
-///// Return the total width of string glyphs.
-//fn string_dimensions(font_size: FontSize,
-//                     label: IsLabel,
-//                     val_string: String) -> (f64, f64) {
-//    let label_string = match label {
-//        NoLabel => String::new(),
-//        Label(ref text, _, _) => text.to_string().append(": "),
-//    };
-//}
+/// Return the dimensions of value string glyphs.
+fn val_string_dimensions(font_size: FontSize,
+                         label: Labeling,
+                         val_string: &String) -> (f64, f64) {
+    let size = match label {
+        NoLabel => font_size,
+        Label(_, label_font_size, _) => label_font_size,
+    };
+    let slot_w = value_glyph_slot_width(size);
+    let val_string_w = slot_w * val_string.len() as f64;
+    (val_string_w, size as f64)
+}
 
-/// Return the dimensions of a character slot for the given font_size.
-fn character_slot_dimensions(font_size: FontSize) -> (f64, f64) {
-    (font_size as f64, (font_size as f64 * 1.5).round())
+/// Determine if the cursor is over the number_dialer and if so, which element.
+fn is_over(pos: Point<f64>,
+           frame_w: f64,
+           mouse_pos: Point<f64>,
+           rect_w: f64,
+           rect_h: f64,
+           label_w: f64,
+           label_h: f64,
+           val_string_w: f64,
+           val_string_h: f64,
+           val_string_len: uint) -> Option<Element> {
+    match rectangle::is_over(pos, mouse_pos, rect_w, rect_h) {
+        false => None,
+        true => {
+            let label_pos = pos + Point::new(RECT_PADDING + frame_w, RECT_PADDING + frame_w, 0.0);
+            match rectangle::is_over(label_pos, mouse_pos, label_w, label_h) {
+                true => Some(LabelGlyphs),
+                false => {
+                    let val_string_pos = label_pos + Point::new(label_w, 0.0, 0.0);
+                    match rectangle::is_over(val_string_pos, mouse_pos, val_string_w, val_string_h) {
+                        false => Some(Rect),
+                        true => {
+                            let slot_w = value_glyph_slot_width(val_string_h as u32);
+                            let mut slot_pos = val_string_pos;
+                            for i in range(0u, val_string_len) {
+                                if rectangle::is_over(slot_pos, mouse_pos, slot_w, val_string_h) {
+                                    return Some(ValueGlyph(i, mouse_pos.y))
+                                }
+                                slot_pos.x += slot_w;
+                            }
+                            Some(Rect)
+                        },
+                    }
+                },
+            }
+        },
+    }
+}
+
+/// Check and return the current state of the NumberDialer.
+fn get_new_state(is_over_elem: Option<Element>,
+                 prev: State,
+                 mouse: MouseState) -> State {
+    match (is_over_elem, prev, mouse.left) {
+        (Some(_), Normal, Down) => Normal,
+        (Some(elem), _, Up) => Highlighted(elem),
+        (Some(elem), Highlighted(_), Down) => Clicked(elem),
+        (Some(_), Clicked(p_elem), Down) => {
+            match p_elem {
+                ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.pos.y)),
+                _ => Clicked(p_elem),
+            }
+        },
+        (None, Clicked(p_elem), Down) => {
+            match p_elem {
+                ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.pos.y)),
+                _ => Clicked(p_elem),
+            }
+        },
+        _ => Normal,
+    }
+}
+
+/// Return the new value along with it's String representation.
+fn get_new_value<T: Num + Copy + Primitive + FromPrimitive + ToPrimitive + ToString>
+(val: T, min: T, max: T, idx: uint, y_ord: Ordering, val_string: &String) -> T {
+    match y_ord {
+        Equal => val,
+        _ => {
+            let decimal_pos = val_string.as_slice().chars().position(|ch| ch == '.');
+            let val_f = val.to_f64().unwrap();
+            let min_f = min.to_f64().unwrap();
+            let max_f = max.to_f64().unwrap();
+            let new_val_f = match decimal_pos {
+                None => {
+                    let power = val_string.len() - idx - 1u;
+                    match y_ord {
+                        Less => clamp(val_f + (10f32).powf(power as f32) as f64, min_f, max_f),
+                        Greater => clamp(val_f - (10f32).powf(power as f32) as f64, min_f, max_f),
+                        _ => val_f,
+                    }
+                },
+                Some(dec_idx) => {
+                    let mut power = dec_idx as int - idx as int - 1;
+                    if power < -1 { power += 1; }
+                    match y_ord {
+                        Less => clamp(val_f + (10f32).powf(power as f32) as f64, min_f, max_f),
+                        Greater => clamp(val_f - (10f32).powf(power as f32) as f64, min_f, max_f),
+                        _ => val_f,
+                    }
+                },
+            };
+            FromPrimitive::from_f64(new_val_f).unwrap()
+        },
+    }
+            
+}
+
+/// Draw the value string glyphs.
+fn draw_value_string(args: &RenderArgs,
+                     gl: &mut Gl,
+                     uic: &mut UIContext,
+                     state: State,
+                     rect_color: Color,
+                     rect_h: f64,
+                     frame_w: f64,
+                     slot_w: f64,
+                     slot_h: f64,
+                     pos: Point<f64>,
+                     size: FontSize,
+                     font_color: Color,
+                     string: &str) {
+    let mut x = 0;
+    let y = 0;
+    let (font_r, font_g, font_b, font_a) = font_color.as_tuple();
+    let context = Context::abs(args.width as f64, args.height as f64)
+                    .trans(pos.x, pos.y + size as f64);
+    let half_slot_w = slot_w / 2.0;
+    for (i, ch) in string.chars().enumerate() {
+        let character = uic.get_character(size, ch);
+        let (rect_r, rect_g, rect_b, rect_a) = match state {
+            Highlighted(elem) => match elem {
+                ValueGlyph(idx, _) => if idx == i { rect_color.highlighted().as_tuple() }
+                                      else { rect_color.as_tuple() },
+                _ => rect_color.as_tuple(),
+            },
+            Clicked(elem) => match elem {
+                ValueGlyph(idx, _) => if idx == i { rect_color.clicked().as_tuple() }
+                                      else { rect_color.as_tuple() },
+                _ => rect_color.as_tuple(),
+            },
+            _ => rect_color.as_tuple(),
+        };
+        context
+            // Something here needs to be changed to RECT_PADDING instead of frame_w
+            .rect((x + character.bitmap_glyph.left()) as f64,
+                  -slot_h + RECT_PADDING, //+ frame_w,
+                  //-(size as f64) - frame_w,
+                  size as f64, rect_h - frame_w * 2.0)
+            .rgba(rect_r, rect_g, rect_b, rect_a)
+            .draw(gl);
+        let x_shift = half_slot_w - (character.glyph.advance().x >> 16) as f64 / 2.0;
+        context.trans((x + character.bitmap_glyph.left() + x_shift as i32) as f64,
+                      (y - character.bitmap_glyph.top()) as f64)
+                        .image(&character.texture)
+                        .rgba(font_r, font_g, font_b, font_a)
+                        .draw(gl);
+        x += slot_w as i32;
+    }
+
 }
 

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -11,6 +11,11 @@ use graphics::{
 };
 use point::Point;
 use color::Color;
+use frame::{
+    Framing,
+    Frame,
+    NoFrame,
+};
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]
@@ -29,42 +34,54 @@ pub fn draw(args: &RenderArgs,
             pos: Point<f64>,
             width: f64,
             height: f64,
-            border: f64,
+            frame: Framing,
             color: Color) {
     let context = &Context::abs(args.width as f64, args.height as f64);
-    draw_border(context, gl, pos, width, height);
-    draw_normal(context, gl, state, pos, width, height, border, color);
+    match frame {
+        Frame(_, f_color) => draw_frame(context, gl, pos, width, height, f_color),
+        NoFrame => (),
+    }
+    draw_normal(context, gl, state, pos, width, height, frame, color);
 }
 
 /// Draw the button border.
-fn draw_border(context: &Context,
-               gl: &mut Gl,
-               pos: Point<f64>,
-               width: f64,
-               height: f64) {
-    let (r, g, b, a) = (0.0, 0.0, 0.0, 1.0);
+fn draw_frame(context: &Context,
+              gl: &mut Gl,
+              pos: Point<f64>,
+              width: f64,
+              height: f64,
+              color: Color) {
+    let (r, g, b, a) = color.as_tuple();
     context
         .rect(pos.x, pos.y, width, height)
         .rgba(r, g, b, a)
         .draw(gl);
 }
 
-/// Draw the button while considering border for dimensions and position.
+/// Draw the rectangle while considering frame
+/// width for position and dimensions.
 fn draw_normal(context: &Context,
                gl: &mut Gl,
                state: RectangleState,
                pos: Point<f64>,
                width: f64,
                height: f64,
-               border: f64,
+               frame: Framing,
                color: Color) {
     let (r, g, b, a) = match state {
         Normal => color.as_tuple(),
         Highlighted => color.highlighted().as_tuple(),
         Clicked => color.clicked().as_tuple(),
     };
+    let frame_w = match frame {
+        Frame(frame_w, _) => frame_w,
+        _ => 0.0,
+    };
     context
-        .rect(pos.x + border, pos.y + border, width - border * 2.0, height - border * 2.0)
+        .rect(pos.x + frame_w,
+              pos.y + frame_w,
+              width - frame_w * 2.0,
+              height - frame_w * 2.0)
         .rgba(r, g, b, a)
         .draw(gl);
 }

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -17,20 +17,21 @@ use mouse_state::{
 };
 use label;
 use label::{
-    IsLabel,
+    Labeling,
     Label,
     NoLabel,
 };
+use frame::Framing;
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]
-pub enum ToggleState {
+pub enum State {
     Normal,
     Highlighted,
     Clicked,
 }
 
-impl ToggleState {
+impl State {
     /// Return the associated Rectangle state.
     fn as_rectangle_state(&self) -> RectangleState {
         match self {
@@ -41,7 +42,7 @@ impl ToggleState {
     }
 }
 
-widget_fns!(Toggle, ToggleState, Toggle(Normal))
+widget_fns!(Toggle, State, Toggle(Normal))
 
 /// Draw a Toggle widget. If the toggle
 /// is switched, call `event` with the
@@ -53,9 +54,9 @@ pub fn draw(args: &RenderArgs,
             pos: Point<f64>,
             width: f64,
             height: f64,
-            border: f64,
+            frame: Framing,
             color: Color,
-            label: IsLabel,
+            label: Labeling,
             value: bool,
             callback: |bool|) {
     let state = get_state(uic, ui_id);
@@ -72,7 +73,7 @@ pub fn draw(args: &RenderArgs,
                 color.a()
             ),
     };
-    rectangle::draw(args, gl, rect_state, pos, width, height, border, rect_color);
+    rectangle::draw(args, gl, rect_state, pos, width, height, frame, rect_color);
     match label {
         NoLabel => (),
         Label(text, size, text_color) => {
@@ -92,12 +93,13 @@ pub fn draw(args: &RenderArgs,
 
 /// Check the current state of the button.
 fn check_state(is_over: bool,
-               prev: ToggleState,
-               mouse: MouseState) -> ToggleState {
-    match (is_over, prev, mouse) {
-        (true, Normal, MouseState { left: Down, .. }) => Normal,
-        (true, _, MouseState { left: Down, .. }) => Clicked,
-        (true, _, MouseState { left: Up, .. }) => Highlighted,
+               prev: State,
+               mouse: MouseState) -> State {
+    match (is_over, prev, mouse.left) {
+        (true, Normal, Down) => Normal,
+        (true, _, Down) => Clicked,
+        (true, _, Up) => Highlighted,
+        (false, Clicked, Down) => Clicked,
         _ => Normal,
     }
 }

--- a/src/ui_context.rs
+++ b/src/ui_context.rs
@@ -35,11 +35,11 @@ pub struct UIContext {
 impl UIContext {
 
     /// Constructor for a UIContext.
-    pub fn new() -> UIContext {
+    pub fn new(font_file: &str) -> UIContext {
         UIContext {
             data: HashMap::new(),
             mouse: MouseState::new(Point::new(0f64, 0f64, 0f64), Up, Up, Up),
-            glyph_cache: GlyphCache::new(),
+            glyph_cache: GlyphCache::new(font_file),
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,4 +9,10 @@ pub fn clampf32(f: f32) -> f32 {
     if f < 0f32 { 0f32 } else if f > 1f32 { 1f32 } else { f }
 }
 
+/// Compare two f64s and return an Ordering.
+pub fn compare_f64s(a: f64, b: f64) -> Ordering {
+    if a > b { Greater }
+    else if a < b { Less }
+    else { Equal }
+}
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,16 +1,16 @@
 
-use button::ButtonState;
-use number_dialer::NumberDialerState;
-use toggle::ToggleState;
-use slider::SliderState;
+use button;
+use number_dialer;
+use toggle;
+use slider;
 
 /// Algebraic widget type for storing in ui_context
 /// and for ease of state-matching.
 pub enum Widget {
-    Button(ButtonState),
-    NumberDialer(NumberDialerState),
-    Toggle(ToggleState),
-    Slider(SliderState),
+    Button(button::State),
+    NumberDialer(number_dialer::State),
+    Toggle(toggle::State),
+    Slider(slider::State),
 }
 
 /*


### PR DESCRIPTION
In summary
- `number_dialer` - woohooo! I've added a couple demos of it to the all_widgets example that also show off the new `Framing` param a little. Still needs some small tweaking but it's looking to be in good shape.
- `UIContext::new()` now takes a font as an argument so a user can specify a font on the top level i.e. `UIContext::new("Arial.ttf")`
- Change `IsLabel` to `Labeling` (as per naming convention)
- Slider (and all widgets) now capture the cursor properly - if the mouse is still pressed when moving the cursor off the widget the widget's state will remain as `Clicked` (can try this out in example).
- Changed `WidgetState` to `State` for use as `widget::State` instead.
- Added a `Color` method `plain.contrast()` which will return either black or white (whichever contrasts the `Color`s total luminance the most). This makes it easier to get font `Color`s that will automatically work with any given background color.
- many other small tweaks and fixes
