### PR TITLE
Fixes #93, Implements EnvelopeEditor widget with example, other small fixes.

### DIFF
--- a/examples/all_widgets/all_widgets.rs
+++ b/examples/all_widgets/all_widgets.rs
@@ -8,19 +8,10 @@ extern crate piston;
 extern crate sdl2_game_window;
 extern crate opengl_graphics;
 
-use sdl2_game_window::GameWindowSDL2;
-use opengl_graphics::Gl;
-use piston::{
-    GameEvent,
-    GameWindowSettings,
-    GameIterator,
-    GameIteratorSettings,
-    RenderArgs,
-    Render,
-};
 use conrod::{
     button,
     drop_down_list,
+    envelope_editor,
     label,
     number_dialer,
     slider,
@@ -42,6 +33,93 @@ use graphics::{
     AddEllipse,
     Draw,
 };
+use opengl_graphics::Gl;
+use piston::{
+    GameEvent,
+    GameWindowSettings,
+    GameIterator,
+    GameIteratorSettings,
+    RenderArgs,
+    Render,
+};
+use sdl2_game_window::GameWindowSDL2;
+
+/// This struct holds all of the variables used to demonstrate
+/// application data being passed through the widgets. If some
+/// of these seem strange, that's because they are! Most of
+/// these simply represent the aesthetic state of different
+/// parts of the GUI to offer visual feedback during interaction
+/// with the widgets.
+struct DemoApp {
+    /// Background color (for demonstration of button and sliders).
+    bg_color: Color,
+    /// Should the button be shown (for demonstration of button).
+    show_button: bool,
+    /// The label that will be drawn to the Toggle.
+    toggle_label: String,
+    /// The number of pixels between the left side of the window
+    /// and the title.
+    title_padding: f64,
+    /// The height of the vertical sliders (we will play with this
+    /// using a number_dialer).
+    v_slider_height: f64,
+    /// The widget frame width (we'll use this to demo Framing
+    /// and number_dialer).
+    frame_width: f64,
+    /// Bool matrix for widget_matrix demonstration.
+    bool_matrix: Vec<Vec<bool>>,
+    /// A vector of strings for drop_down_list demonstration.
+    ddl_colors: Vec<String>,
+    /// We also need an Option<idx> to indicate whether or not an
+    /// item is selected.
+    selected_idx: Option<uint>,
+    /// Co-ordinates for a little circle used to demonstrate the
+    /// xy_pad.
+    circle_pos: Point<f64>,
+    /// Envelope for demonstration of EnvelopeEditor.
+    envelopes: Vec<Vec<Point<f32>>>,
+}
+
+impl DemoApp {
+    /// Constructor for the Demonstration Application data.
+    fn new() -> DemoApp {
+        DemoApp {
+            bg_color: Color::new(0.2, 0.35, 0.45, 1.0),
+            show_button: false,
+            toggle_label: "OFF".to_string(),
+            title_padding: 50.0,
+            v_slider_height: 185.0,
+            frame_width: 1.0,
+            bool_matrix: vec![ vec![true, true, true, true, true, true, true, true],
+                               vec![true, false, false, false, false, false, false, true],
+                               vec![true, false, true, false, true, true, true, true],
+                               vec![true, false, true, false, true, true, true, true],
+                               vec![true, false, false, false, true, true, true, true],
+                               vec![true, true, true, true, true, true, true, true],
+                               vec![true, true, false, true, false, false, false, true],
+                               vec![true, true, true, true, true, true, true, true] ],
+            ddl_colors: vec!["Black".to_string(),
+                              "White".to_string(),
+                              "Red".to_string(),
+                              "Green".to_string(),
+                              "Blue".to_string()],
+            selected_idx: None,
+            circle_pos: Point::new(700.0, 200.0, 0.0),
+            envelopes: vec![ vec![ Point::new(0.0, 0.0, 0.0),
+                                   Point::new(0.1, 0.85, 0.0),
+                                   Point::new(0.25, 0.4, 0.0),
+                                   Point::new(0.5, 0.1, 0.0),
+                                   Point::new(1.0, 0.0, 0.0), ],
+                             vec![ Point::new(0.0, 0.0, 0.0),
+                                   Point::new(0.4, 0.6, 0.0),
+                                   Point::new(1.0, 0.0, 0.0), ],
+                             vec![ Point::new(0.0, 0.85, 0.0),
+                                   Point::new(0.3, 0.2, 0.0),
+                                   Point::new(0.6, 0.6, 0.0),
+                                   Point::new(1.0, 0.0, 0.0), ] ],
+        }
+    }
+}
 
 fn main() {
 
@@ -50,7 +128,7 @@ fn main() {
         piston::shader_version::opengl::OpenGL_3_2,
         GameWindowSettings {
             title: "Hello Conrod".to_string(),
-            size: [860, 600],
+            size: [1200, 600],
             fullscreen: false,
             exit_on_esc: true
         }
@@ -68,61 +146,14 @@ fn main() {
     let mut gl = Gl::new();
     // Create the UIContext and specify the name of a font that's in our "assets" directory.
     let mut uic = UIContext::new("Dense-Regular.otf");
-
-    // TODO: Put the following vars all in an 'app' struct or something and pass
-    // as a mut reference to struct instead.
-
-    // Background color (for demonstration of button and sliders).
-    let mut bg_color = Color::new(0.2, 0.35, 0.45, 1.0);
-    // Should the button be shown (for demonstration of button).
-    let mut show_button = false;
-    // The label that will be drawn to the Toggle.
-    let mut toggle_label = "OFF".to_string();
-    // The number of pixels between the left side of the window and the title.
-    let mut title_padding = 50f64;
-    // The height of the vertical sliders (we will play with this using a number_dialer).
-    let mut v_slider_height = 185f64;
-    // The widget frame width (we'll use this to demo Framing and number_dialer).
-    let mut frame_width = 1f64;
-    // Bool matrix for widget_matrix demonstration.
-    let mut bool_matrix = vec![
-                            vec![true, true, true, true, true, true, true, true],
-                            vec![true, false, false, false, false, false, false, true],
-                            vec![true, false, true, false, true, true, true, true],
-                            vec![true, false, true, false, true, true, true, true],
-                            vec![true, false, false, false, true, true, true, true],
-                            vec![true, true, true, true, true, true, true, true],
-                            vec![true, true, false, true, false, false, false, true],
-                            vec![true, true, true, true, true, true, true, true],
-                            ];
-    // A vector of strings for drop_down_list demonstration.
-    let mut ddl_colors = vec!["Black".to_string(),
-                              "White".to_string(),
-                              "Red".to_string(),
-                              "Green".to_string(),
-                              "Blue".to_string()];
-    // We also need an Option<idx> to indicate whether or not an item is selected.
-    let mut selected_idx = None;
-    // Co-ordinates for a little circle used to demonstrate the xy_pad.
-    let mut circle_pos = Point::new(700f64, 200.0, 0.0);
+    // Create the Demonstration Application data.
+    let mut demo = DemoApp::new();
 
     // Main program loop begins.
     loop {
         match game_iter.next() {
             None => break,
-            Some(mut e) => handle_event(&mut e,
-                                        &mut gl,
-                                        &mut uic,
-                                        &mut bg_color,
-                                        &mut show_button,
-                                        &mut toggle_label,
-                                        &mut title_padding,
-                                        &mut v_slider_height,
-                                        &mut frame_width,
-                                        &mut bool_matrix,
-                                        &mut ddl_colors,
-                                        &mut selected_idx,
-                                        &mut circle_pos),
+            Some(mut e) => handle_event(&mut e, &mut gl, &mut uic, &mut demo),
         }
     }
 
@@ -132,42 +163,19 @@ fn main() {
 fn handle_event(event: &mut GameEvent,
                 gl: &mut Gl,
                 uic: &mut UIContext,
-                bg_color: &mut Color,
-                show_button: &mut bool,
-                toggle_label: &mut String,
-                title_padding: &mut f64,
-                v_slider_height: &mut f64,
-                frame_width: &mut f64,
-                bool_matrix: &mut Vec<Vec<bool>>,
-                ddl_colors: &mut Vec<String>,
-                selected_idx: &mut Option<uint>,
-                circle_pos: &mut Point<f64>) {
+                demo: &mut DemoApp) {
     uic.event(event);
     match *event {
         Render(ref mut args) => {
-            draw_background(args, gl, bg_color);
-            draw_ui(args,
-                    gl,
-                    uic,
-                    bg_color,
-                    show_button,
-                    toggle_label,
-                    title_padding,
-                    v_slider_height,
-                    frame_width,
-                    bool_matrix,
-                    ddl_colors,
-                    selected_idx,
-                    circle_pos);
+            draw_background(args, gl, &demo.bg_color);
+            draw_ui(args, gl, uic, demo);
         },
         _ => (),
     }
 }
 
 /// Draw the window background.
-fn draw_background(args: &RenderArgs,
-                   gl: &mut Gl,
-                   bg_color: &mut Color) {
+fn draw_background(args: &RenderArgs, gl: &mut Gl, bg_color: &Color) {
     // Set up a context to draw into.
     let context = &Context::abs(args.width as f64, args.height as f64);
     // Return the individual  elements of the background color.
@@ -180,27 +188,18 @@ fn draw_background(args: &RenderArgs,
 fn draw_ui(args: &RenderArgs,
            gl: &mut Gl,
            uic: &mut UIContext,
-           bg_color: &mut Color,
-           show_button: &mut bool,
-           toggle_label: &mut String,
-           title_padding: &mut f64,
-           v_slider_height: &mut f64,
-           frame_width: &mut f64,
-           bool_matrix: &mut Vec<Vec<bool>>,
-           ddl_colors: &mut Vec<String>,
-           selected_idx: &mut Option<uint>,
-           circle_pos: &mut Point<f64>) {
+           demo: &mut DemoApp) {
 
     // Label example.
     label::draw(args, // RenderArgs.
                 gl, // Open GL instance.
                 uic, // UIContext.
-                Point::new(*title_padding, 30f64, 0f64), // Screen position.
+                Point::new(demo.title_padding, 30f64, 0f64), // Screen position.
                 48u32, // Font size.
-                bg_color.plain_contrast(),
+                demo.bg_color.plain_contrast(),
                 "Widgets Demonstration");
 
-    if *show_button {
+    if demo.show_button {
         // Button widget example.
         button::draw(args, // RenderArgs.
                      gl, // Open GL instance.
@@ -209,17 +208,17 @@ fn draw_ui(args: &RenderArgs,
                      Point::new(50f64, 115f64, 0f64), // Screen position.
                      90f64, // Width.
                      60f64, // Height.
-                     Frame(*frame_width, Color::black()), // Widget Frame.
+                     Frame(demo.frame_width, Color::black()), // Widget Frame.
                      Color::new(0.4f32, 0.75f32, 0.6f32, 1f32), // Button Color.
                      Label("PRESS", 24u32, Color::black()), // Label for button.
-                     || *bg_color = Color::random()); // Callback closure.
+                     || demo.bg_color = Color::random()); // Callback closure.
     }
 
     // Horizontal slider example.
     else {
 
         // Create the label for the slider.
-        let pad = *title_padding as i16;
+        let pad = demo.title_padding as i16;
         let pad_string = pad.to_string();
         let label = "Padding: ".to_string().append(pad_string.as_slice());
 
@@ -231,19 +230,19 @@ fn draw_ui(args: &RenderArgs,
                      Point::new(50.0f64, 115.0, 0.0), // Screen position.
                      200f64, // Width.
                      50f64, // Height.
-                     Frame(*frame_width, Color::black()), // Widget Frame.
+                     Frame(demo.frame_width, Color::black()), // Widget Frame.
                      Color::new(0.5, 0.3, 0.6, 1.0), // Rectangle color.
                      //NoLabel,
                      Label(label.as_slice(), 24u32, Color::white()),
                      pad as i16, // Slider value.
                      10i16, // Min value.
-                     560i16, // Max value.
-                     |new_pad| *title_padding = new_pad as f64); // Callback closure.
+                     910i16, // Max value.
+                     |new_pad| demo.title_padding = new_pad as f64); // Callback closure.
 
     }
 
     // Clone the label toggle to be drawn.
-    let label = toggle_label.clone();
+    let label = demo.toggle_label.clone();
 
     // Toggle widget example.
     toggle::draw(args, // RenderArgs.
@@ -253,18 +252,18 @@ fn draw_ui(args: &RenderArgs,
                  Point::new(50f64, 200f64, 0f64), // Screen position.
                  75f64, // Width.
                  75f64, // Height.
-                 Frame(*frame_width, Color::black()), // Widget Frame.
+                 Frame(demo.frame_width, Color::black()), // Widget Frame.
                  Color::new(0.6f32, 0.25f32, 0.75f32, 1f32), // Button Color.
                  Label(label.as_slice(), 24u32, Color::white()),
-                 *show_button, // bool.
+                 demo.show_button, // bool.
                  |value| {
-        *show_button = value;
+        demo.show_button = value;
         match value {
             true => {
-                *toggle_label = "ON".to_string();
+                demo.toggle_label = "ON".to_string();
             },
             false => {
-                *toggle_label = "OFF".to_string();
+                demo.toggle_label = "OFF".to_string();
             },
         }
     });
@@ -282,9 +281,9 @@ fn draw_ui(args: &RenderArgs,
 
         // Grab the value of the color element.
         let value = match i {
-            0u => bg_color.r(),
-            1u => bg_color.g(),
-            _  => bg_color.b(),
+            0u => demo.bg_color.r(),
+            1u => demo.bg_color.g(),
+            _  => demo.bg_color.b(),
         };
 
         // Create the label to be drawn with the slider.
@@ -298,8 +297,8 @@ fn draw_ui(args: &RenderArgs,
                      3u64 + i as u64, // UI ID.
                      Point::new(50f64 + i as f64 * 60f64, 300f64, 0f64), // Position.
                      35f64, // Width.
-                     *v_slider_height, // Height.
-                     Frame(*frame_width, Color::black()), // Widget Frame.
+                     demo.v_slider_height, // Height.
+                     Frame(demo.frame_width, Color::black()), // Widget Frame.
                      color, // Slider color.
                      //NoLabel,
                      Label(label.as_slice(), 24u32, Color::white()),
@@ -308,9 +307,9 @@ fn draw_ui(args: &RenderArgs,
                      1f32, // Maximum value.
                      |color| {
             match i {
-                0u => { bg_color.set_r(color); },
-                1u => { bg_color.set_g(color); },
-                _ => { bg_color.set_b(color); },
+                0u => { demo.bg_color.set_r(color); },
+                1u => { demo.bg_color.set_g(color); },
+                _ => { demo.bg_color.set_b(color); },
             }
         });
 
@@ -325,14 +324,14 @@ fn draw_ui(args: &RenderArgs,
                         260.0, // width.
                         60.0, // height.
                         24u32, // Font size. If a label is given, that size will be used instead.
-                        Frame(*frame_width, Color::black()), // Widget Frame
-                        bg_color.invert(), // Number Dialer Color.
-                        Label("Height (pixels)", 24u32, bg_color.invert().plain_contrast()),
-                        *v_slider_height, // Initial value.
+                        Frame(demo.frame_width, Color::black()), // Widget Frame
+                        demo.bg_color.invert(), // Number Dialer Color.
+                        Label("Height (pixels)", 24u32, demo.bg_color.invert().plain_contrast()),
+                        demo.v_slider_height, // Initial value.
                         25f64, // Minimum value.
                         250f64, // Maximum value.
                         1u8, // Precision (number of digits to show after decimal point).
-                        |new_height| *v_slider_height = new_height); // Callback closure.
+                        |new_height| demo.v_slider_height = new_height); // Callback closure.
 
     // Number Dialer example.
     number_dialer::draw(args, // RenderArgs.
@@ -343,14 +342,14 @@ fn draw_ui(args: &RenderArgs,
                         260.0, // width.
                         60.0, // height.
                         24u32, // Font size. If a label is given, label size will be used instead.
-                        Frame(*frame_width, bg_color.plain_contrast()), // Widget Frame
-                        bg_color.invert().plain_contrast(), // Number Dialer Color.
-                        Label("Frame (pixels)", 24u32, bg_color.plain_contrast()),
-                        *frame_width, // Initial value.
+                        Frame(demo.frame_width, demo.bg_color.plain_contrast()), // Widget Frame
+                        demo.bg_color.invert().plain_contrast(), // Number Dialer Color.
+                        Label("Frame (pixels)", 24u32, demo.bg_color.plain_contrast()),
+                        demo.frame_width, // Initial value.
                         0f64, // Minimum value.
                         15f64, // Maximum value.
                         2u8, // Precision (number of digits to show after decimal point).
-                        |new_width| *frame_width = new_width); // Callback closure.
+                        |new_width| demo.frame_width = new_width); // Callback closure.
 
     // A demonstration using widget_matrix to easily draw
     // a matrix of any kind of widget.
@@ -363,9 +362,9 @@ fn draw_ui(args: &RenderArgs,
                         |num, col, row, pos, width, height| { // This is called for every widget.
 
         // Now draw the widgets with the given callback.
-        let val = (*bool_matrix)[col][row];
+        let val = demo.bool_matrix[col][row];
         toggle::draw(args, gl, uic, 8u64 + num as u64, pos, width, height,
-                     Frame(*frame_width, Color::black()),
+                     Frame(demo.frame_width, Color::black()),
                      Color::new(0.5 + (col as f32 / cols as f32) / 2.0,
                                 0.75,
                                 1.0 - (row as f32 / rows as f32) / 2.0,
@@ -373,13 +372,13 @@ fn draw_ui(args: &RenderArgs,
                      NoLabel,
                      val,
                      |new_val| {
-            *bool_matrix.get_mut(col).get_mut(row) = new_val;
+            *demo.bool_matrix.get_mut(col).get_mut(row) = new_val;
         });
 
     });
 
-    let ddl_color = match *selected_idx {
-        Some(idx) => match (*ddl_colors)[idx].as_slice() {
+    let ddl_color = match demo.selected_idx {
+        Some(idx) => match demo.ddl_colors[idx].as_slice() {
             "Black" => Color::black(),
             "White" => Color::white(),
             "Red" => Color::new(0.75, 0.4, 0.4, 1.0),
@@ -391,7 +390,7 @@ fn draw_ui(args: &RenderArgs,
     };
 
     // Draw the circle that's controlled by the XYPad.
-    draw_circle(args, gl, *circle_pos, ddl_color);
+    draw_circle(args, gl, demo.circle_pos, ddl_color);
 
     // A demonstration using drop_down_list.
     drop_down_list::draw(args, // RenderArgs.
@@ -401,13 +400,13 @@ fn draw_ui(args: &RenderArgs,
                          Point::new(620.0, 115.0, 0.0), // Position.
                          150.0, // width.
                          40.0, // height.
-                         Frame(*frame_width, ddl_color.plain_contrast()),
+                         Frame(demo.frame_width, ddl_color.plain_contrast()),
                          ddl_color, // Color of drop_down_list.
                          Label("Colors", 24u32, ddl_color.plain_contrast()),
-                         ddl_colors, // String vector.
-                         *selected_idx, // Currently selected string index.
-                         |idx, _string| { // Callback (on new selection).
-        *selected_idx = Some(idx); // Assign the newly selected index.
+                         &mut demo.ddl_colors, // String vector.
+                         &mut demo.selected_idx, // Currently selected string index.
+                         |selected_idx, new_idx, _string| { // Callback (upon new selection).
+        *selected_idx = Some(new_idx);
     });
 
     // Draw a xy_pad.
@@ -419,14 +418,46 @@ fn draw_ui(args: &RenderArgs,
                  150.0, // width.
                  150.0, // height.
                  18u32, // font size.
-                 Frame(*frame_width, Color::white()),
-                 Color::black(), // rect color.
-                 Label("Circle Position", 32u32, Color::new(1.0, 1.0, 1.0, 0.5)),
-                 circle_pos.x, 760.0, 610.0, // x range.
-                 circle_pos.y, 320.0, 170.0, // y range.
+                 Frame(demo.frame_width, Color::white()),
+                 ddl_color, // rect color.
+                 Label("Circle Position", 32u32,
+                       Color::new(1.0, 1.0, 1.0, 0.5) * ddl_color.plain_contrast()),
+                 demo.circle_pos.x, 760.0, 610.0, // x range.
+                 demo.circle_pos.y, 320.0, 170.0, // y range.
                  |new_x, new_y| { // Callback when x/y changes or mousepress/release.
-        circle_pos.x = new_x;
-        circle_pos.y = new_y;
+        demo.circle_pos.x = new_x;
+        demo.circle_pos.y = new_y;
+    });
+
+    let (cols, rows) = (1u, 3u);
+    widget_matrix::draw(cols, // cols.
+                        rows, // rows.
+                        Point::new(830.0, 115.0, 0.0), // matrix position.
+                        320.0, // width.
+                        415.0, // height.
+                        |num, _col, _row, pos, width, height| { // This is called for every widget.
+
+        // Draw an EnvelopeEditor.
+        envelope_editor::draw(args, // RenderArgs.
+                              gl, // OpenGL instance.
+                              uic, // UIContext.
+                              77u64 + num as u64, // UIID.
+                              pos, // Position.
+                              width, // Width.
+                              height - 10.0, // Height.
+                              18u32, // Font size.
+                              Frame(demo.frame_width, demo.bg_color.invert().plain_contrast()),
+                              demo.bg_color.invert(), // Rect color.
+                              Label("Envelope Editor ", 32u32,
+                                    Color::new(1.0, 1.0, 1.0, 0.5)
+                                    * demo.bg_color.invert().plain_contrast()),
+                              demo.envelopes.get_mut(num), // Envelope.
+                              0.0, 1.0, // `x` axis range.
+                              0.0, 1.0, // `y` axis range.
+                              6.0, // Point radius.
+                              2.0, // Line width.
+                              |_env, _idx| { }); // Callback upon x/y changes or mousepress/release.
+
     });
 
 }

--- a/src/button.rs
+++ b/src/button.rs
@@ -1,27 +1,25 @@
 
-use opengl_graphics::Gl;
-use piston::RenderArgs;
 use color::Color;
-use point::Point;
-use rectangle;
 use frame::Framing;
-use widget::{
-    Button,
-};
-use ui_context::{
-    UIID,
-    UIContext,
+use label::{
+    Labeling,
+    NoLabel,
+    Label,
 };
 use mouse_state::{
     MouseState,
     Up,
     Down,
 };
-use label::{
-    Labeling,
-    NoLabel,
-    Label,
+use opengl_graphics::Gl;
+use piston::RenderArgs;
+use point::Point;
+use rectangle;
+use ui_context::{
+    UIID,
+    UIContext,
 };
+use widget::Button;
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,8 +1,8 @@
 
-use std::default::Default;
 use utils::clampf32;
-use std::rand::random;
+use std::default::Default;
 use std::num::abs;
+use std::rand::random;
 
 /// A basic color struct for general color use
 /// made of red, green, blue and alpha elements.
@@ -228,7 +228,7 @@ impl Div<Color, Color> for Color {
                 self.r() / rhs.r(), 
                 self.g() / rhs.g(), 
                 self.b() / rhs.b(), 
-                self.a()
+                self.a() / rhs.a(),
             ])
         )
     }
@@ -241,7 +241,7 @@ impl Mul<Color, Color> for Color {
                 self.r() * rhs.r(), 
                 self.g() * rhs.g(), 
                 self.b() * rhs.b(), 
-                self.a()
+                self.a() * rhs.a(),
             ])
         )
     }

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -1,18 +1,9 @@
 
-use opengl_graphics::Gl;
-use piston::RenderArgs;
 use color::Color;
-use point::Point;
-use rectangle;
-use widget::DropDownList;
-use ui_context::{
-    UIID,
-    UIContext,
-};
-use mouse_state::{
-    MouseState,
-    Up,
-    Down,
+use frame::{
+    Framing,
+    Frame,
+    NoFrame,
 };
 use label;
 use label::{
@@ -20,11 +11,20 @@ use label::{
     NoLabel,
     Label,
 };
-use frame::{
-    Framing,
-    Frame,
-    NoFrame,
+use mouse_state::{
+    MouseState,
+    Up,
+    Down,
 };
+use opengl_graphics::Gl;
+use piston::RenderArgs;
+use point::Point;
+use rectangle;
+use ui_context::{
+    UIID,
+    UIContext,
+};
+use widget::DropDownList;
 
 /// Tuple / Callback params.
 pub type Idx = uint;
@@ -78,15 +78,15 @@ pub fn draw(args: &RenderArgs,
             frame: Framing,
             color: Color,
             label: Labeling,
-            strings: &Vec<String>,
-            selected: Option<Idx>,
-            callback: |Idx, String|) {
+            strings: &mut Vec<String>,
+            selected: &mut Option<Idx>,
+            callback: |&mut Option<Idx>, Idx, String|) {
 
     let len = strings.len();
     if len == 0u { return }
-    let selected = match selected {
+    let sel = match *selected {
         Some(idx) => if idx >= len { None } else { Some(idx) },
-        None => selected,
+        None => *selected,
     };
     let state = get_state(uic, ui_id);
     let mouse = uic.get_mouse_state();
@@ -104,7 +104,7 @@ pub fn draw(args: &RenderArgs,
                 NoLabel => (label::auto_size_from_rect_height(height),
                             color.plain_contrast()),
             };
-            let text = match selected {
+            let text = match sel {
                 Some(idx) => (*strings)[idx].as_slice(),
                 None => match label {
                     Label(text, _, _) => text,
@@ -123,7 +123,7 @@ pub fn draw(args: &RenderArgs,
                             color.plain_contrast()),
             };
             for (i, string) in strings.iter().enumerate() {
-                let rect_state = match selected {
+                let rect_state = match sel {
                     None => {
                         match draw_state {
                             Normal => rectangle::Normal,
@@ -164,7 +164,9 @@ pub fn draw(args: &RenderArgs,
     match (state, new_state) {
         (Open(o_d_state), Closed(c_d_state)) => {
             match (o_d_state, c_d_state) {
-                (Clicked(idx, _), Normal) => callback(idx, (*strings)[idx].clone()),
+                (Clicked(idx, _), Normal) => {
+                    callback(selected, idx, (*strings)[idx].clone())
+                },
                 _ => (),
             }
         },

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -1,0 +1,459 @@
+
+use color::Color;
+use frame::{
+    Framing,
+    Frame,
+    NoFrame,
+};
+use graphics::{
+    AddColor,
+    AddEllipse,
+    AddLine,
+    AddRoundBorder,
+    Context,
+    Draw,
+};
+use label;
+use label::{
+    NoLabel,
+    Label,
+    FontSize,
+    Labeling,
+};
+use mouse_state::{
+    MouseState,
+    Up,
+    Down,
+};
+use opengl_graphics::Gl;
+use piston::{
+    RenderArgs,
+};
+use point::Point;
+use rectangle;
+use rectangle::{
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+};
+use ui_context::{
+    UIID,
+    UIContext,
+};
+use utils::{
+    clamp,
+    map_range,
+    val_to_string,
+};
+use widget::EnvelopeEditor;
+
+/// Represents the specific elements that the
+/// EnvelopeEditor is made up of. This is used to
+/// specify which element is Highlighted or Clicked
+/// when storing State.
+#[deriving(Show, PartialEq)]
+pub enum Element {
+    Rect,
+    Pad,
+    /// Represents an EnvelopePoint at `uint` index
+    /// as well as the last mouse pos for comparison
+    /// in determining new value.
+    EnvPoint(uint, Point<f64>),
+}
+
+/// An enum to define which button is clicked.
+#[deriving(Show, PartialEq)]
+pub enum MouseButton {
+    Left,
+    Right,
+}
+
+/// Represents the state of the xy_pad widget.
+#[deriving(Show, PartialEq)]
+pub enum State {
+    Normal,
+    Highlighted(Element),
+    Clicked(Element, MouseButton),
+}
+
+impl State {
+    /// Return the associated Rectangle state.
+    fn as_rectangle_state(&self) -> rectangle::State {
+        match self {
+            &Normal => rectangle::Normal,
+            &Highlighted(_) => rectangle::Highlighted,
+            &Clicked(_, _) => rectangle::Clicked,
+        }
+    }
+}
+
+widget_fns!(EnvelopeEditor, State, EnvelopeEditor(Normal))
+
+/// `EnvPoint` MUST be implemented for any type that is
+/// contained within the Envelope.
+pub trait EnvelopePoint
+<X: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
+ Y: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString> {
+    /// Return the X value.
+    fn get_x(&self) -> X;
+    /// Return the Y value.
+    fn get_y(&self) -> Y;
+    /// Return the X value.
+    fn set_x(&mut self, _x: X);
+    /// Return the Y value.
+    fn set_y(&mut self, _y: Y);
+    /// Create a new EnvPoint.
+    fn new(_x: X, _y: Y) -> Self;
+}
+
+/// Draw the envelope_editor. When successfully pressed,
+/// the given `callback` closure will be called with the
+/// xy coordinates as params.
+pub fn draw
+<X: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
+ Y: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
+ E: EnvelopePoint<X, Y>>
+           (args: &RenderArgs,
+            gl: &mut Gl,
+            uic: &mut UIContext,
+            ui_id: UIID,
+            pos: Point<f64>,
+            width: f64,
+            height: f64,
+            font_size: FontSize,
+            frame: Framing,
+            color: Color,
+            label: Labeling,
+            env: &mut Vec<E>,
+            min_x: X, max_x: X, // pub enum Ranging { AutoRange, Range(min, max) }
+            min_y: Y, max_y: Y,
+            pt_radius: f64,
+            line_width: f64,
+            callback: |&mut Vec<E>, uint|) {
+
+    let state = get_state(uic, ui_id);
+    let mouse = uic.get_mouse_state();
+
+    // Rect.
+    let frame_w = match frame { Frame(w, _) => w, NoFrame => 0.0 };
+    let frame_w2 = frame_w * 2.0;
+    let pad_pos = pos + Point::new(frame_w, frame_w, 0.0);
+    let pad_w = width - frame_w2;
+    let pad_h = height - frame_w2;
+
+    // Check for new state.
+    let (is_over_elem, is_closest_elem) = is_over_and_closest::<X, Y, E>(
+        pos, mouse.pos, width, height, pad_pos, pad_w, pad_h,
+        env, min_x, max_x, min_y, max_y, pt_radius
+    );
+    let new_state = get_new_state(is_over_elem, state, mouse);
+
+    // Draw rect.
+    rectangle::draw(args, gl, new_state.as_rectangle_state(), pos, width, height, frame, color);
+
+    // If there's a label, draw it.
+    match label {
+        NoLabel => (),
+        Label(l_text, l_size, l_color) => {
+            let l_w = label::width(uic, l_size, l_text);
+            let l_pos = Point::new(pad_pos.x + (pad_w - l_w) / 2.0,
+                                   pad_pos.y + (pad_h - l_size as f64) / 2.0,
+                                   0.0);
+            label::draw(args, gl, uic, l_pos, l_size, l_color, l_text);
+        },
+    };
+
+    // Draw the envelope lines.
+    match env.len() {
+        0u | 1u => (),
+        _ => {
+            let (r, g, b, a) = color.plain_contrast().as_tuple();
+            for (i, env_p) in env.iter().enumerate().skip(1u) {
+                let x_a = (*env)[i - 1u].get_x();
+                let y_a = (*env)[i - 1u].get_y();
+                let x_b = (*env)[i].get_x();
+                let y_b = (*env)[i].get_y();
+                let p_a = Point::new(map_range(x_a, min_x, max_x, pad_pos.x, pad_pos.x + pad_w),
+                                     map_range(y_a, min_y, max_y, pad_pos.y + pad_h, pad_pos.y), 0.0);
+                let p_b = Point::new(map_range(x_b, min_x, max_x, pad_pos.x, pad_pos.x + pad_w),
+                                     map_range(y_b, min_y, max_y, pad_pos.y + pad_h, pad_pos.y), 0.0);
+                let context = Context::abs(args.width as f64, args.height as f64);
+                context
+                    .line(p_a.x, p_a.y, p_b.x, p_b.y)
+                    .round_border_width(line_width)
+                    .rgba(r, g, b, a)
+                    .draw(gl);
+            }
+        },
+    }
+
+    // Determine the left and right X bounds.
+    let get_x_bounds = |envelope: &mut Vec<E>, idx: uint| -> (X, X) {
+        let right_bound = if envelope.len() > 0u && envelope.len() - 1u > idx {
+            (*envelope)[idx + 1u].get_x()
+        } else { max_x };
+        let left_bound = if envelope.len() > 0u && idx > 0u {
+            (*envelope)[idx - 1u].get_x()
+        } else { min_x };
+        (left_bound, right_bound)
+    };
+
+    // Draw the (closest) envelope point and it's label and
+    // return the idx if it is currently clicked.
+    let is_clicked_env_point = match (state, new_state) {
+
+        (_, Clicked(elem, _)) | (_, Highlighted(elem)) => {
+
+            // Draw the envelope point.
+            let draw_env_pt = ref |envelope: &mut Vec<E>, idx: uint, p_pos: Point<f64>| {
+                let x_string = val_to_string((*envelope)[idx].get_x(), max_x, max_x - min_x, pad_w as uint);
+                let y_string = val_to_string((*envelope)[idx].get_y(), max_y, max_y - min_y, pad_h as uint);
+                let xy_string = x_string.append(", ").append(y_string.as_slice());
+                let xy_string_w = label::width(uic, font_size, xy_string.as_slice());
+                let xy_string_pos = match rectangle::corner(pad_pos, p_pos, pad_w, pad_h) {
+                    TopLeft => Point::new(p_pos.x, p_pos.y, 0.0),
+                    TopRight => Point::new(p_pos.x - xy_string_w, p_pos.y, 0.0),
+                    BottomLeft => Point::new(p_pos.x, p_pos.y - font_size as f64, 0.0),
+                    BottomRight => Point::new(p_pos.x - xy_string_w, p_pos.y - font_size as f64, 0.0),
+                };
+                label::draw(args, gl, uic, xy_string_pos, font_size,
+                            color.plain_contrast(), xy_string.as_slice());
+                draw_circle(args, gl, p_pos - Point::new(pt_radius, pt_radius, 0.0),
+                            color.plain_contrast(), pt_radius);
+            };
+
+            match elem {
+                // If a point is clicked, draw the that point.
+                EnvPoint(idx, p_pos) => {
+                    let pad_x_right = pad_pos.x + pad_w;
+                    let (left_x_bound, right_x_bound) = get_x_bounds(env, idx);
+                    let left_pixel_bound = map_range(left_x_bound, min_x, max_x, pad_pos.x, pad_x_right);
+                    let right_pixel_bound = map_range(right_x_bound, min_x, max_x, pad_pos.x, pad_x_right);
+                    let p_pos_x_clamped = clamp(p_pos.x, left_pixel_bound, right_pixel_bound);
+                    let p_pos_y_clamped = clamp(p_pos.y, pad_pos.y, pad_pos.y + pad_h);
+                    draw_env_pt(env, idx, Point::new(p_pos_x_clamped, p_pos_y_clamped, 0.0));
+                    Some(idx)
+                },
+                // Otherwise, draw the closest point.
+                Pad => {
+                    for closest_elem in is_closest_elem.iter() {
+                        match *closest_elem {
+                            EnvPoint(closest_idx, closest_env_pt) => {
+                                draw_env_pt(env, closest_idx, closest_env_pt);
+                            },
+                            _ => (),
+                        }
+                    }
+                    None
+                }, _ => None,
+            }
+
+        }, _ => None,
+
+    };
+
+    // Set the new state.
+    set_state(uic, ui_id, new_state);
+
+    // Determine new values.
+    let get_new_value = |envelope: &mut Vec<E>,
+                         idx: uint,
+                         mouse_x: f64,
+                         mouse_y: f64| -> (X, Y) {
+        let mouse_x_on_pad = mouse_x - pad_pos.x;
+        let mouse_y_on_pad = mouse_y - pad_pos.y;
+        let mouse_x_clamped = clamp(mouse_x_on_pad, 0f64, pad_w);
+        let mouse_y_clamped = clamp(mouse_y_on_pad, 0f64, pad_h);
+        let new_x = map_range(mouse_x_clamped, 0f64, pad_w, min_x, max_x);
+        let new_y = map_range(mouse_y_clamped, pad_h, 0f64, min_y, max_y);
+        let (left_bound, right_bound) = get_x_bounds(envelope, idx);
+        (if new_x > right_bound { right_bound }
+         else if new_x < left_bound { left_bound }
+         else { new_x }, new_y)
+    };
+
+    // If a point is currently clicked, check for callback
+    // and value setting conditions.
+    match is_clicked_env_point {
+
+        Some(idx) => {
+
+            // Call the `callback` closure if mouse was released
+            // on one of the DropDownMenu items.
+            match (state, new_state) {
+                (Clicked(_, m_button), Highlighted(_)) | (Clicked(_, m_button), Normal) => {
+                    match m_button {
+                        Left => {
+                            // Adjust the point and trigger the callback.
+                            let (new_x, new_y) = get_new_value(env, idx, mouse.pos.x, mouse.pos.y);
+                            env.get_mut(idx).set_x(new_x);
+                            env.get_mut(idx).set_y(new_y);
+                            callback(env, idx);
+                        },
+                        Right => {
+                            // Delete the point and trigger the callback.
+                            env.remove(idx);
+                            callback(env, idx);
+                        },
+                    }
+                },
+
+                (Clicked(_, prev_m_button), Clicked(_, m_button)) => {
+                    match (prev_m_button, m_button) {
+                        (Left, Left) => {
+                            let (new_x, new_y) = get_new_value(env, idx, mouse.pos.x, mouse.pos.y);
+                            let current_x = (*env)[idx].get_x();
+                            let current_y = (*env)[idx].get_y();
+                            if new_x != current_x || new_y != current_y {
+                                // Adjust the point and trigger the callback.
+                                env.get_mut(idx).set_x(new_x);
+                                env.get_mut(idx).set_y(new_y);
+                                callback(env, idx);
+                            }
+                        }, _ => (),
+                    }
+                }, _ => (),
+            }
+
+        },
+
+        None => {
+
+            // Check if a there are no points. If there are
+            // and the mouse was clicked, add a point.
+            if env.len() == 0u {
+                match (state, new_state) {
+                    (Clicked(elem, m_button), Highlighted(_)) => {
+                        match (elem, m_button) {
+                            (Pad, Left) => {
+                                let (new_x, new_y) = get_new_value(env, 0u, mouse.pos.x, mouse.pos.y);
+                                let new_point = EnvelopePoint::new(new_x, new_y);
+                                env.push(new_point);
+                            }, _ => (),
+                        }
+                    }, _ => (),
+                }
+            }
+
+            else {
+                // Check if a new point should be created.
+                match (state, new_state) {
+                    (Clicked(elem, m_button), Highlighted(_)) => {
+                        match (elem, m_button) {
+                            (Pad, Left) => for closest_elem in is_closest_elem.iter() {
+                                match *closest_elem {
+                                    EnvPoint(idx, p_pos) => {
+                                        // Create a new point.
+                                        let (new_x, new_y) = get_new_value(env, idx, mouse.pos.x, mouse.pos.y);
+                                        let new_point = EnvelopePoint::new(new_x, new_y);
+                                        let insert_idx = if mouse.pos.x > p_pos.x { idx + 1u }
+                                                         else { idx };
+                                        env.insert(insert_idx, new_point);
+                                    }, _ => (),
+                                }
+                            }, _ => (),
+                        }
+                    }, _ => (),
+                }
+            }
+
+        },
+
+    }
+
+}
+
+/// Determine whether or not the cursor is over the EnvelopeEditor.
+/// If it is, return the element under the cursor and the closest
+/// EnvPoint to the cursor.
+fn is_over_and_closest<X: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
+                       Y: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
+                       E: EnvelopePoint<X, Y>>
+                       (pos: Point<f64>,
+                        mouse_pos: Point<f64>,
+                        rect_w: f64,
+                        rect_h: f64,
+                        pad_pos: Point<f64>,
+                        pad_w: f64,
+                        pad_h: f64,
+                        env: &mut Vec<E>,
+                        min_x: X, max_x: X,
+                        min_y: Y, max_y: Y,
+                        pt_radius: f64) -> (Option<Element>, Option<Element>) {
+    match rectangle::is_over(pos, mouse_pos, rect_w, rect_h) {
+        false => (None, None),
+        true => match rectangle::is_over(pad_pos, mouse_pos, pad_w, pad_h) {
+            false => (Some(Rect), Some(Rect)),
+            true => {
+                let mut closest_distance = ::std::f64::MAX_VALUE;
+                let mut closest_env_point = Pad;
+                for (i, p) in env.iter().enumerate() {
+                    let p_pos = Point::new(map_range(p.get_x(),
+                                                     min_x, max_x,
+                                                     pad_pos.x, pad_pos.x + pad_w),
+                                           map_range(p.get_y(),
+                                                     min_y, max_y,
+                                                     pad_pos.y + pad_h, pad_pos.y), 0.0);
+                    let distance = (mouse_pos.x - p_pos.x).powf(2.0)
+                                 + (mouse_pos.y - p_pos.y).powf(2.0);
+                    if distance <= pt_radius.powf(2.0) {
+                        return (Some(EnvPoint(i, p_pos)), Some(EnvPoint(i, p_pos)))
+                    }
+                    else if distance < closest_distance {
+                        closest_distance = distance;
+                        closest_env_point = EnvPoint(i, p_pos);
+                    }
+                }
+                (Some(Pad), Some(closest_env_point))
+            },
+        },
+    }
+}
+
+/// Determine and return the new state from the previous
+/// state and the mouse position.
+fn get_new_state(is_over_elem: Option<Element>,
+                 prev: State,
+                 mouse: MouseState) -> State {
+    match (is_over_elem, prev, mouse.left, mouse.right) {
+        (Some(_), Normal, Down, Up) => Normal,
+        (Some(elem), _, Up, Up) => Highlighted(elem),
+        (Some(elem), Highlighted(_), Down, Up) => Clicked(elem, Left),
+        (Some(_), Clicked(p_elem, m_button), Down, Up)
+        | (Some(_), Clicked(p_elem, m_button), Up, Down) => {
+            match p_elem {
+                EnvPoint(idx, _) => Clicked(EnvPoint(idx, mouse.pos), m_button),
+                _ => Clicked(p_elem, m_button),
+            }
+        },
+        (None, Clicked(p_elem, m_button), Down, Up) => {
+            match (p_elem, m_button) {
+                (EnvPoint(idx, _), Left) => Clicked(EnvPoint(idx, mouse.pos), Left),
+                _ => Clicked(p_elem, Left),
+            }
+        },
+        (Some(_), Highlighted(p_elem), Up, Down) => {
+            match p_elem {
+                EnvPoint(idx, _) => Clicked(EnvPoint(idx, mouse.pos), Right),
+                _ => Clicked(p_elem, Right),
+            }
+        },
+        _ => Normal,
+    }
+}
+
+/// Draw a circle at the given position.
+fn draw_circle(args: &RenderArgs,
+               gl: &mut Gl,
+               pos: Point<f64>,
+               color: Color,
+               radius: f64) {
+    let context = &Context::abs(args.width as f64, args.height as f64);
+    let (r, g, b, a) = color.as_tuple();
+    context
+        .ellipse(pos.x, pos.y, radius * 2.0, radius * 2.0)
+        .rgba(r, g, b, a)
+        .draw(gl)
+}
+

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -1,12 +1,8 @@
 
 use freetype;
 use label::FontSize;
-use opengl_graphics::{
-    Texture,
-};
-use piston::{
-    AssetStore,
-};
+use opengl_graphics::Texture;
+use piston::AssetStore;
 use std::collections::HashMap;
 
 /// Struct used to hold rendered character data.

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,11 +1,5 @@
 
 use color::Color;
-use piston::{
-    RenderArgs,
-};
-use opengl_graphics::{
-    Gl,
-};
 use graphics::{
     Context,
     AddColor,
@@ -13,8 +7,10 @@ use graphics::{
     Draw,
     RelativeTransform2d,
 };
-use ui_context::UIContext;
+use opengl_graphics::Gl;
+use piston::RenderArgs;
 use point::Point;
+use ui_context::UIContext;
 
 pub type FontSize = u32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,27 @@
 
 #![feature(macro_rules, phase)]
 
-extern crate graphics;
-extern crate piston;
-extern crate opengl_graphics;
-extern crate serialize;
 extern crate freetype;
+extern crate graphics;
+extern crate opengl_graphics;
+extern crate piston;
+extern crate serialize;
 
-pub use widget::Widget;
 pub use color::Color;
+pub use frame::{Framing, Frame, NoFrame};
 pub use point::Point;
 pub use ui_context::UIContext;
-pub use frame::{Framing, Frame, NoFrame};
+pub use widget::Widget;
 
 pub mod macros;
 
 pub mod button;
 pub mod color;
 pub mod drop_down_list;
+pub mod envelope_editor;
 pub mod frame;
 pub mod glyph_cache;
 pub mod label;
-pub mod widget_matrix;
 pub mod mouse_state;
 pub mod number_dialer;
 pub mod point;
@@ -31,5 +31,6 @@ pub mod toggle;
 pub mod ui_context;
 pub mod utils;
 pub mod widget;
+pub mod widget_matrix;
 pub mod xy_pad;
 

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -1,7 +1,10 @@
 
-use opengl_graphics::Gl;
-use piston::RenderArgs;
 use color::Color;
+use frame::{
+    Framing,
+    Frame,
+    NoFrame,
+};
 use graphics::{
     Context,
     AddColor,
@@ -10,9 +13,22 @@ use graphics::{
     Draw,
     RelativeTransform2d,
 };
+use label;
+use label::{
+    FontSize,
+    Labeling,
+    NoLabel,
+    Label,
+};
+use mouse_state::{
+    MouseState,
+    Up,
+    Down,
+};
+use opengl_graphics::Gl;
+use piston::RenderArgs;
 use point::Point;
 use rectangle;
-use widget::NumberDialer;
 use utils::{
     clamp,
     compare_f64s,
@@ -21,23 +37,7 @@ use ui_context::{
     UIID,
     UIContext,
 };
-use mouse_state::{
-    MouseState,
-    Up,
-    Down,
-};
-use label;
-use label::{
-    FontSize,
-    Labeling,
-    NoLabel,
-    Label,
-};
-use frame::{
-    Framing,
-    Frame,
-    NoFrame,
-};
+use widget::NumberDialer;
 
 /// Represents the specific elements that the
 /// NumberDialer is made up of. This is used to
@@ -376,7 +376,6 @@ fn draw_value_string(args: &RenderArgs,
                         .draw(gl);
         x += slot_w as i32;
     }
-
 }
 
 /// Draw the slot behind the value.

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,11 +1,13 @@
 
+use envelope_editor::EnvelopePoint;
 use std::default::Default;
+use std::num::from_f32;
 
 /// General use 3D spatial point. Although only
 /// 2D widgets exist at the moment, this allows
 /// for the possibility of 3D widgets in the
 /// future.
-#[deriving(Show, Clone)]
+#[deriving(Show, Clone, PartialEq)]
 pub struct Point<T> {
     pub x: T,
     pub y: T,
@@ -29,6 +31,21 @@ impl<T: Num + Copy> Point<T> {
         (self.x, self.y, self.z)
     }
 
+}
+
+impl<T: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString> EnvelopePoint<T, T> for Point<T> {
+    /// Return the X value.
+    fn get_x(&self) -> T { self.x }
+    /// Return the Y value.
+    fn get_y(&self) -> T { self.y }
+    /// Return the X value.
+    fn set_x(&mut self, x: T) { self.x = x }
+    /// Return the Y value.
+    fn set_y(&mut self, y: T) { self.y = y }
+    /// Create a new Envelope Point.
+    fn new(x: T, y: T) -> Point<T> {
+        Point::new(x, y, from_f32(0f32).unwrap())
+    }
 }
 
 impl<T: Num + Copy + Default> Default for Point<T> {

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,24 +1,23 @@
 
-use piston::{
-    RenderArgs,
-};
-use opengl_graphics::Gl;
-use graphics::{
-    Context,
-    AddRectangle,
-    AddColor,
-    Draw,
-};
-use point::Point;
 use color::Color;
 use frame::{
     Framing,
     Frame,
     NoFrame,
 };
+use graphics::{
+    Context,
+    AddRectangle,
+    AddColor,
+    Draw,
+};
 use label;
 use label::FontSize;
+use opengl_graphics::Gl;
+use piston::RenderArgs;
+use point::Point;
 use ui_context::UIContext;
+use utils::map_range;
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq, Show)]
@@ -125,4 +124,22 @@ pub fn draw_with_centered_label(args: &RenderArgs,
     label::draw(args, gl, uic, l_pos, font_size, text_color, text);
 }
 
+pub enum Corner {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+/// Return which corner of the rectangle the given Point is within.
+pub fn corner(rect_p: Point<f64>, p: Point<f64>, width: f64, height: f64) -> Corner {
+    let x_temp = p.x - rect_p.x;
+    let y_temp = p.y - rect_p.y;
+    let x_perc = map_range(x_temp, 0.0, width, 0f64, 1.0);
+    let y_perc = map_range(y_temp, height, 0.0, 0f64, 1.0);
+    if      x_perc <= 0.5 && y_perc <= 0.5 { BottomLeft }
+    else if x_perc >  0.5 && y_perc <= 0.5 { BottomRight }
+    else if x_perc <= 0.5 && y_perc >  0.5 { TopLeft }
+    else                                   { TopRight }
+}
 

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -1,35 +1,35 @@
 
-use piston::RenderArgs;
+use color::Color;
+use frame::{
+    Framing,
+    Frame,
+    NoFrame,
+};
 use label;
 use label::{
     Labeling,
     Label,
     NoLabel,
 };
-use rectangle;
-use point::Point;
-use color::Color;
-use utils::{
-    clamp,
-    percentage,
-    value_from_perc,
-};
-use opengl_graphics::Gl;
-use ui_context::{
-    UIID,
-    UIContext,
-};
 use mouse_state::{
     MouseState,
     Up,
     Down,
 };
-use widget::Slider;
-use frame::{
-    Framing,
-    Frame,
-    NoFrame,
+use opengl_graphics::Gl;
+use piston::RenderArgs;
+use point::Point;
+use rectangle;
+use ui_context::{
+    UIID,
+    UIContext,
 };
+use utils::{
+    clamp,
+    percentage,
+    value_from_perc,
+};
+use widget::Slider;
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -1,25 +1,25 @@
 
-use opengl_graphics::Gl;
-use piston::RenderArgs;
 use color::Color;
-use point::Point;
-use rectangle;
-use widget::Toggle;
-use ui_context::{
-    UIID,
-    UIContext,
+use frame::Framing;
+use label::{
+    Labeling,
+    Label,
+    NoLabel,
 };
 use mouse_state::{
     MouseState,
     Up,
     Down,
 };
-use label::{
-    Labeling,
-    Label,
-    NoLabel,
+use opengl_graphics::Gl;
+use piston::RenderArgs;
+use point::Point;
+use rectangle;
+use ui_context::{
+    UIID,
+    UIContext,
 };
-use frame::Framing;
+use widget::Toggle;
 
 /// Represents the state of the Button widget.
 #[deriving(PartialEq)]

--- a/src/ui_context.rs
+++ b/src/ui_context.rs
@@ -1,11 +1,7 @@
 
-use std::collections::HashMap;
-use point::Point;
-use widget::Widget;
-use piston::{
-    GameEvent,
-    Input,
-    input,
+use glyph_cache::{
+    GlyphCache,
+    Character,
 };
 use label::FontSize;
 use mouse_state::{
@@ -13,10 +9,14 @@ use mouse_state::{
     Down,
     MouseState,
 };
-use glyph_cache::{
-    GlyphCache,
-    Character,
+use piston::{
+    GameEvent,
+    Input,
+    input,
 };
+use point::Point;
+use std::collections::HashMap;
+use widget::Widget;
 
 /// User Interface Identifier. Each unique `widget::draw` call
 /// should pass it's own unique UIID so that UIContext can keep
@@ -50,15 +50,15 @@ impl UIContext {
             },
             Input(input::MousePress { button, .. }) => {
                 *match button {
-                    /*Left*/ _ => &mut self.mouse.left,
-                    //Right => &mut self.mouse.right,
+                    input::mouse::Left => &mut self.mouse.left,
+                    _/*input::mouse::Right*/ => &mut self.mouse.right,
                     //Middle => &mut self.mouse.middle,
                 } = Down;
             },
             Input(input::MouseRelease { button, .. }) => {
                 *match button {
-                    /*Left*/ _ => &mut self.mouse.left,
-                    //Right => &mut self.mouse.right,
+                    input::mouse::Left => &mut self.mouse.left,
+                    _/*input::mouse::Right*/ => &mut self.mouse.right,
                     //Middle => &mut self.mouse.middle,
                 } = Up;
             },

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,8 @@
 
+use std::num::pow;
+
 /// Clamp a value between a given min and max.
-pub fn clamp<T: Num + Primitive>(n: T, min: T, max: T) -> T {
+pub fn clamp<T: Num + PartialOrd>(n: T, min: T, max: T) -> T {
     if n < min { min } else if n > max { max } else { n }
 }
 
@@ -32,8 +34,9 @@ pub fn value_from_perc<T: Num + Copy + FromPrimitive + ToPrimitive>
 }
 
 /// Map a value from a given range to a new given range.
-pub fn map<T: Num + Copy + FromPrimitive + ToPrimitive>
-    (val: T, in_min: T, in_max: T, out_min: T, out_max: T) -> T {
+pub fn map_range<X: Num + Copy + FromPrimitive + ToPrimitive,
+                 Y: Num + Copy + FromPrimitive + ToPrimitive>
+    (val: X, in_min: X, in_max: X, out_min: Y, out_max: Y) -> Y {
     let (val_f, in_min_f, in_max_f, out_min_f, out_max_f) = (
         val.to_f64().unwrap(),
         in_min.to_f64().unwrap(),
@@ -44,5 +47,45 @@ pub fn map<T: Num + Copy + FromPrimitive + ToPrimitive>
     FromPrimitive::from_f64(
         (val_f - in_min_f) / (in_max_f - in_min_f) * (out_max_f - out_min_f) + out_min_f
     ).unwrap()
+}
+
+/// Get a suitable string from the value, its max and the pixel range.
+pub fn val_to_string<T: ToString + ToPrimitive>
+                (val: T, max: T, val_rng: T, pixel_range: uint) -> String {
+    let mut s = val.to_string();
+    let decimal = s.as_slice().chars().position(|ch| ch == '.');
+    match decimal {
+        None => s,
+        Some(idx) => {
+            // Find the minimum string length by determing
+            // what power of ten both the max and range are.
+            let val_rng_f = val_rng.to_f64().unwrap();
+            let max_f = max.to_f64().unwrap();
+            let mut n = 0f64;
+            let mut pow_ten = 0f64;
+            while pow_ten < val_rng_f || pow_ten < max_f {
+                pow_ten = (10f64).powf(n);
+                n += 1.0
+            }
+            let min_string_len = n as uint;
+
+            // Find out how many pixels there are to actually use
+            // and judge a reasonable precision from this.
+            let mut n = 0u;
+            while pow(10u, n) < pixel_range { n += 1u }
+            let precision = n - 1u;
+
+            // Truncate the length to the pixel precision as
+            // long as this doesn't cause it to be smaller
+            // than the necessary decimal place.
+            let truncate_len = {
+                if precision >= min_string_len { precision }
+                else { min_string_len }
+            };
+            if truncate_len - 1u == idx { s.truncate(truncate_len + 1u) }
+            else { s.truncate(truncate_len) }
+            s
+        }
+    }
 }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,6 +1,7 @@
 
 use button;
 use drop_down_list;
+use envelope_editor;
 use number_dialer;
 use slider;
 use toggle;
@@ -11,6 +12,7 @@ use xy_pad;
 pub enum Widget {
     Button(button::State),
     DropDownList(drop_down_list::State),
+    EnvelopeEditor(envelope_editor::State),
     NumberDialer(number_dialer::State),
     Slider(slider::State),
     Toggle(toggle::State),

--- a/src/widget_matrix.rs
+++ b/src/widget_matrix.rs
@@ -19,8 +19,8 @@ pub fn draw(cols: uint,
             width: f64,
             height: f64,
             widget_draw_callback: |WidgetNum, ColNum, RowNum, Point<f64>, Width, Height|) {
-    let widget_w = width / rows as f64;
-    let widget_h = height / cols as f64;
+    let widget_w = width / cols as f64;
+    let widget_h = height / rows as f64;
     let mut widget_num = 0u;
     for col in range(0u, cols) {
         for row in range(0u, rows) {


### PR DESCRIPTION
The main things are,
- Implemented EnvelopeEditor widget for manipulating a vector of `E` where `E` implements `EnvelopePoint` (see `all_widgets` and `envelope_editor` for details).
- Moved all the messy variables in `all_widgets` app into a `DemoApp` struct.
- Fixed ordering of `use`s so that they're in alphabetical order.
