### PR TITLE
Moved all potentially optional arguments into context methods.

### DIFF
--- a/examples/all_widgets/all_widgets.rs
+++ b/examples/all_widgets/all_widgets.rs
@@ -22,7 +22,9 @@ use conrod::{
     Labelable,
     NumberDialer,
     Point,
+    Positionable,
     Slider,
+    Shapeable,
     TextBox,
     Toggle,
     UIContext,
@@ -197,8 +199,10 @@ fn draw_ui(gl: &mut Gl,
 
     if demo.show_button {
 
-        // Button widget example button(UIID, x, y, f64, f64).
-        uic.button(0u64, 50.0, 115.0, 90.0, 60.0)
+        // Button widget example button(UIID).
+        uic.button(0u64)
+            .dimensions(90.0, 60.0)
+            .position(50.0, 115.0)
             .rgba(0.4, 0.75, 0.6, 1.0)
             .frame(demo.frame_width, Color::black())
             .label("PRESS", 24u32, Color::black())
@@ -215,8 +219,10 @@ fn draw_ui(gl: &mut Gl,
         let pad_string = pad.to_string();
         let label = "Padding: ".to_string().append(pad_string.as_slice());
 
-        // Slider widget example slider(UIID, value, min, max, x, y, width, height).
-        uic.slider(1u64, pad as i16, 10i16, 910i16, 50.0, 115.0, 200.0, 50.0)
+        // Slider widget example slider(UIID, value, min, max).
+        uic.slider(1u64, pad as i16, 10i16, 910i16)
+            .dimensions(200.0, 50.0)
+            .position(50.0, 115.0)
             .rgba(0.5, 0.3, 0.6, 1.0)
             .frame(demo.frame_width, Color::black())
             .label(label.as_slice(), 24u32, Color::white())
@@ -228,15 +234,18 @@ fn draw_ui(gl: &mut Gl,
     // Clone the label toggle to be drawn.
     let label = demo.toggle_label.clone();
 
-    // Toggle widget example toggle(UIID, value, x, y, width, height).
-    uic.toggle(2u64, demo.show_button, 50.0, 200.0, 75.0, 75.0)
+    // Toggle widget example toggle(UIID, value).
+    uic.toggle(2u64, demo.show_button)
+        .dimensions(75.0, 75.0)
+        .position(50.0, 200.0)
         .rgba(0.6, 0.25, 0.75, 1.0)
         .frame(demo.frame_width, Color::black())
         .label(label.as_slice(), 24u32, Color::white())
         .callback(|value| {
             demo.show_button = value;
             demo.toggle_label = match value {
-                true => "ON".to_string(), false => "OFF".to_string()
+                true => "ON".to_string(),
+                false => "OFF".to_string()
             }
         })
         .draw(gl);
@@ -263,11 +272,10 @@ fn draw_ui(gl: &mut Gl,
         let mut label = value.to_string();
         if label.len() > 4u { label.truncate(4u); }
 
-        // Slider widget examples.
-        uic.slider(3u64 + i as u64, // UIID
-                   value, 0.0, 1.0, // value, min, max
-                   50.0 + i as f64 * 60.0, 300.0, // x, y
-                   35.0, demo.v_slider_height) // width, height
+        // Slider widget examples. slider(UIID, value, min, max)
+        uic.slider(3u64 + i as u64, value, 0.0, 1.0)
+            .dimensions(35.0, demo.v_slider_height)
+            .position(50.0 + i as f64 * 60.0, 300.0)
             .color(color)
             .frame(demo.frame_width, Color::black())
             .label(label.as_slice(), 24u32, Color::white())
@@ -280,25 +288,23 @@ fn draw_ui(gl: &mut Gl,
 
     }
 
-    // Number Dialer widget example.
-    uic.number_dialer(6u64, // UIID
-                      demo.v_slider_height, 25.0, 250.0, // value, min, max
-                      1u8, // decimal precision
-                      300.0, 115.0, 260.0, 60.0) // x, y, width, height
+    // Number Dialer widget example. number_dialer(UIID, value, min, max, precision)
+    uic.number_dialer(6u64, demo.v_slider_height, 25.0, 250.0, 1u8)
+        .dimensions(260.0, 60.0)
+        .position(300.0, 115.0)
         .color(demo.bg_color.invert())
         .frame(demo.frame_width, Color::black())
         .label("Height (pixels)", 24u32, demo.bg_color.invert().plain_contrast())
         .callback(|new_height| demo.v_slider_height = new_height)
         .draw(gl);
 
-    // Number Dialer widget example.
-    uic.number_dialer(7u64, // UIID
-                      demo.frame_width, 0.0, 15.0, // value, min, max
-                      2u8, // decimal precision
-                      300.0, 195.0, 260.0, 60.0) // x, y, width, height
+    // Number Dialer widget example. number_dialer(UIID, value, min, max, precision)
+    uic.number_dialer(7u64, demo.frame_width, 0.0, 15.0, 2u8)
+        .dimensions(260.0, 60.0)
+        .position(300.0, 195.0)
         .color(demo.bg_color.invert().plain_contrast())
         .frame(demo.frame_width, demo.bg_color.plain_contrast())
-        .label("Height (pixels)", 24u32, demo.bg_color.plain_contrast())
+        .label("Frame Width (pixels)", 24u32, demo.bg_color.plain_contrast())
         .callback(|new_width| demo.frame_width = new_width)
         .draw(gl);
 
@@ -324,7 +330,9 @@ fn draw_ui(gl: &mut Gl,
 
             // Now draw the widgets with the given callback.
             let val = demo.bool_matrix[col][row];
-            uic.toggle(8u64 + num as u64, val, pos.x, pos.y, width, height)
+            uic.toggle(8u64 + num as u64, val)
+                .dimensions(width, height)
+                .position(pos.x, pos.y)
                 .rgba(r, g, b, a)
                 .frame(demo.frame_width, Color::black())
                 .callback(|new_val| *demo.bool_matrix.get_mut(col).get_mut(row) = new_val)
@@ -349,8 +357,9 @@ fn draw_ui(gl: &mut Gl,
     draw_circle(uic.win_w, uic.win_h, gl, demo.circle_pos, ddl_color);
 
     // A demonstration using drop_down_list.
-    uic.drop_down_list(75u64, &mut demo.ddl_colors, &mut demo.selected_idx,
-                       620.0, 115.0, 150.0, 40.0) // x, y, width, height
+    uic.drop_down_list(75u64, &mut demo.ddl_colors, &mut demo.selected_idx)
+        .dimensions(150.0, 40.0)
+        .position(620.0, 115.0)
         .color(ddl_color)
         .frame(demo.frame_width, ddl_color.plain_contrast())
         .label("Colors", 24u32, ddl_color.plain_contrast())
@@ -361,11 +370,14 @@ fn draw_ui(gl: &mut Gl,
     let label_color = Color::new(1.0, 1.0, 1.0, 0.5) * ddl_color.plain_contrast();
     uic.xy_pad(76u64, // UIID
                demo.circle_pos.x, 760.0, 610.0, // x range.
-               demo.circle_pos.y, 320.0, 170.0, // y range.
-               620.0, 370.0, 150.0, 150.0) // x, y, width, height.
+               demo.circle_pos.y, 320.0, 170.0) // y range.
+        .dimensions(150.0, 150.0)
+        .position(620.0, 370.0)
         .color(ddl_color)
         .frame(demo.frame_width, Color::white())
         .label("Circle Position", 32u32, label_color)
+        .line_width(2.0)
+        .value_font_size(18u32)
         .callback(|new_x, new_y| {
             demo.circle_pos.x = new_x;
             demo.circle_pos.y = new_y;
@@ -388,30 +400,35 @@ fn draw_ui(gl: &mut Gl,
             let text_box_height = height / 4.0;
             let env_editor_height = height - text_box_height;
             let env_editor_pos = pos + Point::new(0.0, text_box_height, 0.0);
+            let env_label_color = Color::new(1.0, 1.0, 1.0, 0.5)           
+                                * demo.bg_color.invert().plain_contrast();
+            let env_y_max = match num { 0u => 20000.0, _ => 1.0 };
+            let tbox_uiid = 77u64 + (num * 2u) as u64;
+            let env_uiid = tbox_uiid + 1u64;
+            let env_skew_y = match num { 0u => 3.0, _ => 1.0 };
 
-            // Draw a TextBox.
-            uic.text_box(77u64 + (num * 2u) as u64, // UIID
-                         text, 24u32, // mutable string, font size
-                         pos.x, pos.y, width, text_box_height - 10.0) // x, y, w, h
+            // Draw a TextBox. text_box(UIID, &mut String, FontSize)
+            uic.text_box(tbox_uiid, text)
+                .font_size(24u32)
+                .dimensions(width, text_box_height - 10.0)
+                .position(pos.x, pos.y)
                 .frame(demo.frame_width, demo.bg_color.invert().plain_contrast())
                 .color(demo.bg_color.invert())
                 .draw(gl);
 
             // Draw an EnvelopeEditor.
-            let label_color =
-                Color::new(1.0, 1.0, 1.0, 0.5) * demo.bg_color.invert().plain_contrast();
-            uic.envelope_editor(77u64 + (num * 2u + 1u) as u64, // UIID
-                                env, // vector of envelope points.
-                                match num { 0u => Some(3f32), _ => None }, // y axis skew.
-                                0.0, 1.0, // x axis range.
-                                0.0, match num { 0u => 20000.0, _ => 1.0 }, // y axis range.
-                                env_editor_pos.x, env_editor_pos.y, // x, y
-                                width, env_editor_height - 10.0) // width, height
+            uic.envelope_editor(env_uiid, // UIID
+                                env, // vector of `E: EnvelopePoint`s.
+                                0.0, 1.0, 0.0, env_y_max) // x_min, x_max, y_min, y_max.
+                .dimensions(width, env_editor_height - 10.0)
+                .position(env_editor_pos.x, env_editor_pos.y)
+                .skew_y(env_skew_y)
                 .color(demo.bg_color.invert())
                 .frame(demo.frame_width, demo.bg_color.invert().plain_contrast())
-                .label(text.as_slice(), 32u32, label_color)
+                .label(text.as_slice(), 32u32, env_label_color)
+                .point_radius(6.0)
+                .line_width(2.0)
                 .draw(gl);
-            
 
         } // End of matrix widget callback.
     ); 

--- a/src/button.rs
+++ b/src/button.rs
@@ -63,21 +63,19 @@ pub struct ButtonContext<'a> {
 
 pub trait ButtonBuilder<'a> {
     /// A button builder method to be implemented by the UIContext.
-    fn button(&'a mut self, ui_id: UIID,
-              x: f64, y: f64, width: f64, height: f64) -> ButtonContext<'a>;
+    fn button(&'a mut self, ui_id: UIID) -> ButtonContext<'a>;
 }
 
 impl<'a> ButtonBuilder<'a> for UIContext {
 
     /// Create a button context to be built upon.
-    fn button(&'a mut self, ui_id: UIID,
-              x: f64, y: f64, width: f64, height: f64) -> ButtonContext<'a> {
+    fn button(&'a mut self, ui_id: UIID) -> ButtonContext<'a> {
         ButtonContext {
             uic: self,
             ui_id: ui_id,
-            pos: Point::new(x, y, 0.0),
-            width: width,
-            height: height,
+            pos: Point::new(0.0, 0.0, 0.0),
+            width: 64.0,
+            height: 64.0,
             maybe_callback: None,
             maybe_color: None,
             maybe_frame: None,
@@ -91,6 +89,7 @@ impl_colorable!(ButtonContext)
 impl_frameable!(ButtonContext)
 impl_labelable!(ButtonContext)
 impl_positionable!(ButtonContext)
+impl_shapeable!(ButtonContext)
 
 impl<'a> ::callback::Callable<||:'a> for ButtonContext<'a> {
     #[inline]

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -140,23 +140,21 @@ pub struct DropDownListContext<'a> {
 
 pub trait DropDownListBuilder<'a> {
     /// A dropdownlist builder method to be implemented by the UIContext.
-    fn drop_down_list(&'a mut self, ui_id: UIID,
-                      strings: &'a mut Vec<String>, selected: &'a mut Option<Idx>,
-                      x: f64, y: f64, width: f64, height: f64) -> DropDownListContext<'a>;
+    fn drop_down_list(&'a mut self, ui_id: UIID, strings: &'a mut Vec<String>,
+                      selected: &'a mut Option<Idx>) -> DropDownListContext<'a>;
 }
 
 impl<'a> DropDownListBuilder<'a> for UIContext {
-    fn drop_down_list(&'a mut self, ui_id: UIID,
-                      strings: &'a mut Vec<String>, selected: &'a mut Option<Idx>,
-                      x: f64, y: f64, width: f64, height: f64) -> DropDownListContext<'a> {
+    fn drop_down_list(&'a mut self, ui_id: UIID, strings: &'a mut Vec<String>,
+                      selected: &'a mut Option<Idx>) -> DropDownListContext<'a> {
         DropDownListContext {
             uic: self,
             ui_id: ui_id,
             strings: strings,
             selected: selected,
-            pos: Point::new(x, y, 0.0),
-            width: width,
-            height: height,
+            pos: Point::new(0.0, 0.0, 0.0),
+            width: 128.0,
+            height: 32.0,
             maybe_callback: None,
             maybe_color: None,
             maybe_frame: None,
@@ -169,6 +167,7 @@ impl_colorable!(DropDownListContext)
 impl_frameable!(DropDownListContext)
 impl_labelable!(DropDownListContext)
 impl_positionable!(DropDownListContext)
+impl_shapeable!(DropDownListContext)
 
 impl<'a> ::callback::Callable<|&mut Option<Idx>, Idx, String|:'a> for DropDownListContext<'a> {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use frame::{Framing, Frame, Frameable, NoFrame};
 pub use label::Labelable;
 pub use point::Point;
 pub use position::Positionable;
+pub use shape::Shapeable;
 pub use ui_context::UIContext;
 pub use widget::Widget;
 
@@ -43,6 +44,7 @@ pub mod number_dialer;
 pub mod point;
 pub mod position;
 pub mod rectangle;
+pub mod shape;
 pub mod slider;
 pub mod text_box;
 pub mod toggle;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,4 +89,15 @@ macro_rules! impl_positionable(
         }
     )
 )
+/// Simplify implementation of the `Shapeable` trait.
+macro_rules! impl_shapeable(
+    ($context:ident) => (
+        impl<'a> ::shape::Shapeable for $context<'a> {
+            #[inline]
+            fn dimensions(self, width: f64, height: f64) -> $context<'a> {
+                $context { width: width, height: height, ..self }
+            }
+        }
+    )
+)
 

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -313,24 +313,24 @@ pub struct NumberDialerContext<'a, T> {
 pub trait NumberDialerBuilder
 <'a, T: Num + Copy + Primitive + FromPrimitive + ToPrimitive + ToString> {
     /// A number_dialer builder method to be implemented by the UIContext.
-    fn number_dialer(&'a mut self, ui_id: UIID, value: T, min: T, max: T, precision: u8,
-                     x: f64, y: f64, width: f64, height: f64) -> NumberDialerContext<'a, T>;
+    fn number_dialer(&'a mut self, ui_id: UIID, value: T, min: T, max: T,
+                     precision: u8) -> NumberDialerContext<'a, T>;
 }
 
 impl<'a, T: Num + Copy + Primitive + FromPrimitive + ToPrimitive + ToString>
 NumberDialerBuilder<'a, T> for UIContext {
     /// A number_dialer builder method to be implemented by the UIContext.
-    fn number_dialer(&'a mut self, ui_id: UIID, value: T, min: T, max: T, precision: u8,
-                     x: f64, y: f64, width: f64, height: f64) -> NumberDialerContext<'a, T> {
+    fn number_dialer(&'a mut self, ui_id: UIID, value: T, min: T, max: T,
+                     precision: u8) -> NumberDialerContext<'a, T> {
         NumberDialerContext {
             uic: self,
             ui_id: ui_id,
             value: clamp(value, min, max),
             min: min,
             max: max,
-            pos: Point::new(x, y, 0.0),
-            width: width,
-            height: height,
+            pos: Point::new(0.0, 0.0, 0.0),
+            width: 128.0,
+            height: 48.0,
             precision: precision,
             maybe_color: None,
             maybe_frame: None,
@@ -363,6 +363,13 @@ impl<'a, T> ::position::Positionable for NumberDialerContext<'a, T> {
     #[inline]
     fn position(self, x: f64, y: f64) -> NumberDialerContext<'a, T> {
         NumberDialerContext { pos: Point::new(x, y, 0.0), ..self }
+    }
+}
+
+impl<'a, T> ::shape::Shapeable for NumberDialerContext<'a, T> {
+    #[inline]
+    fn dimensions(self, width: f64, height: f64) -> NumberDialerContext<'a, T> {
+        NumberDialerContext { width: width, height: height, ..self }
     }
 }
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,0 +1,7 @@
+
+/// A trait that indicates whether or not a widget
+/// builder is positionable.
+pub trait Shapeable {
+    fn dimensions(self, width: f64, height: f64) -> Self;
+}
+

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -72,24 +72,24 @@ pub struct SliderContext<'a, T> {
 
 pub trait SliderBuilder<'a, T: Num + Copy + FromPrimitive + ToPrimitive> {
     /// A slider builder method to be implemented by the UIContext.
-    fn slider(&'a mut self, ui_id: UIID, value: T, min: T, max: T,
-              x: f64, y: f64, width: f64, height: f64) -> SliderContext<'a, T>;
+    fn slider(&'a mut self, ui_id: UIID,
+              value: T, min: T, max: T) -> SliderContext<'a, T>;
 }
 
 impl<'a, T: Num + Copy + FromPrimitive + ToPrimitive>
 SliderBuilder<'a, T> for UIContext {
     /// A button builder method to be implemented by the UIContext.
-    fn slider(&'a mut self, ui_id: UIID, value: T, min: T, max: T,
-              x: f64, y: f64, width: f64, height: f64) -> SliderContext<'a, T> {
+    fn slider(&'a mut self, ui_id: UIID,
+              value: T, min: T, max: T) -> SliderContext<'a, T> {
         SliderContext {
             uic: self,
             ui_id: ui_id,
             value: value,
             min: min,
             max: max,
-            pos: Point::new(x, y, 0.0),
-            width: width,
-            height: height,
+            pos: Point::new(0.0, 0.0, 0.0),
+            width: 192.0,
+            height: 48.0,
             maybe_callback: None,
             maybe_color: None,
             maybe_frame: None,
@@ -121,6 +121,13 @@ impl<'a, T> ::position::Positionable for SliderContext<'a, T> {
     #[inline]
     fn position(self, x: f64, y: f64) -> SliderContext<'a, T> {
         SliderContext { pos: Point::new(x, y, 0.0), ..self }
+    }
+}
+
+impl<'a, T> ::shape::Shapeable for SliderContext<'a, T> {
+    #[inline]
+    fn dimensions(self, width: f64, height: f64) -> SliderContext<'a, T> {
+        SliderContext { width: width, height: height, ..self }
     }
 }
 

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -193,26 +193,28 @@ pub struct TextBoxContext<'a> {
     maybe_frame: Option<(f64, Color)>,
 }
 
+impl<'a> TextBoxContext<'a> {
+    pub fn font_size(self, font_size: FontSize) -> TextBoxContext<'a> {
+        TextBoxContext { font_size: font_size, ..self }
+    }
+}
+
 pub trait TextBoxBuilder<'a> {
     /// An text box builder method to be implemented by the UIContext.
-    fn text_box(&'a mut self, ui_id: UIID,
-                text: &'a mut String, font_size: u32,
-                x: f64, y: f64, width: f64, height: f64) -> TextBoxContext<'a>;
+    fn text_box(&'a mut self, ui_id: UIID, text: &'a mut String) -> TextBoxContext<'a>;
 }
 
 impl<'a> TextBoxBuilder<'a> for UIContext {
     /// Initialise a TextBoxContext.
-    fn text_box(&'a mut self, ui_id: UIID,
-                text: &'a mut String, font_size: u32,
-                x: f64, y: f64, width: f64, height: f64) -> TextBoxContext<'a> {
+    fn text_box(&'a mut self, ui_id: UIID, text: &'a mut String) -> TextBoxContext<'a> {
         TextBoxContext {
             uic: self,
             ui_id: ui_id,
             text: text,
-            font_size: font_size,
-            pos: Point::new(x, y, 0.0),
-            width: width,
-            height: height,
+            font_size: 24u32, // Default font_size.
+            pos: Point::new(0.0, 0.0, 0.0),
+            width: 192.0,
+            height: 48.0,
             maybe_callback: None,
             maybe_color: None,
             maybe_frame: None,
@@ -224,6 +226,7 @@ impl<'a> TextBoxBuilder<'a> for UIContext {
 impl_colorable!(TextBoxContext)
 impl_frameable!(TextBoxContext)
 impl_positionable!(TextBoxContext)
+impl_shapeable!(TextBoxContext)
 
 /*
 impl<'a> ::color::Colorable<'a> for TextBoxContext<'a> {

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -64,21 +64,19 @@ pub struct ToggleContext<'a> {
 
 pub trait ToggleBuilder<'a> {
     /// A builder method to be implemented by the UIContext.
-    fn toggle(&'a mut self, ui_id: UIID, value: bool,
-              x: f64, y: f64, width: f64, height: f64) -> ToggleContext<'a>;
+    fn toggle(&'a mut self, ui_id: UIID, value: bool) -> ToggleContext<'a>;
 }
 
 impl<'a> ToggleBuilder<'a> for UIContext {
 
     /// Create a toggle context to be built upon.
-    fn toggle(&'a mut self, ui_id: UIID, value: bool,
-              x: f64, y: f64, width: f64, height: f64) -> ToggleContext<'a> {
+    fn toggle(&'a mut self, ui_id: UIID, value: bool) -> ToggleContext<'a> {
         ToggleContext {
             uic: self,
             ui_id: ui_id,
-            pos: Point::new(x, y, 0.0),
-            width: width,
-            height: height,
+            pos: Point::new(0.0, 0.0, 0.0),
+            width: 64.0,
+            height: 64.0,
             maybe_callback: None,
             maybe_color: None,
             maybe_frame: None,
@@ -93,6 +91,7 @@ impl_colorable!(ToggleContext)
 impl_frameable!(ToggleContext)
 impl_labelable!(ToggleContext)
 impl_positionable!(ToggleContext)
+impl_shapeable!(ToggleContext)
 
 impl<'a> ::callback::Callable<|bool|:'a> for ToggleContext<'a> {
     #[inline]


### PR DESCRIPTION
Including `font_size`, `line_width`, `point_radius`, `skew`, `position`, `dimensions`
