### PR TITLE
Implement `Encodable, Decodable` for `Color`.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -289,25 +289,25 @@ impl Show for Color {
     }
 }
 
-impl<E, D: Decoder<E>> Decodable<E, D> for Color {
+impl<E, D: Decoder<E>> Decodable<D, E> for Color {
     fn decode(dec: &mut D) -> Result<Color, E> {
         let vec = try!(dec.read_to_vec(|le_dec| le_dec.read_f32()));
 
         if vec.len() != 4 {
-            return dec.err(format!(
+            return Err(dec.error(format!(
                 "Expected a 4 element vector when decoding Color.
-                Found a vector of length {}.", vec.len()));
+                Found a vector of length {}.", vec.len()).as_slice()));
         }
 
         Ok(Color([vec[0], vec[1], vec[2], vec[3]]))
     }
 }
 
-impl<E, S: Encoder<E>> Encodable<E, D> for Color {
+impl<E, S: Encoder<E>> Encodable<S, E> for Color {
     fn encode(&self, enc: &mut S) -> Result<(), E> {
         let Color(ref vec) = *self;
 
-        enc.emit_from_vec(vec, |le_enc, elt| le_enc.emit_f32(elt))
+        enc.emit_from_vec(vec, |le_enc, elt| le_enc.emit_f32(*elt))
     }
 }
 


### PR DESCRIPTION
The implementation of `Encodable` encodes the Color as a length-4 vector of `f32`. `Decodable` expects a length-4 vector of `f32` and errors if it is not the correct length.

I figured encoding `Color` as a tuple-struct would only add unnecessary complexity, though it won't be as clear that the object is a `Color` in the encoded representation, if it is human-readable. However, this adds the benefit of allowing any encoded length-4 vector of `f32` to decode as `Color`, making it easier to use in manually edited config and JSON files.

I was not able to test the implementation due to unrelated build errors. At the very least, I eliminated all type-check errors in `color.rs`, so the committed code _should_ be correct.

When I work on a fork I haven't touched in a while, I should remember to update the fork before doing anything else. I can attempt to rebase these commits to slim it all down, but I don't think that to be a huge concern. 

I was pleased to discover that the type-checker treats a reference to a fixed-length vector (e.g. `[f32, ..4]`) the same as a vector slice, so `encode()` was very simple to implement. 

Closes #58, #59.
