### PR TITLE
fix graphics dependency change (rust-graphics -> graphics)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ git = "https://github.com/PistonDevelopers/piston"
 
 [dependencies.graphics]
 
-git = "https://github.com/PistonDevelopers/rust-graphics.git"
+git = "https://github.com/PistonDevelopers/graphics.git"
 
 [dependencies.opengl_graphics]
 

--- a/examples/all_widgets/Cargo.toml
+++ b/examples/all_widgets/Cargo.toml
@@ -23,7 +23,7 @@ git = "https://github.com/PistonDevelopers/sdl2_game_window.git"
 
 [dependencies.graphics]
 
-git = "https://github.com/PistonDevelopers/rust-graphics.git"
+git = "https://github.com/PistonDevelopers/graphics.git"
 
 [dependencies.opengl_graphics]
 


### PR DESCRIPTION
This fixes #123 rust-graphics has changed to graphics upstream.
