### PR TITLE
Added background drawing method to UiContext and updated example.

### DIFF
--- a/examples/all_widgets/all_widgets.rs
+++ b/examples/all_widgets/all_widgets.rs
@@ -1,7 +1,6 @@
 
-#![feature(phase)]
+#![feature(if_let)]
 
-#[phase(plugin, link)]
 extern crate conrod;
 extern crate graphics;
 extern crate piston;
@@ -10,6 +9,7 @@ extern crate opengl_graphics;
 extern crate vecmath;
 
 use conrod::{
+    Background,
     Button,
     Callable,
     Color,
@@ -39,12 +39,10 @@ use graphics::{
 };
 use opengl_graphics::Gl;
 use piston::{
-    Event,
     WindowSettings,
     EventIterator,
     EventSettings,
     Render,
-    RenderArgs,
 };
 use sdl2_game_window::WindowSDL2;
 use vecmath::vec2_add;
@@ -153,41 +151,22 @@ fn main() {
     let mut demo = DemoApp::new();
 
     // Main program loop begins.
-    for e in event_iter {
-        handle_event(&e, &mut gl, &mut uic, &mut demo);
+    for event in event_iter {
+        uic.handle_event(&event);
+        if let Render(_) = event {
+            draw_ui(&mut gl, &mut uic, &mut demo)
+        }
     }
 
-}
-
-/// Match the game event.
-fn handle_event(event: &Event,
-                gl: &mut Gl,
-                uic: &mut UiContext,
-                demo: &mut DemoApp) {
-    uic.handle_event(event);
-    match *event {
-        Render(ref args) => {
-            draw_background(args, gl, &demo.bg_color);
-            draw_ui(gl, uic, demo);
-        },
-        _ => (),
-    }
-}
-
-/// Draw the window background.
-fn draw_background(args: &RenderArgs, gl: &mut Gl, bg_color: &Color) {
-    // Set up a context to draw into.
-    let context = &Context::abs(args.width as f64, args.height as f64);
-    // Return the individual  elements of the background color.
-    let (r, g, b, a) = bg_color.as_tuple();
-    // Draw the background.
-    context.rgba(r, g, b, a).draw(gl);
 }
 
 /// Draw the User Interface.
 fn draw_ui(gl: &mut Gl,
            uic: &mut UiContext,
            demo: &mut DemoApp) {
+
+    // Draw the background.
+    uic.background().color(demo.bg_color).draw(gl);
 
     // Label example.
     uic.label("Widget Demonstration")

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,42 @@
+
+use color::Color;
+use draw::Drawable;
+use graphics::{
+    AddColor,
+    Context,
+    Draw,
+};
+use opengl_graphics::Gl;
+use ui_context::UiContext;
+
+/// The context from which we'll draw the background.
+pub struct BackgroundContext<'a> {
+    uic: &'a mut UiContext,
+    maybe_color: Option<Color>,
+}
+
+/// A trait to be implemented for the UiContext.
+pub trait BackgroundBuilder {
+    fn background<'a>(&'a mut self) -> BackgroundContext<'a>;
+}
+
+impl BackgroundBuilder for UiContext {
+    fn background<'a>(&'a mut self) -> BackgroundContext<'a> {
+        BackgroundContext {
+            uic: self,
+            maybe_color: None,
+        }
+    }
+}
+
+impl_colorable!(BackgroundContext)
+
+impl<'a> Drawable for BackgroundContext<'a> {
+    fn draw(&mut self, graphics: &mut Gl) {
+        let (r, g, b, a) = self.maybe_color.unwrap_or(self.uic.theme.background_color).as_tuple();
+        Context::abs(self.uic.win_w, self.uic.win_h)
+            .rgba(r, g, b, a)
+            .draw(graphics)
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate serialize;
 extern crate time;
 extern crate vecmath;
 
+pub use background::BackgroundBuilder as Background;
 pub use button::ButtonBuilder as Button;
 pub use drop_down_list::DropDownListBuilder as DropDownList;
 pub use envelope_editor::EnvelopeEditorBuilder as EnvelopeEditor;
@@ -36,6 +37,7 @@ pub use widget::Widget;
 
 pub mod macros;
 
+pub mod background;
 pub mod button;
 pub mod callback;
 pub mod color;

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -2,9 +2,9 @@
 use color::Color;
 use dimensions::Dimensions;
 use graphics::{
-    Context,
     AddRectangle,
     AddColor,
+    Context,
     Draw,
 };
 use label;

--- a/src/ui_context.rs
+++ b/src/ui_context.rs
@@ -203,7 +203,3 @@ impl UiContext {
 
 }
 
-
-
-
-


### PR DESCRIPTION
It can be called in these ways:
- `uic.background().draw(gl)`
- `uic.background().color(Color::black()).draw(gl)`
- `uic.background().rgba(r, g, b, a).draw(gl)`

See [this line](https://github.com/PistonDevelopers/conrod/blob/master/examples/all_widgets/all_widgets.rs#L169) for an example.
