### PR TITLE
Add Show trait as requirement for Drawable impl

### DIFF
--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -1,4 +1,4 @@
-
+use std::fmt::Show;
 use color::Color;
 use dimensions::Dimensions;
 use graphics::{
@@ -285,8 +285,8 @@ impl_labelable!(EnvelopeEditorContext, X, Y, E)
 impl_positionable!(EnvelopeEditorContext, X, Y, E)
 impl_shapeable!(EnvelopeEditorContext, X, Y, E)
 
-impl<'a, X: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
-         Y: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
+impl<'a, X: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString + Show,
+         Y: Num + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString + Show,
          E: EnvelopePoint<X, Y>> ::draw::Drawable for EnvelopeEditorContext<'a, X, Y, E> {
     #[inline]
     fn draw(&mut self, graphics: &mut Gl) {


### PR DESCRIPTION
Suddenly realized conrod did not compile in my project any more due to a compiler error, where `val_to_string` expects the Show trait to be implemented, which the calling function did not explicitly require. I am unsure why this appears to be required, since the function val_to_string only expects ToString, which is required in the Drawable impl and furthermore only its generic implementation requires Show, it is not even a subtrait. In any case, this seems to fix it at least.
