### PR TITLE
hashmap is now hash_map

### DIFF
--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -5,7 +5,7 @@ use freetype::error::MissingFontField;
 use label::FontSize;
 use opengl_graphics::Texture;
 use std::collections::HashMap;
-use std::collections::hashmap::{Occupied, Vacant};
+use std::collections::hash_map::{Occupied, Vacant};
 
 /// Struct used to hold rendered character data.
 pub struct Character {


### PR DESCRIPTION
The `hashmap` module has been renamed `hash_map` - this pull request fixes this.
