### PR TITLE
Removed artifacts when draw text.

### DIFF
--- a/src/ui_context.rs
+++ b/src/ui_context.rs
@@ -216,10 +216,11 @@ impl UiContext {
         use graphics::Context;
         use graphics::text::Text;
         use graphics::RelativeTransform;
+        use std::num::Float;
 
         let Color(col) = color;
         let context = Context::abs(self.win_w, self.win_h)
-                        .trans(pos[0], pos[1] + size as f64);
+                        .trans(pos[0].ceil(), pos[1].ceil() + size as f64);
         Text::colored(col, size).draw(
             text,
             &mut self.glyph_cache,


### PR DESCRIPTION
I found this issue on macbook pro with retina (mac os 10.10).
Before:
![before](https://cloud.githubusercontent.com/assets/3009258/5564289/4d2f5668-8ed7-11e4-8ed2-a29367affb06.png)
After:
![after](https://cloud.githubusercontent.com/assets/3009258/5564292/5f7c0be0-8ed7-11e4-8b41-3af43fcfb638.png)
See conversation on #66 
