### PR TITLE
Add quack dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ git = "https://github.com/PistonDevelopers/opengl_graphics.git"
 
 git = "https://github.com/PistonDevelopers/freetype-rs.git"
 
+[dependencies.quack]
+
+git = "https://github.com/PistonDevelopers/quack"
+
 [dependencies.rustc-serialize]
 
 version = "*"


### PR DESCRIPTION
I am not sure how this was compiling before since the all_widgets example
depends on quack, but I don't see a commit removing the quack dependency.