### PR TITLE
Auto implement all traits with duck typing

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -19,17 +19,12 @@ impl Background {
     }
 }
 
-// impl_colorable!(Background,);
-
-impl ::color::Colorable for Background {
-    #[inline]
-    fn color(self, color: Color) -> Self {
-        Background { maybe_color: Some(color), ..self }
-    }
-    #[inline]
-    fn rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self {
-        Background { maybe_color: Some(Color::new(r, g, b, a)), ..self }
-    }
+quack! {
+    bg: Background[]
+    get:
+    set:
+        fn (val: Color) { bg.maybe_color = Some(val) }
+    action:
 }
 
 impl Drawable for Background {

--- a/src/button.rs
+++ b/src/button.rs
@@ -13,6 +13,9 @@ use widget::Widget;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -95,10 +98,12 @@ quack! {
         }
         fn (val: FrameColor) { button.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { button.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { button.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { button.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { button.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(Button,);
 impl_positionable!(Button,);
 impl_shapeable!(Button,);
 

--- a/src/button.rs
+++ b/src/button.rs
@@ -17,6 +17,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -92,6 +93,7 @@ impl<'a> Button<'a> {
 quack! {
     button: Button['a]
     get:
+        fn () -> Size { Size(button.dim) }
     set:
         fn (val: Color) { button.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut() + 'a>>) {
@@ -103,10 +105,9 @@ quack! {
         fn (val: LabelColor) { button.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { button.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { button.pos = val.0 }
+        fn (val: Size) { button.dim = val.0 }
     action:
 }
-
-impl_shapeable!(Button,);
 
 impl<'a> ::draw::Drawable for Button<'a> {
     fn draw(&mut self, uic: &mut UiContext, graphics: &mut Gl) {

--- a/src/button.rs
+++ b/src/button.rs
@@ -11,6 +11,8 @@ use ui_context::{
 };
 use widget::Widget;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -91,10 +93,11 @@ quack! {
         fn (val: Callback<Box<FnMut() + 'a>>) {
             button.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { button.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { button.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(Button,);
 impl_labelable!(Button,);
 impl_positionable!(Button,);
 impl_shapeable!(Button,);

--- a/src/button.rs
+++ b/src/button.rs
@@ -16,6 +16,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -101,10 +102,10 @@ quack! {
         fn (val: LabelText<'a>) { button.maybe_label = Some(val.0) }
         fn (val: LabelColor) { button.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { button.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { button.pos = val.0 }
     action:
 }
 
-impl_positionable!(Button,);
 impl_shapeable!(Button,);
 
 impl<'a> ::draw::Drawable for Button<'a> {

--- a/src/button.rs
+++ b/src/button.rs
@@ -82,8 +82,15 @@ impl<'a> Button<'a> {
 
 }
 
+quack! {
+    button: Button['a]
+    get:
+    set:
+        fn (val: Color) { button.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(Button, FnMut(),);
-impl_colorable!(Button,);
 impl_frameable!(Button,);
 impl_labelable!(Button,);
 impl_positionable!(Button,);

--- a/src/button.rs
+++ b/src/button.rs
@@ -10,6 +10,7 @@ use ui_context::{
     UiContext,
 };
 use widget::Widget;
+use Callback;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -87,10 +88,12 @@ quack! {
     get:
     set:
         fn (val: Color) { button.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut() + 'a>>) {
+            button.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(Button, FnMut(),);
 impl_frameable!(Button,);
 impl_labelable!(Button,);
 impl_positionable!(Button,);

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,6 +1,18 @@
+use piston::quack::{ Pair, Set, SetAt };
 
 /// A trait for widgets who implement a callback of
 pub trait Callable<T> {
     fn callback(self, cb: T) -> Self;
 }
 
+/// Callback property.
+pub struct Callback<T>(pub T);
+
+impl<T, U> Callable<U> for T
+    where
+        (Callback<U>, T): Pair<Data = Callback<U>, Object = T> + SetAt
+{
+    fn callback(self, cb: U) -> Self {
+        self.set(Callback(cb))
+    }
+}

--- a/src/color.rs
+++ b/src/color.rs
@@ -11,6 +11,7 @@ use rustc_serialize::{
     DecoderHelpers, EncoderHelpers
 };
 use utils::clampf32;
+use piston::quack::{ Pair, Set, SetAt };
 
 /// A basic color struct for general color use
 /// made of red, green, blue and alpha elements.
@@ -308,4 +309,14 @@ pub trait Colorable {
     fn color(self, color: Color) -> Self;
     /// A method used for passing color as rgba.
     fn rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self;
+}
+
+impl<T> Colorable for T
+    where
+        (Color, T): Pair<Data = Color, Object = T> + SetAt
+{
+    fn color(self, color: Color) -> Self { self.set(color) }
+    fn rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self {
+        self.set(Color([r, g, b, a]))
+    }
 }

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -17,6 +17,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Tuple / Callback params.
 pub type Idx = usize;
@@ -169,6 +170,7 @@ impl<'a> DropDownList<'a> {
 quack! {
     list: DropDownList['a]
     get:
+        fn () -> Size { Size(list.dim) }
     set:
         fn (val: Color) { list.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(&mut Option<Idx>, Idx, String) + 'a>>) {
@@ -180,10 +182,9 @@ quack! {
         fn (val: LabelColor) { list.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { list.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { list.pos = val.0 }
+        fn (val: Size) { list.dim = val.0 }
     action:
 }
-
-impl_shapeable!(DropDownList,);
 
 impl<'a> ::draw::Drawable for DropDownList<'a> {
     fn draw(&mut self, uic: &mut UiContext, graphics: &mut Gl) {

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -13,6 +13,9 @@ use widget::Widget;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Tuple / Callback params.
 pub type Idx = usize;
@@ -172,10 +175,12 @@ quack! {
         }
         fn (val: FrameColor) { list.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { list.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { list.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { list.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { list.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(DropDownList,);
 impl_positionable!(DropDownList,);
 impl_shapeable!(DropDownList,);
 

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -159,8 +159,15 @@ impl<'a> DropDownList<'a> {
     }
 }
 
+quack! {
+    list: DropDownList['a]
+    get:
+    set:
+        fn (val: Color) { list.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(DropDownList, FnMut(&mut Option<Idx>, Idx, String),);
-impl_colorable!(DropDownList,);
 impl_frameable!(DropDownList,);
 impl_labelable!(DropDownList,);
 impl_positionable!(DropDownList,);

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -16,6 +16,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Tuple / Callback params.
 pub type Idx = usize;
@@ -178,10 +179,10 @@ quack! {
         fn (val: LabelText<'a>) { list.maybe_label = Some(val.0) }
         fn (val: LabelColor) { list.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { list.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { list.pos = val.0 }
     action:
 }
 
-impl_positionable!(DropDownList,);
 impl_shapeable!(DropDownList,);
 
 impl<'a> ::draw::Drawable for DropDownList<'a> {

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -10,6 +10,7 @@ use ui_context::{
 };
 use vecmath::vec2_add;
 use widget::Widget;
+use Callback;
 
 /// Tuple / Callback params.
 pub type Idx = usize;
@@ -164,10 +165,12 @@ quack! {
     get:
     set:
         fn (val: Color) { list.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(&mut Option<Idx>, Idx, String) + 'a>>) {
+            list.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(DropDownList, FnMut(&mut Option<Idx>, Idx, String),);
 impl_frameable!(DropDownList,);
 impl_labelable!(DropDownList,);
 impl_positionable!(DropDownList,);

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -11,6 +11,8 @@ use ui_context::{
 use vecmath::vec2_add;
 use widget::Widget;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Tuple / Callback params.
 pub type Idx = usize;
@@ -168,10 +170,11 @@ quack! {
         fn (val: Callback<Box<FnMut(&mut Option<Idx>, Idx, String) + 'a>>) {
             list.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { list.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { list.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(DropDownList,);
 impl_labelable!(DropDownList,);
 impl_positionable!(DropDownList,);
 impl_shapeable!(DropDownList,);

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -33,6 +33,8 @@ use vecmath::{
     vec2_sub
 };
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Represents the specific elements that the
 /// EnvelopeEditor is made up of. This is used to
@@ -271,10 +273,11 @@ quack! {
         fn (val: Callback<Box<FnMut(&mut Vec<E>, usize) + 'a>>) {
             env.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { env.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { env.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(EnvelopeEditor, X, Y, E);
 impl_labelable!(EnvelopeEditor, X, Y, E);
 impl_positionable!(EnvelopeEditor, X, Y, E);
 impl_shapeable!(EnvelopeEditor, X, Y, E);

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -32,6 +32,7 @@ use vecmath::{
     vec2_add,
     vec2_sub
 };
+use Callback;
 
 /// Represents the specific elements that the
 /// EnvelopeEditor is made up of. This is used to
@@ -267,10 +268,12 @@ quack! {
     get:
     set:
         fn (val: Color) { env.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(&mut Vec<E>, usize) + 'a>>) {
+            env.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(EnvelopeEditor, FnMut(&mut Vec<E>, usize), X, Y, E);
 impl_frameable!(EnvelopeEditor, X, Y, E);
 impl_labelable!(EnvelopeEditor, X, Y, E);
 impl_positionable!(EnvelopeEditor, X, Y, E);

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -39,6 +39,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Represents the specific elements that the
 /// EnvelopeEditor is made up of. This is used to
@@ -272,6 +273,7 @@ impl <'a, X: Float + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
 quack! {
     env: EnvelopeEditor['a, X, Y, E]
     get:
+        fn () -> Size { Size(env.dim) }
     set:
         fn (val: Color) { env.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(&mut Vec<E>, usize) + 'a>>) {
@@ -283,10 +285,9 @@ quack! {
         fn (val: LabelColor) { env.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { env.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { env.pos = val.0 }
+        fn (val: Size) { env.dim = val.0 }
     action:
 }
-
-impl_shapeable!(EnvelopeEditor, X, Y, E);
 
 impl<'a, X: Float + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
          Y: Float + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -35,6 +35,9 @@ use vecmath::{
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Represents the specific elements that the
 /// EnvelopeEditor is made up of. This is used to
@@ -275,10 +278,12 @@ quack! {
         }
         fn (val: FrameColor) { env.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { env.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { env.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { env.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { env.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(EnvelopeEditor, X, Y, E);
 impl_positionable!(EnvelopeEditor, X, Y, E);
 impl_shapeable!(EnvelopeEditor, X, Y, E);
 

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -38,6 +38,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Represents the specific elements that the
 /// EnvelopeEditor is made up of. This is used to
@@ -281,10 +282,10 @@ quack! {
         fn (val: LabelText<'a>) { env.maybe_label = Some(val.0) }
         fn (val: LabelColor) { env.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { env.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { env.pos = val.0 }
     action:
 }
 
-impl_positionable!(EnvelopeEditor, X, Y, E);
 impl_shapeable!(EnvelopeEditor, X, Y, E);
 
 impl<'a, X: Float + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,

--- a/src/envelope_editor.rs
+++ b/src/envelope_editor.rs
@@ -262,8 +262,15 @@ impl <'a, X: Float + Copy + ToPrimitive + FromPrimitive + PartialOrd + ToString,
     }
 }
 
+quack! {
+    env: EnvelopeEditor['a, X, Y, E]
+    get:
+    set:
+        fn (val: Color) { env.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(EnvelopeEditor, FnMut(&mut Vec<E>, usize), X, Y, E);
-impl_colorable!(EnvelopeEditor, X, Y, E);
 impl_frameable!(EnvelopeEditor, X, Y, E);
 impl_labelable!(EnvelopeEditor, X, Y, E);
 impl_positionable!(EnvelopeEditor, X, Y, E);

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,3 +1,4 @@
+use piston::quack::{ Pair, Set, SetAt };
 
 use color::Color;
 
@@ -17,3 +18,28 @@ pub trait Frameable {
     fn frame_rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self;
 }
 
+/// Frame width property.
+#[derive(Copy)]
+pub struct FrameWidth(pub f64);
+
+/// Frame color property.
+#[derive(Copy)]
+pub struct FrameColor(pub Color);
+
+impl<T> Frameable for T
+    where
+        (FrameWidth, T): Pair<Data = FrameWidth, Object = T> + SetAt,
+        (FrameColor, T): Pair<Data = FrameColor, Object = T> + SetAt
+{
+    fn frame(self, width: f64) -> Self {
+        self.set(FrameWidth(width))
+    }
+
+    fn frame_color(self, color: Color) -> Self {
+        self.set(FrameColor(color))
+    }
+
+    fn frame_rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self {
+        self.set(FrameColor(Color([r, g, b, a])))
+    }
+}

--- a/src/label.rs
+++ b/src/label.rs
@@ -73,7 +73,14 @@ impl<'a> Label<'a> {
 
 }
 
-impl_colorable!(Label,);
+quack! {
+    label: Label['a]
+    get:
+    set:
+        fn (val: Color) { label.maybe_color = Some(val) }
+    action:
+}
+
 impl_positionable!(Label,);
 
 impl<'a> ::draw::Drawable for Label<'a> {

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,4 +1,4 @@
-
+use piston::quack::{ Pair, Set, SetAt };
 use color::Color;
 use opengl_graphics::Gl;
 use point::Point;
@@ -39,9 +39,52 @@ pub trait Labelable<'a> {
     fn large_font(self, uic: &UiContext) -> Self;
 }
 
+/// Label text property.
+#[derive(Copy)]
+pub struct LabelText<'a>(pub &'a str);
 
+/// Label color property.
+#[derive(Copy)]
+pub struct LabelColor(pub Color);
 
+/// Label font size property.
+#[derive(Copy)]
+pub struct LabelFontSize(pub FontSize);
 
+impl<'a, T: 'a> Labelable<'a> for T
+    where
+        (LabelText<'a>, T): Pair<Data = LabelText<'a>, Object = T> + SetAt,
+        (LabelColor, T): Pair<Data = LabelColor, Object = T> + SetAt,
+        (LabelFontSize, T): Pair<Data = LabelFontSize, Object = T> + SetAt
+{
+    fn label(self, text: &'a str) -> Self {
+        self.set(LabelText(text))
+    }
+
+    fn label_color(self, color: Color) -> Self {
+        self.set(LabelColor(color))
+    }
+
+    fn label_rgba(self, r: f32, g: f32, b: f32, a: f32) -> Self {
+        self.set(LabelColor(Color([r, g, b, a])))
+    }
+
+    fn label_font_size(self, size: FontSize) -> Self {
+        self.set(LabelFontSize(size))
+    }
+
+    fn small_font(self, uic: &UiContext) -> Self {
+        self.set(LabelFontSize(uic.theme.font_size_small))
+    }
+
+    fn medium_font(self, uic: &UiContext) -> Self {
+        self.set(LabelFontSize(uic.theme.font_size_medium))
+    }
+
+    fn large_font(self, uic: &UiContext) -> Self {
+        self.set(LabelFontSize(uic.theme.font_size_large))
+    }
+}
 
 
 /// A context on which the builder pattern can be implemented.

--- a/src/label.rs
+++ b/src/label.rs
@@ -3,6 +3,7 @@ use color::Color;
 use opengl_graphics::Gl;
 use point::Point;
 use ui_context::UiContext;
+use Position;
 
 pub type FontSize = u32;
 
@@ -121,10 +122,9 @@ quack! {
     get:
     set:
         fn (val: Color) { label.maybe_color = Some(val) }
+        fn (val: Position) { label.pos = val.0 }
     action:
 }
-
-impl_positionable!(Label,);
 
 impl<'a> ::draw::Drawable for Label<'a> {
     fn draw(&mut self, uic: &mut UiContext, graphics: &mut Gl) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use callback::{ Callable, Callback };
 pub use color::{Color, Colorable};
 pub use dimensions::Dimensions;
 pub use draw::Drawable;
-pub use frame::{Framing, Frameable};
+pub use frame::{Framing, Frameable, FrameColor, FrameWidth};
 pub use label::Labelable;
 pub use point::Point;
 pub use position::Positionable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use color::{Color, Colorable};
 pub use dimensions::Dimensions;
 pub use draw::Drawable;
 pub use frame::{Framing, Frameable, FrameColor, FrameWidth};
-pub use label::Labelable;
+pub use label::{Labelable, LabelText, LabelColor, LabelFontSize};
 pub use point::Point;
 pub use position::Positionable;
 pub use shape::Shapeable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![feature(core, collections, io, path, std_misc, rand)]
 
 #[macro_use] extern crate bitflags;
-extern crate piston;
+#[macro_use] extern crate piston;
 extern crate freetype;
 extern crate graphics;
 extern crate opengl_graphics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use frame::{Framing, Frameable, FrameColor, FrameWidth};
 pub use label::{Labelable, LabelText, LabelColor, LabelFontSize};
 pub use point::Point;
 pub use position::{Positionable, Position};
-pub use shape::Shapeable;
+pub use shape::{Shapeable, Size};
 pub use theme::Theme;
 pub use ui_context::UiContext;
 pub use widget::Widget;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use draw::Drawable;
 pub use frame::{Framing, Frameable, FrameColor, FrameWidth};
 pub use label::{Labelable, LabelText, LabelColor, LabelFontSize};
 pub use point::Point;
-pub use position::Positionable;
+pub use position::{Positionable, Position};
 pub use shape::Shapeable;
 pub use theme::Theme;
 pub use ui_context::UiContext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use toggle::Toggle;
 pub use widget_matrix::WidgetMatrix;
 pub use xy_pad::XYPad;
 
-pub use callback::Callable;
+pub use callback::{ Callable, Callback };
 pub use color::{Color, Colorable};
 pub use dimensions::Dimensions;
 pub use draw::Drawable;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,45 +39,6 @@ macro_rules! widget_fns(
     )
 );
 
-/// Simplify implementation of the `Labelable` trait.
-macro_rules! impl_labelable(
-    ($context:ident, $($t:ident),*) => (
-        impl<'a $(, $t)*> ::label::Labelable<'a> for $context<'a $(, $t)*> {
-            #[inline]
-            fn label(self, text: &'a str) -> $context<'a $(, $t)*> {
-                $context { maybe_label: Some(text), ..self }
-            }
-            #[inline]
-            fn label_color(self, color: ::color::Color) -> $context<'a $(, $t)*> {
-                $context { maybe_label_color: Some(color), ..self }
-            }
-            #[inline]
-            fn label_rgba(self, r: f32, g: f32, b: f32, a: f32) -> $context<'a $(, $t)*> {
-                $context { maybe_label_color: Some(Color::new(r, g, b, a)), ..self }
-            }
-            #[inline]
-            fn label_font_size(self, size: u32) -> $context<'a $(, $t)*> {
-                $context { maybe_label_font_size: Some(size), ..self }
-            }
-            #[inline]
-            fn small_font(self, uic: &UiContext) -> $context<'a $(, $t)*> {
-                let size = uic.theme.font_size_small;
-                $context { maybe_label_font_size: Some(size), ..self }
-            }
-            #[inline]
-            fn medium_font(self, uic: &UiContext) -> $context<'a $(, $t)*> {
-                let size = uic.theme.font_size_medium;
-                $context { maybe_label_font_size: Some(size), ..self }
-            }
-            #[inline]
-            fn large_font(self, uic: &UiContext) -> $context<'a $(, $t)*> {
-                let size = uic.theme.font_size_large;
-                $context { maybe_label_font_size: Some(size), ..self }
-            }
-        }
-    )
-);
-
 /// Simplify implementation of the `Positionable` trait.
 macro_rules! impl_positionable(
     ($context:ident, $($t:ident),*) => (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,22 +51,6 @@ macro_rules! impl_callable(
     )
 );
 
-/// Simplify implementation of the `Colorable` trait.
-macro_rules! impl_colorable(
-    ($context:ident, $($t:ident),*) => (
-        impl<'a $(, $t)*> ::color::Colorable for $context<'a $(, $t)*> {
-            #[inline]
-            fn color(self, color: Color) -> $context<'a $(, $t)*> {
-                $context { maybe_color: Some(color), ..self }
-            }
-            #[inline]
-            fn rgba(self, r: f32, g: f32, b: f32, a: f32) -> $context<'a $(, $t)*> {
-                $context { maybe_color: Some(Color::new(r, g, b, a)), ..self }
-            }
-        }
-    )
-);
-
 /// Simplify implementation of the `Frameable` trait.
 macro_rules! impl_frameable(
     ($context:ident, $($t:ident),*) => (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,67 +39,6 @@ macro_rules! widget_fns(
     )
 );
 
-/// Simplify implementation of the `Positionable` trait.
-macro_rules! impl_positionable(
-    ($context:ident, $($t:ident),*) => (
-        impl<'a $(,$t)*> ::position::Positionable for $context<'a $(,$t)*> {
-
-            #[inline]
-            fn point(self, pos: Point) -> $context<'a $(,$t)*> {
-                $context { pos: pos, ..self }
-            }
-
-            #[inline]
-            fn position(self, x: f64, y: f64) -> $context<'a $(,$t)*> {
-                $context { pos: [x, y], ..self }
-            }
-
-            #[inline]
-            fn down(self, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uic.get_prev_uiid()).down(padding);
-                $context { pos: [x, y], ..self }
-            }
-            #[inline]
-            fn up(self, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uic.get_prev_uiid()).up(padding);
-                $context { pos: [x, y], ..self }
-            }
-            #[inline]
-            fn left(self, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uic.get_prev_uiid()).left(padding);
-                $context { pos: [x, y], ..self }
-            }
-            #[inline]
-            fn right(self, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uic.get_prev_uiid()).right(padding);
-                $context { pos: [x, y], ..self }
-            }
-
-            #[inline]
-            fn down_from(self, uiid: u64, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uiid).down(padding);
-                $context { pos: [x, y], ..self }
-            }
-            #[inline]
-            fn up_from(self, uiid: u64, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uiid).up(padding);
-                $context { pos: [x, y], ..self }
-            }
-            #[inline]
-            fn left_from(self, uiid: u64, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uiid).left(padding);
-                $context { pos: [x, y], ..self }
-            }
-            #[inline]
-            fn right_from(self, uiid: u64, padding: f64, uic: &UiContext) -> $context<'a $(,$t)*> {
-                let (x, y) = uic.get_placing(uiid).right(padding);
-                $context { pos: [x, y], ..self }
-            }
-
-        }
-    )
-);
-
 /// Simplify implementation of the `Shapeable` trait.
 macro_rules! impl_shapeable(
     ($context:ident, $($t:ident),*) => (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,18 +39,6 @@ macro_rules! widget_fns(
     )
 );
 
-/// Simplify implementation of the `Colorable` trait.
-macro_rules! impl_callable(
-    ($context:ident, $cb:ty, $($t:ident),*) => (
-        impl<'a $(, $t)*> ::callback::Callable<Box<$cb + 'a>> for $context<'a $(, $t)*> {
-            #[inline]
-            fn callback(self, callback: Box<$cb + 'a>) -> $context<'a $(, $t)*> {
-                $context { maybe_callback: Some(callback), ..self }
-            }
-        }
-    )
-);
-
 /// Simplify implementation of the `Frameable` trait.
 macro_rules! impl_frameable(
     ($context:ident, $($t:ident),*) => (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,27 +38,3 @@ macro_rules! widget_fns(
 
     )
 );
-
-/// Simplify implementation of the `Shapeable` trait.
-macro_rules! impl_shapeable(
-    ($context:ident, $($t:ident),*) => (
-        impl<'a $(, $t)*> ::shape::Shapeable for $context<'a $(, $t)*> {
-            #[inline]
-            fn dimensions(self, width: f64, height: f64) -> $context<'a $(, $t)*> {
-                $context { dim: [width, height], ..self }
-            }
-            #[inline]
-            fn dim(self, dim: ::dimensions::Dimensions) -> $context<'a $(, $t)*> {
-                $context { dim: dim, ..self }
-            }
-            #[inline]
-            fn width(self, width: f64) -> $context<'a $(, $t)*> {
-                $context { dim: [width, self.dim[1]], ..self }
-            }
-            #[inline]
-            fn height(self, height: f64) -> $context<'a $(, $t)*> {
-                $context { dim: [self.dim[0], height], ..self }
-            }
-        }
-    )
-);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,26 +39,6 @@ macro_rules! widget_fns(
     )
 );
 
-/// Simplify implementation of the `Frameable` trait.
-macro_rules! impl_frameable(
-    ($context:ident, $($t:ident),*) => (
-        impl<'a $(, $t)*> ::frame::Frameable for $context<'a $(, $t)*> {
-            #[inline]
-            fn frame(self, width: f64) -> $context<'a $(, $t)*> {
-                $context { maybe_frame: Some(width), ..self }
-            }
-            #[inline]
-            fn frame_color(self, color: ::color::Color) -> $context<'a $(, $t)*> {
-                $context { maybe_frame_color: Some(color), ..self }
-            }
-            #[inline]
-            fn frame_rgba(self, r: f32, g: f32, b: f32, a: f32) -> $context<'a $(, $t)*> {
-                $context { maybe_frame_color: Some(::color::Color::new(r, g, b, a)), ..self }
-            }
-        }
-    )
-);
-
 /// Simplify implementation of the `Labelable` trait.
 macro_rules! impl_labelable(
     ($context:ident, $($t:ident),*) => (

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -32,6 +32,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Represents the specific elements that the
 /// NumberDialer is made up of. This is used to
@@ -343,10 +344,10 @@ quack! {
         fn (val: LabelText<'a>) { nd.maybe_label = Some(val.0) }
         fn (val: LabelColor) { nd.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { nd.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { nd.pos = val.0 }
     action:
 }
 
-impl_positionable!(NumberDialer, T);
 impl_shapeable!(NumberDialer, T);
 
 impl<'a, T: Float + Copy + FromPrimitive + ToPrimitive + ToString>

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -27,6 +27,8 @@ use ui_context::{
 use vecmath::vec2_add;
 use widget::Widget;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Represents the specific elements that the
 /// NumberDialer is made up of. This is used to
@@ -333,10 +335,11 @@ quack! {
         fn (val: Callback<Box<FnMut(T) + 'a>>) {
             nd.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { nd.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { nd.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(NumberDialer, T);
 impl_labelable!(NumberDialer, T);
 impl_positionable!(NumberDialer, T);
 impl_shapeable!(NumberDialer, T);

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -26,6 +26,7 @@ use ui_context::{
 };
 use vecmath::vec2_add;
 use widget::Widget;
+use Callback;
 
 /// Represents the specific elements that the
 /// NumberDialer is made up of. This is used to
@@ -329,10 +330,12 @@ quack! {
     get:
     set:
         fn (val: Color) { nd.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(T) + 'a>>) {
+            nd.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(NumberDialer, FnMut(T), T);
 impl_frameable!(NumberDialer, T);
 impl_labelable!(NumberDialer, T);
 impl_positionable!(NumberDialer, T);

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -324,8 +324,15 @@ NumberDialer<'a, T> {
     }
 }
 
+quack! {
+    nd: NumberDialer['a, T]
+    get:
+    set:
+        fn (val: Color) { nd.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(NumberDialer, FnMut(T), T);
-impl_colorable!(NumberDialer, T);
 impl_frameable!(NumberDialer, T);
 impl_labelable!(NumberDialer, T);
 impl_positionable!(NumberDialer, T);

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -29,6 +29,9 @@ use widget::Widget;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Represents the specific elements that the
 /// NumberDialer is made up of. This is used to
@@ -337,10 +340,12 @@ quack! {
         }
         fn (val: FrameColor) { nd.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { nd.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { nd.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { nd.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { nd.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(NumberDialer, T);
 impl_positionable!(NumberDialer, T);
 impl_shapeable!(NumberDialer, T);
 

--- a/src/number_dialer.rs
+++ b/src/number_dialer.rs
@@ -33,6 +33,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Represents the specific elements that the
 /// NumberDialer is made up of. This is used to
@@ -334,6 +335,7 @@ NumberDialer<'a, T> {
 quack! {
     nd: NumberDialer['a, T]
     get:
+        fn () -> Size { Size(nd.dim) }
     set:
         fn (val: Color) { nd.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(T) + 'a>>) {
@@ -345,10 +347,9 @@ quack! {
         fn (val: LabelColor) { nd.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { nd.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { nd.pos = val.0 }
+        fn (val: Size) { nd.dim = val.0 }
     action:
 }
-
-impl_shapeable!(NumberDialer, T);
 
 impl<'a, T: Float + Copy + FromPrimitive + ToPrimitive + ToString>
 ::draw::Drawable for NumberDialer<'a, T> {

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,7 +1,8 @@
-
+use piston::quack::{ Pair, Set, SetAt };
 use point::Point;
 use ui_context::UIID;
 use UiContext;
+use graphics::vecmath::Scalar;
 
 /// A trait that indicates whether or not a widget
 /// builder is positionable.
@@ -16,4 +17,66 @@ pub trait Positionable {
     fn up_from(self, ui_id: UIID, padding: f64, uic: &UiContext) -> Self;
     fn left_from(self, ui_id: UIID, padding: f64, uic: &UiContext) -> Self;
     fn right_from(self, ui_id: UIID, padding: f64, uic: &UiContext) -> Self;
+}
+
+/// Position property.
+#[derive(Copy)]
+pub struct Position(pub [Scalar; 2]);
+
+impl<T> Positionable for T
+    where
+        (Position, T): Pair<Data = Position, Object = T> + SetAt
+{
+
+    #[inline]
+    fn point(self, pos: Point) -> Self {
+        self.set(Position(pos))
+    }
+
+    #[inline]
+    fn position(self, x: f64, y: f64) -> Self {
+        self.set(Position([x as Scalar, y as Scalar]))
+    }
+
+    #[inline]
+    fn down(self, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uic.get_prev_uiid()).down(padding);
+        self.set(Position([x, y]))
+    }
+    #[inline]
+    fn up(self, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uic.get_prev_uiid()).up(padding);
+        self.set(Position([x, y]))
+    }
+    #[inline]
+    fn left(self, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uic.get_prev_uiid()).left(padding);
+        self.set(Position([x, y]))
+    }
+    #[inline]
+    fn right(self, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uic.get_prev_uiid()).right(padding);
+        self.set(Position([x, y]))
+    }
+
+    #[inline]
+    fn down_from(self, uiid: u64, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uiid).down(padding);
+        self.set(Position([x, y]))
+    }
+    #[inline]
+    fn up_from(self, uiid: u64, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uiid).up(padding);
+        self.set(Position([x, y]))
+    }
+    #[inline]
+    fn left_from(self, uiid: u64, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uiid).left(padding);
+        self.set(Position([x, y]))
+    }
+    #[inline]
+    fn right_from(self, uiid: u64, padding: f64, uic: &UiContext) -> Self {
+        let (x, y) = uic.get_placing(uiid).right(padding);
+        self.set(Position([x, y]))
+    }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,4 +1,4 @@
-
+use piston::quack::{ GetFrom, Get, Pair, Set, SetAt };
 use dimensions::Dimensions;
 
 /// A trait that indicates whether or not a widget
@@ -10,3 +10,30 @@ pub trait Shapeable {
     fn height(self, height: f64) -> Self;
 }
 
+/// Size property.
+#[derive(Copy)]
+pub struct Size(pub Dimensions);
+
+impl<T> Shapeable for T
+    where
+        (Size, T): Pair<Data = Size, Object = T> + SetAt + GetFrom
+{
+    #[inline]
+    fn dimensions(self, width: f64, height: f64) -> Self {
+        self.set(Size([width, height]))
+    }
+    #[inline]
+    fn dim(self, dim: ::dimensions::Dimensions) -> Self {
+        self.set(Size(dim))
+    }
+    #[inline]
+    fn width(self, width: f64) -> Self {
+        let Size([_, height]) = self.get();
+        self.set(Size([width, height]))
+    }
+    #[inline]
+    fn height(self, height: f64) -> Self {
+        let Size([width, _]) = self.get();
+        self.set(Size([width, height]))
+    }
+}

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -97,8 +97,15 @@ Slider<'a, T> {
     }
 }
 
+quack! {
+    slider: Slider['a, T]
+    get:
+    set:
+        fn (val: Color) { slider.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(Slider, FnMut(T), T);
-impl_colorable!(Slider, T);
 impl_frameable!(Slider, T);
 impl_labelable!(Slider, T);
 impl_positionable!(Slider, T);

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -25,6 +25,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -116,10 +117,10 @@ quack! {
         fn (val: LabelText<'a>) { slider.maybe_label = Some(val.0) }
         fn (val: LabelColor) { slider.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { slider.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { slider.pos = val.0 }
     action:
 }
 
-impl_positionable!(Slider, T);
 impl_shapeable!(Slider, T);
 
 impl<'a, T: Float + Copy + FromPrimitive + ToPrimitive>

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -26,6 +26,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -107,6 +108,7 @@ Slider<'a, T> {
 quack! {
     slider: Slider['a, T]
     get:
+        fn () -> Size { Size(slider.dim) }
     set:
         fn (val: Color) { slider.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(T) + 'a>>) {
@@ -118,10 +120,9 @@ quack! {
         fn (val: LabelColor) { slider.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { slider.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { slider.pos = val.0 }
+        fn (val: Size) { slider.dim = val.0 }
     action:
 }
-
-impl_shapeable!(Slider, T);
 
 impl<'a, T: Float + Copy + FromPrimitive + ToPrimitive>
 ::draw::Drawable for Slider<'a, T> {

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -19,6 +19,7 @@ use utils::{
 };
 use widget::Widget;
 use vecmath::vec2_add;
+use Callback;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -102,10 +103,12 @@ quack! {
     get:
     set:
         fn (val: Color) { slider.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(T) + 'a>>) {
+            slider.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(Slider, FnMut(T), T);
 impl_frameable!(Slider, T);
 impl_labelable!(Slider, T);
 impl_positionable!(Slider, T);

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -22,6 +22,9 @@ use vecmath::vec2_add;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -110,10 +113,12 @@ quack! {
         }
         fn (val: FrameColor) { slider.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { slider.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { slider.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { slider.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { slider.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(Slider, T);
 impl_positionable!(Slider, T);
 impl_shapeable!(Slider, T);
 

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -20,6 +20,8 @@ use utils::{
 use widget::Widget;
 use vecmath::vec2_add;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Represents the state of the Button widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -106,10 +108,11 @@ quack! {
         fn (val: Callback<Box<FnMut(T) + 'a>>) {
             slider.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { slider.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { slider.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(Slider, T);
 impl_labelable!(Slider, T);
 impl_positionable!(Slider, T);
 impl_shapeable!(Slider, T);

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -29,6 +29,8 @@ use vecmath::{
 use widget::Widget;
 use std::cmp;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 pub type Idx = usize;
 pub type CursorX = f64;
@@ -225,10 +227,11 @@ quack! {
         fn (val: Callback<Box<FnMut(&mut String) + 'a>>) {
             tb.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { tb.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { tb.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(TextBox,);
 impl_positionable!(TextBox,);
 impl_shapeable!(TextBox,);
 

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -31,6 +31,7 @@ use std::cmp;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use Position;
 
 pub type Idx = usize;
 pub type CursorX = f64;
@@ -229,10 +230,10 @@ quack! {
         }
         fn (val: FrameColor) { tb.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { tb.maybe_frame = Some(val.0) }
+        fn (val: Position) { tb.pos = val.0 }
     action:
 }
 
-impl_positionable!(TextBox,);
 impl_shapeable!(TextBox,);
 
 impl<'a> ::draw::Drawable for TextBox<'a> {

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -32,6 +32,7 @@ use Callback;
 use FrameColor;
 use FrameWidth;
 use Position;
+use Size;
 
 pub type Idx = usize;
 pub type CursorX = f64;
@@ -223,6 +224,7 @@ impl<'a> TextBox<'a> {
 quack! {
     tb: TextBox['a]
     get:
+        fn () -> Size { Size(tb.dim) }
     set:
         fn (val: Color) { tb.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(&mut String) + 'a>>) {
@@ -231,10 +233,9 @@ quack! {
         fn (val: FrameColor) { tb.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { tb.maybe_frame = Some(val.0) }
         fn (val: Position) { tb.pos = val.0 }
+        fn (val: Size) { tb.dim = val.0 }
     action:
 }
-
-impl_shapeable!(TextBox,);
 
 impl<'a> ::draw::Drawable for TextBox<'a> {
     #[inline]

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -216,9 +216,15 @@ impl<'a> TextBox<'a> {
     }
 }
 
+quack! {
+    tb: TextBox['a]
+    get:
+    set:
+        fn (val: Color) { tb.maybe_color = Some(val) }
+    action:
+}
 
 impl_callable!(TextBox, FnMut(&mut String),);
-impl_colorable!(TextBox,);
 impl_frameable!(TextBox,);
 impl_positionable!(TextBox,);
 impl_shapeable!(TextBox,);

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -28,6 +28,7 @@ use vecmath::{
 };
 use widget::Widget;
 use std::cmp;
+use Callback;
 
 pub type Idx = usize;
 pub type CursorX = f64;
@@ -221,10 +222,12 @@ quack! {
     get:
     set:
         fn (val: Color) { tb.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(&mut String) + 'a>>) {
+            tb.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(TextBox, FnMut(&mut String),);
 impl_frameable!(TextBox,);
 impl_positionable!(TextBox,);
 impl_shapeable!(TextBox,);

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -11,6 +11,8 @@ use ui_context::{
 };
 use widget::Widget;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Represents the state of the Toggle widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -92,10 +94,11 @@ quack! {
         fn (val: Callback<Box<FnMut(bool) + 'a>>) {
             toggle.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { toggle.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { toggle.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(Toggle,);
 impl_labelable!(Toggle,);
 impl_positionable!(Toggle,);
 impl_shapeable!(Toggle,);

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -13,6 +13,9 @@ use widget::Widget;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Represents the state of the Toggle widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -96,10 +99,12 @@ quack! {
         }
         fn (val: FrameColor) { toggle.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { toggle.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { toggle.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { toggle.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { toggle.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(Toggle,);
 impl_positionable!(Toggle,);
 impl_shapeable!(Toggle,);
 

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -83,8 +83,15 @@ impl<'a> Toggle<'a> {
 
 }
 
+quack! {
+    toggle: Toggle['a]
+    get:
+    set:
+        fn (val: Color) { toggle.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(Toggle, FnMut(bool),);
-impl_colorable!(Toggle,);
 impl_frameable!(Toggle,);
 impl_labelable!(Toggle,);
 impl_positionable!(Toggle,);

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -16,6 +16,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Represents the state of the Toggle widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -102,10 +103,10 @@ quack! {
         fn (val: LabelText<'a>) { toggle.maybe_label = Some(val.0) }
         fn (val: LabelColor) { toggle.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { toggle.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { toggle.pos = val.0 }
     action:
 }
 
-impl_positionable!(Toggle,);
 impl_shapeable!(Toggle,);
 
 impl<'a> ::draw::Drawable for Toggle<'a> {

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -17,6 +17,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Represents the state of the Toggle widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -93,6 +94,7 @@ impl<'a> Toggle<'a> {
 quack! {
     toggle: Toggle['a]
     get:
+        fn () -> Size { Size(toggle.dim) }
     set:
         fn (val: Color) { toggle.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(bool) + 'a>>) {
@@ -104,10 +106,9 @@ quack! {
         fn (val: LabelColor) { toggle.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { toggle.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { toggle.pos = val.0 }
+        fn (val: Size) { toggle.dim = val.0 }
     action:
 }
-
-impl_shapeable!(Toggle,);
 
 impl<'a> ::draw::Drawable for Toggle<'a> {
     fn draw(&mut self, uic: &mut UiContext, graphics: &mut Gl) {

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -10,6 +10,7 @@ use ui_context::{
     UiContext,
 };
 use widget::Widget;
+use Callback;
 
 /// Represents the state of the Toggle widget.
 #[derive(PartialEq, Clone, Copy)]
@@ -88,10 +89,12 @@ quack! {
     get:
     set:
         fn (val: Color) { toggle.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(bool) + 'a>>) {
+            toggle.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(Toggle, FnMut(bool),);
 impl_frameable!(Toggle,);
 impl_labelable!(Toggle,);
 impl_positionable!(Toggle,);

--- a/src/widget_matrix.rs
+++ b/src/widget_matrix.rs
@@ -2,6 +2,7 @@
 use dimensions::Dimensions;
 use point::Point;
 use Position;
+use Size;
 
 /// Callback params.
 pub type WidgetNum = usize;
@@ -100,28 +101,9 @@ impl WidgetMatrix {
 quack! {
     wm: WidgetMatrix[]
     get:
+        fn () -> Size { Size(wm.pos) }
     set:
         fn (val: Position) { wm.pos = val.0 }
+        fn (val: Size) { wm.dim = val.0 }
     action:
-}
-
-// impl_shapeable!(WidgetMatrix,);
-
-impl ::shape::Shapeable for WidgetMatrix {
-    #[inline]
-    fn dimensions(self, width: f64, height: f64) -> WidgetMatrix {
-        WidgetMatrix { dim: [width, height], ..self }
-    }
-    #[inline]
-    fn dim(self, dim: ::dimensions::Dimensions) -> WidgetMatrix {
-        WidgetMatrix { dim: dim, ..self }
-    }
-    #[inline]
-    fn width(self, width: f64) -> WidgetMatrix {
-        WidgetMatrix { dim: [width, self.dim[1]], ..self }
-    }
-    #[inline]
-    fn height(self, height: f64) -> WidgetMatrix {
-        WidgetMatrix { dim: [self.dim[0], height], ..self }
-    }
 }

--- a/src/widget_matrix.rs
+++ b/src/widget_matrix.rs
@@ -1,7 +1,7 @@
 
 use dimensions::Dimensions;
 use point::Point;
-use ui_context::UiContext;
+use Position;
 
 /// Callback params.
 pub type WidgetNum = usize;
@@ -97,62 +97,12 @@ impl WidgetMatrix {
     }
 }
 
-// impl_positionable!(WidgetMatrix,);
-
-impl ::position::Positionable for WidgetMatrix {
-
-    #[inline]
-    fn point(self, pos: Point) -> WidgetMatrix {
-        WidgetMatrix { pos: pos, ..self }
-    }
-
-    #[inline]
-    fn position(self, x: f64, y: f64) -> WidgetMatrix {
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-
-    #[inline]
-    fn down(self, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uic.get_prev_uiid()).down(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-    #[inline]
-    fn up(self, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uic.get_prev_uiid()).up(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-    #[inline]
-    fn left(self, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uic.get_prev_uiid()).left(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-    #[inline]
-    fn right(self, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uic.get_prev_uiid()).right(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-
-    #[inline]
-    fn down_from(self, uiid: u64, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uiid).down(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-    #[inline]
-    fn up_from(self, uiid: u64, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uiid).up(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-    #[inline]
-    fn left_from(self, uiid: u64, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uiid).left(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-    #[inline]
-    fn right_from(self, uiid: u64, padding: f64, uic: &UiContext) -> WidgetMatrix {
-        let (x, y) = uic.get_placing(uiid).right(padding);
-        WidgetMatrix { pos: [x, y], ..self }
-    }
-
+quack! {
+    wm: WidgetMatrix[]
+    get:
+    set:
+        fn (val: Position) { wm.pos = val.0 }
+    action:
 }
 
 // impl_shapeable!(WidgetMatrix,);

--- a/src/xy_pad.rs
+++ b/src/xy_pad.rs
@@ -142,8 +142,15 @@ XYPad<'a, X, Y> {
     }
 }
 
+quack! {
+    xy_pad: XYPad['a, X, Y]
+    get:
+    set:
+        fn (val: Color) { xy_pad.maybe_color = Some(val) }
+    action:
+}
+
 impl_callable!(XYPad, FnMut(X, Y), X, Y);
-impl_colorable!(XYPad, X, Y);
 impl_frameable!(XYPad, X, Y);
 impl_labelable!(XYPad, X, Y);
 impl_positionable!(XYPad, X, Y);

--- a/src/xy_pad.rs
+++ b/src/xy_pad.rs
@@ -33,6 +33,9 @@ use widget::Widget;
 use Callback;
 use FrameColor;
 use FrameWidth;
+use LabelText;
+use LabelColor;
+use LabelFontSize;
 
 /// Represents the state of the xy_pad widget.
 #[derive(Show, PartialEq, Clone, Copy)]
@@ -155,10 +158,12 @@ quack! {
         }
         fn (val: FrameColor) { xy_pad.maybe_frame_color = Some(val.0) }
         fn (val: FrameWidth) { xy_pad.maybe_frame = Some(val.0) }
+        fn (val: LabelText<'a>) { xy_pad.maybe_label = Some(val.0) }
+        fn (val: LabelColor) { xy_pad.maybe_label_color = Some(val.0) }
+        fn (val: LabelFontSize) { xy_pad.maybe_label_font_size = Some(val.0) }
     action:
 }
 
-impl_labelable!(XYPad, X, Y);
 impl_positionable!(XYPad, X, Y);
 impl_shapeable!(XYPad, X, Y);
 

--- a/src/xy_pad.rs
+++ b/src/xy_pad.rs
@@ -30,6 +30,7 @@ use vecmath::{
     vec2_sub,
 };
 use widget::Widget;
+use Callback;
 
 /// Represents the state of the xy_pad widget.
 #[derive(Show, PartialEq, Clone, Copy)]
@@ -147,10 +148,12 @@ quack! {
     get:
     set:
         fn (val: Color) { xy_pad.maybe_color = Some(val) }
+        fn (val: Callback<Box<FnMut(X, Y) + 'a>>) {
+            xy_pad.maybe_callback = Some(val.0)
+        }
     action:
 }
 
-impl_callable!(XYPad, FnMut(X, Y), X, Y);
 impl_frameable!(XYPad, X, Y);
 impl_labelable!(XYPad, X, Y);
 impl_positionable!(XYPad, X, Y);

--- a/src/xy_pad.rs
+++ b/src/xy_pad.rs
@@ -36,6 +36,7 @@ use FrameWidth;
 use LabelText;
 use LabelColor;
 use LabelFontSize;
+use Position;
 
 /// Represents the state of the xy_pad widget.
 #[derive(Show, PartialEq, Clone, Copy)]
@@ -161,10 +162,10 @@ quack! {
         fn (val: LabelText<'a>) { xy_pad.maybe_label = Some(val.0) }
         fn (val: LabelColor) { xy_pad.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { xy_pad.maybe_label_font_size = Some(val.0) }
+        fn (val: Position) { xy_pad.pos = val.0 }
     action:
 }
 
-impl_positionable!(XYPad, X, Y);
 impl_shapeable!(XYPad, X, Y);
 
 impl<'a, X: Float + Copy + ToPrimitive + FromPrimitive + ToString,

--- a/src/xy_pad.rs
+++ b/src/xy_pad.rs
@@ -37,6 +37,7 @@ use LabelText;
 use LabelColor;
 use LabelFontSize;
 use Position;
+use Size;
 
 /// Represents the state of the xy_pad widget.
 #[derive(Show, PartialEq, Clone, Copy)]
@@ -152,6 +153,7 @@ XYPad<'a, X, Y> {
 quack! {
     xy_pad: XYPad['a, X, Y]
     get:
+        fn () -> Size { Size(xy_pad.dim) }
     set:
         fn (val: Color) { xy_pad.maybe_color = Some(val) }
         fn (val: Callback<Box<FnMut(X, Y) + 'a>>) {
@@ -163,10 +165,9 @@ quack! {
         fn (val: LabelColor) { xy_pad.maybe_label_color = Some(val.0) }
         fn (val: LabelFontSize) { xy_pad.maybe_label_font_size = Some(val.0) }
         fn (val: Position) { xy_pad.pos = val.0 }
+        fn (val: Size) { xy_pad.dim = val.0 }
     action:
 }
-
-impl_shapeable!(XYPad, X, Y);
 
 impl<'a, X: Float + Copy + ToPrimitive + FromPrimitive + ToString,
          Y: Float + Copy + ToPrimitive + FromPrimitive + ToString>

--- a/src/xy_pad.rs
+++ b/src/xy_pad.rs
@@ -31,6 +31,8 @@ use vecmath::{
 };
 use widget::Widget;
 use Callback;
+use FrameColor;
+use FrameWidth;
 
 /// Represents the state of the xy_pad widget.
 #[derive(Show, PartialEq, Clone, Copy)]
@@ -151,10 +153,11 @@ quack! {
         fn (val: Callback<Box<FnMut(X, Y) + 'a>>) {
             xy_pad.maybe_callback = Some(val.0)
         }
+        fn (val: FrameColor) { xy_pad.maybe_frame_color = Some(val.0) }
+        fn (val: FrameWidth) { xy_pad.maybe_frame = Some(val.0) }
     action:
 }
 
-impl_frameable!(XYPad, X, Y);
 impl_labelable!(XYPad, X, Y);
 impl_positionable!(XYPad, X, Y);
 impl_shapeable!(XYPad, X, Y);


### PR DESCRIPTION
This uses the "quack" library that is included in the piston core.

* Will make it simpler for people to make their own widgets by using the "quack!" macro
* Will make it easier to add new widgets
* Removes most of the macros (since they are no longer needed)
* Does not break the look and feel if you don't want to use the `.set` methods