### PR TITLE
Changed example to use conventional box syntax

### DIFF
--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -1,6 +1,4 @@
-#![feature(core)]
-#![feature(collections)]
-#![feature(path)]
+#![feature(box_syntax, collections, core, path)]
 
 extern crate piston;
 extern crate conrod;
@@ -179,7 +177,7 @@ fn draw_ui(gl: &mut Gl,
             .rgba(0.4, 0.75, 0.6, 1.0)
             .frame(demo.frame_width)
             .label("PRESS")
-            .callback(Box::new(|| demo.bg_color = Color::random()))
+            .callback(box |&mut:| demo.bg_color = Color::random())
             .draw(uic, gl);
 
     }
@@ -204,7 +202,7 @@ fn draw_ui(gl: &mut Gl,
             .frame(demo.frame_width)
             .label(label.as_slice())
             .label_color(Color::white())
-            .callback(Box::new(|new_pad| demo.title_padding = new_pad as f64))
+            .callback(box |&mut: new_pad: f32| demo.title_padding = new_pad as f64)
             .draw(uic, gl);
 
     }
@@ -220,13 +218,13 @@ fn draw_ui(gl: &mut Gl,
         .frame(demo.frame_width)
         .label(label.as_slice())
         .label_color(Color::white())
-        .callback(Box::new(|value| {
+        .callback(box |&mut: value| {
             demo.show_button = value;
             demo.toggle_label = match value {
                 true => "ON".to_string(),
                 false => "OFF".to_string()
             }
-        }))
+        })
         .draw(uic, gl);
 
     // Let's draw a slider for each color element.
@@ -259,11 +257,11 @@ fn draw_ui(gl: &mut Gl,
             .frame(demo.frame_width)
             .label(label.as_slice())
             .label_color(Color::white())
-            .callback(Box::new(|color| match i {
+            .callback(box |&mut: color| match i {
                 0us => demo.bg_color.set_r(color),
                 1us => demo.bg_color.set_g(color),
                 _ => demo.bg_color.set_b(color),
-            }))
+            })
             .draw(uic, gl);
 
     }
@@ -276,7 +274,7 @@ fn draw_ui(gl: &mut Gl,
         .frame(demo.frame_width)
         .label("Height (pixels)")
         .label_color(demo.bg_color.invert().plain_contrast())
-        .callback(Box::new(|new_height| demo.v_slider_height = new_height))
+        .callback(box |&mut: new_height| demo.v_slider_height = new_height)
         .draw(uic, gl);
 
     // Number Dialer widget example. number_dialer(UIID, value, min, max, precision)
@@ -288,7 +286,7 @@ fn draw_ui(gl: &mut Gl,
         .frame_color(demo.bg_color.plain_contrast())
         .label("Frame Width (pixels)")
         .label_color(demo.bg_color.plain_contrast())
-        .callback(Box::new(|new_width| demo.frame_width = new_width))
+        .callback(box |&mut: new_width| demo.frame_width = new_width)
         .draw(uic, gl);
 
 
@@ -298,7 +296,7 @@ fn draw_ui(gl: &mut Gl,
     WidgetMatrix::new(cols, rows)
         .dimensions(260.0, 260.0) // matrix width and height.
         .position(300.0, 270.0) // matrix position.
-        .each_widget(Box::new(|num, col, row, pos, dim| { // This is called for every widget.
+        .each_widget(box |&mut: num, col, row, pos, dim| { // This is called for every widget.
 
             // Color effect for fun.
             let (r, g, b, a) = (
@@ -315,10 +313,10 @@ fn draw_ui(gl: &mut Gl,
                 .point(pos)
                 .rgba(r, g, b, a)
                 .frame(demo.frame_width)
-                .callback(Box::new(|&mut: new_val: bool| demo.bool_matrix[col][row] = new_val))
+                .callback(box |&mut: new_val: bool| demo.bool_matrix[col][row] = new_val)
                 .draw(uic, gl);
 
-        }));
+        });
 
     let ddl_color = match demo.selected_idx {
         Some(idx) => match demo.ddl_colors[idx].as_slice() {
@@ -344,7 +342,9 @@ fn draw_ui(gl: &mut Gl,
         .frame_color(ddl_color.plain_contrast())
         .label("Colors")
         .label_color(ddl_color.plain_contrast())
-        .callback(Box::new(|selected_idx, new_idx, _string| *selected_idx = Some(new_idx)))
+        .callback(box |&mut: selected_idx: &mut Option<usize>, new_idx, _string| {
+            *selected_idx = Some(new_idx)
+        })
         .draw(uic, gl);
 
     // Draw an xy_pad.
@@ -360,10 +360,10 @@ fn draw_ui(gl: &mut Gl,
         .label_color(Color::new(1.0, 1.0, 1.0, 0.5) * ddl_color.plain_contrast())
         .line_width(2.0)
         .value_font_size(18u32)
-        .callback(Box::new(|new_x, new_y| {
+        .callback(box |&mut: new_x, new_y| {
             demo.circle_pos[0] = new_x;
             demo.circle_pos[1] = new_y;
-        }))
+        })
         .draw(uic, gl);
 
     // Let's use the widget matrix to draw
@@ -373,7 +373,7 @@ fn draw_ui(gl: &mut Gl,
     WidgetMatrix::new(cols, rows)
         .position(810.0, 115.0)
         .dimensions(320.0, 425.0)
-        .each_widget(Box::new(|num, _col, _row, pos, dim| { // This is called for every widget.
+        .each_widget(box |&mut: num, _col, _row, pos, dim| { // This is called for every widget.
             use conrod::draw::Drawable;
 
             let &mut (ref mut env, ref mut text) = &mut demo.envelopes[num];
@@ -413,7 +413,7 @@ fn draw_ui(gl: &mut Gl,
                 .line_width(2.0)
                 .draw(uic, gl);
 
-        })); // End of matrix widget callback.
+        }); // End of matrix widget callback.
 
 }
 

--- a/src/drop_down_list.rs
+++ b/src/drop_down_list.rs
@@ -62,7 +62,7 @@ impl State {
 
 widget_fns!(DropDownList, State, Widget::DropDownList(State::Closed(DrawState::Normal)));
 
-/// Is the cursor currently over the
+/// Is the cursor currently over the widget? If so which item?
 fn is_over(pos: Point,
            mouse_pos: Point,
            dim: Dimensions,


### PR DESCRIPTION
@eddyb I'm guessing this is why `Box::new` has been appearing in a few places.

```
error: box expression syntax is experimental in alpha release; you can call `Box::new` instead.
     .callback(box |&mut: new_val: bool| demo.bool_matrix[col][row] = new_val)                 
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                  
help: add #![feature(box_syntax)] to the crate attributes to enable                            
     .callback(box |&mut: new_val: bool| demo.bool_matrix[col][row] = new_val)                 
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```