### PR TITLE
Unboxed all callback closures, closes #301

### DIFF
--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -177,7 +177,7 @@ fn draw_ui(gl: &mut Gl,
             .rgba(0.4, 0.75, 0.6, 1.0)
             .frame(demo.frame_width)
             .label("PRESS")
-            .callback(box |&mut:| demo.bg_color = Color::random())
+            .callback(|&mut:| demo.bg_color = Color::random())
             .draw(uic, gl);
 
     }
@@ -202,7 +202,7 @@ fn draw_ui(gl: &mut Gl,
             .frame(demo.frame_width)
             .label(label.as_slice())
             .label_color(Color::white())
-            .callback(box |&mut: new_pad: f32| demo.title_padding = new_pad as f64)
+            .callback(|&mut: new_pad: f32| demo.title_padding = new_pad as f64)
             .draw(uic, gl);
 
     }
@@ -218,7 +218,7 @@ fn draw_ui(gl: &mut Gl,
         .frame(demo.frame_width)
         .label(label.as_slice())
         .label_color(Color::white())
-        .callback(box |&mut: value| {
+        .callback(|&mut: value| {
             demo.show_button = value;
             demo.toggle_label = match value {
                 true => "ON".to_string(),
@@ -257,7 +257,7 @@ fn draw_ui(gl: &mut Gl,
             .frame(demo.frame_width)
             .label(label.as_slice())
             .label_color(Color::white())
-            .callback(box |&mut: color| match i {
+            .callback(|&mut: color| match i {
                 0us => demo.bg_color.set_r(color),
                 1us => demo.bg_color.set_g(color),
                 _ => demo.bg_color.set_b(color),
@@ -274,7 +274,7 @@ fn draw_ui(gl: &mut Gl,
         .frame(demo.frame_width)
         .label("Height (pixels)")
         .label_color(demo.bg_color.invert().plain_contrast())
-        .callback(box |&mut: new_height| demo.v_slider_height = new_height)
+        .callback(|&mut: new_height| demo.v_slider_height = new_height)
         .draw(uic, gl);
 
     // Number Dialer widget example. number_dialer(UIID, value, min, max, precision)
@@ -286,7 +286,7 @@ fn draw_ui(gl: &mut Gl,
         .frame_color(demo.bg_color.plain_contrast())
         .label("Frame Width (pixels)")
         .label_color(demo.bg_color.plain_contrast())
-        .callback(box |&mut: new_width| demo.frame_width = new_width)
+        .callback(|&mut: new_width| demo.frame_width = new_width)
         .draw(uic, gl);
 
 
@@ -296,7 +296,7 @@ fn draw_ui(gl: &mut Gl,
     WidgetMatrix::new(cols, rows)
         .dimensions(260.0, 260.0) // matrix width and height.
         .position(300.0, 270.0) // matrix position.
-        .each_widget(box |&mut: num, col, row, pos, dim| { // This is called for every widget.
+        .each_widget(|&mut: num, col, row, pos, dim| { // This is called for every widget.
 
             // Color effect for fun.
             let (r, g, b, a) = (
@@ -313,7 +313,7 @@ fn draw_ui(gl: &mut Gl,
                 .point(pos)
                 .rgba(r, g, b, a)
                 .frame(demo.frame_width)
-                .callback(box |&mut: new_val: bool| demo.bool_matrix[col][row] = new_val)
+                .callback(|&mut: new_val: bool| demo.bool_matrix[col][row] = new_val)
                 .draw(uic, gl);
 
         });
@@ -342,7 +342,7 @@ fn draw_ui(gl: &mut Gl,
         .frame_color(ddl_color.plain_contrast())
         .label("Colors")
         .label_color(ddl_color.plain_contrast())
-        .callback(box |&mut: selected_idx: &mut Option<usize>, new_idx, _string| {
+        .callback(|&mut: selected_idx: &mut Option<usize>, new_idx, _string| {
             *selected_idx = Some(new_idx)
         })
         .draw(uic, gl);
@@ -360,7 +360,7 @@ fn draw_ui(gl: &mut Gl,
         .label_color(Color::new(1.0, 1.0, 1.0, 0.5) * ddl_color.plain_contrast())
         .line_width(2.0)
         .value_font_size(18u32)
-        .callback(box |&mut: new_x, new_y| {
+        .callback(|&mut: new_x, new_y| {
             demo.circle_pos[0] = new_x;
             demo.circle_pos[1] = new_y;
         })
@@ -373,7 +373,7 @@ fn draw_ui(gl: &mut Gl,
     WidgetMatrix::new(cols, rows)
         .position(810.0, 115.0)
         .dimensions(320.0, 425.0)
-        .each_widget(box |&mut: num, _col, _row, pos, dim| { // This is called for every widget.
+        .each_widget(|&mut: num, _col, _row, pos, dim| { // This is called for every widget.
             use conrod::draw::Drawable;
 
             let &mut (ref mut env, ref mut text) = &mut demo.envelopes[num];
@@ -395,6 +395,7 @@ fn draw_ui(gl: &mut Gl,
                 .frame(demo.frame_width)
                 .frame_color(demo.bg_color.invert().plain_contrast())
                 .color(demo.bg_color.invert())
+                .callback(|&mut: _string: &mut String|{})
                 .draw(uic, gl);
 
             // Draw an EnvelopeEditor.
@@ -411,6 +412,7 @@ fn draw_ui(gl: &mut Gl,
                 .label_color(env_label_color)
                 .point_radius(6.0)
                 .line_width(2.0)
+                .callback(|&mut: _points: &mut Vec<Point>, _idx: usize|{})
                 .draw(uic, gl);
 
         }); // End of matrix widget callback.

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -58,11 +58,11 @@ fn get_new_state(is_over: bool,
 }
 
 /// A context on which the builder pattern can be implemented.
-pub struct Toggle<'a> {
+pub struct Toggle<'a, F> {
     ui_id: UIID,
     pos: Point,
     dim: Dimensions,
-    maybe_callback: Option<Box<FnMut(bool) + 'a>>,
+    maybe_callback: Option<F>,
     maybe_color: Option<Color>,
     maybe_frame: Option<f64>,
     maybe_frame_color: Option<Color>,
@@ -72,10 +72,10 @@ pub struct Toggle<'a> {
     value: bool,
 }
 
-impl<'a> Toggle<'a> {
+impl<'a, F> Toggle<'a, F> {
 
     /// Create a toggle context to be built upon.
-    pub fn new(ui_id: UIID, value: bool) -> Toggle<'a> {
+    pub fn new(ui_id: UIID, value: bool) -> Toggle<'a, F> {
         Toggle {
             ui_id: ui_id,
             pos: [0.0, 0.0],
@@ -94,7 +94,7 @@ impl<'a> Toggle<'a> {
 }
 
 quack! {
-    toggle: Toggle['a]
+    toggle: Toggle['a, F]
     get:
         fn () -> Size [] { Size(toggle.dim) }
         fn () -> DefaultWidgetState [] {
@@ -103,7 +103,7 @@ quack! {
         fn () -> Id [] { Id(toggle.ui_id) }
     set:
         fn (val: Color) [] { toggle.maybe_color = Some(val) }
-        fn (val: Callback<Box<FnMut(bool) + 'a>>) [] {
+        fn (val: Callback<F>) [where F: FnMut(bool) + 'a] {
             toggle.maybe_callback = Some(val.0)
         }
         fn (val: FrameColor) [] { toggle.maybe_frame_color = Some(val.0) }
@@ -118,7 +118,7 @@ quack! {
     action:
 }
 
-impl<'a> ::draw::Drawable for Toggle<'a> {
+impl<'a, F> ::draw::Drawable for Toggle<'a, F> where F: FnMut(bool) + 'a {
     fn draw<B, C>(&mut self, uic: &mut UiContext<C>, graphics: &mut B)
         where
             B: BackEnd<Texture = <C as CharacterCache>::Texture>,

--- a/src/widget_matrix.rs
+++ b/src/widget_matrix.rs
@@ -37,7 +37,10 @@ impl WidgetMatrix {
 
     /// The callback called for each widget in the matrix.
     /// This should be called following all builder methods.
-    pub fn each_widget(&mut self, mut callback: Box<FnMut(WidgetNum, ColNum, RowNum, Point, Dimensions)>) {
+    pub fn each_widget<F>(&mut self, mut callback: F)
+        where
+            F: FnMut(WidgetNum, ColNum, RowNum, Point, Dimensions)
+    {
         let widget_w = self.dim[0] / self.cols as f64;
         let widget_h = self.dim[1] / self.rows as f64;
         let mut widget_num = 0us;


### PR DESCRIPTION
Note that there is not yet a default type for the generic callback type parameter, meaning the user is forced to give a callback whether they want to or not. In most cases callbacks are given anyway, but for widgets like TextBox and EnvelopeEditor it isn't always necessary.

Perhaps we could create some empty Dummy type that impls the necessary FnMut for each widget as a default for the generic callback parameter so that the widget's type is always satisfied whether or not the user gives a callback?

@bvssvni @eddyb are there nicer ways to handle this?