### PR TITLE
Changed all_widgets over to glutin (still needs some fixes), started basic counter example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,28 @@
 language: rust
+
 notifications:
     irc: "irc.mozilla.org#piston-internals"
+
 os:
     - linux
     - osx
+
 env:
     global:
         - secure: W/pxVmgtzNXIQNPOm9lsIjSr2nEHGVD8uOGV0be4kdz0bUXCjFDe1j45VVDnXPoJZDrnv7TO0etn3yT7hpuiZGAT40Ovn7LVq7gqtTAoP2U7vbURN55g0MU9dSIAOUdfclAMZez9HgOHWC0P3Tg6bNkNrW5B5wwpmaFVyYwiQkE=
+
 install:
-    # SDL2
-    - curl -O http://www.libsdl.org/release/SDL2-2.0.0.tar.gz
-    - tar -xzvf SDL2-2.0.0.tar.gz
-    - (cd SDL2-2.0.0 && ./configure && make && sudo make install)
+    # # SDL2
+    # - curl -O http://www.libsdl.org/release/SDL2-2.0.0.tar.gz
+    # - tar -xzvf SDL2-2.0.0.tar.gz
+    # - (cd SDL2-2.0.0 && ./configure && make && sudo make install)
+    - sudo apt-get install libXxf86vm-dev libosmesa6-dev
+
 script:
-    - cargo build -v
-    - cargo test -v
-    - cargo doc -v
+    - cargo build --verbose
+    - cargo test --verbose
+    - cargo doc --verbose
+
 after_success:
     - cp -R target/doc doc
     - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ git = "https://github.com/PistonDevelopers/graphics.git"
 [dependencies.vecmath]
 git = "https://github.com/PistonDevelopers/vecmath.git"
 
-[dev-dependencies.pistoncore-sdl2_window]
-git = "https://github.com/PistonDevelopers/sdl2_window.git"
+[dev-dependencies.pistoncore-glutin_window]
+git = "https://github.com/PistonDevelopers/glutin_window.git"
 
 [dev-dependencies.piston2d-opengl_graphics]
 git = "https://github.com/PistonDevelopers/opengl_graphics.git"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -4,7 +4,7 @@ extern crate piston;
 extern crate conrod;
 extern crate graphics;
 extern crate opengl_graphics;
-extern crate sdl2_window;
+extern crate glutin_window;
 extern crate vecmath;
 
 use conrod::{
@@ -41,7 +41,7 @@ use piston::event::{
 };
 use piston::Set;
 use piston::window::WindowSettings;
-use sdl2_window::Sdl2Window;
+use glutin_window::GlutinWindow;
 use std::cell::RefCell;
 use vecmath::vec2_add;
 
@@ -123,7 +123,7 @@ impl DemoApp {
 
 fn main() {
     let opengl = OpenGL::_3_2;
-    let window = Sdl2Window::new(
+    let window = GlutinWindow::new(
         opengl,
         WindowSettings {
             title: "Hello Conrod".to_string(),

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,0 +1,90 @@
+
+#![feature(old_path)]
+
+extern crate conrod;
+extern crate glutin_window;
+extern crate opengl_graphics;
+extern crate piston;
+
+use conrod::{
+    Background,
+    Button,
+    Callable,
+    Colorable,
+    Shapeable,
+    Drawable,
+    Label,
+    Positionable,
+    Theme,
+    UiContext,
+};
+use glutin_window::GlutinWindow;
+use opengl_graphics::{Gl, OpenGL};
+use opengl_graphics::glyph_cache::GlyphCache;
+use piston::event::{
+    Event,
+    Events,
+    Ups,
+    MaxFps,
+};
+use piston::Set;
+use piston::window::WindowSettings;
+use std::cell::RefCell;
+
+type Ui = UiContext<GlyphCache>;
+
+fn main () {
+
+    let opengl = OpenGL::_3_2;
+    let window = GlutinWindow::new(
+        opengl,
+        WindowSettings {
+            title: "Hello Conrod".to_string(),
+            size: [200, 100],
+            fullscreen: false,
+            exit_on_esc: true,
+            samples: 4,
+        }
+    );
+    let window_ref = RefCell::new(window);
+    let event_iter = Events::new(&window_ref).set(Ups(180)).set(MaxFps(60));
+    let mut gl = Gl::new(opengl);
+    let font_path = Path::new("./assets/NotoSans/NotoSans-Regular.ttf");
+    let theme = Theme::default();
+    let glyph_cache = GlyphCache::new(&font_path).unwrap();
+    let uic = &mut UiContext::new(glyph_cache, theme);
+
+    let mut count: u32 = 0;
+
+    for event in event_iter {
+        uic.handle_event(&event);
+        if let Event::Render(args) = event {
+            gl.draw([0, 0, args.width as i32, args.height as i32], |_, gl| {
+
+                // Draw the background.
+                Background::new().rgba(0.2, 0.25, 0.4, 1.0).draw(uic, gl);
+
+                // Draw the counter.
+                counter(gl, uic, &mut count)
+
+            });
+        }
+    }
+
+}
+
+/// Function for drawing the counter widget.
+fn counter(gl: &mut Gl, uic: &mut Ui, count: &mut u32) {
+
+    // Draw the value.
+    Label::new(&count.to_string()).position(10.0, 10.0).draw(uic, gl);
+
+    // Draw the button and increment count if pressed..
+    Button::new(0)
+        .position(110.0, 10.0)
+        .dimensions(80.0, 80.0)
+        .callback(|| *count += 1)
+        .draw(uic, gl)
+
+}
+


### PR DESCRIPTION
Not sure if we should merge this yet, however at least the tests would pass as sdl2 seems to still be broken.

Remaining issues:

- the widgets in the "all_widgets" example seem to render a few pixels higher than they should (if someone could test this on windows or linux that would be great).
- everything halves in size on retina display. I think this is because unlike `sdl2`, `glutin` works with a literal pixel count (2.5k+), so maybe we should have an option to halve the res with `glutin_window`? Maybe glutin already offers this though? @bvssvni

I think it'd be cool to try and implement each of the examples from here #317 as nicely as possible as conrod could use some simpler examples and it would also encourage us to address some fixes and new features.