### PR TITLE
Added proper support for mouse/keyboard capturing and some warnings.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,9 @@ pub use background::Background;
 pub use color::{Color, Colorable};
 pub use frame::{Framing, Frameable};
 pub use label::Labelable;
-pub use position::{Depth, Direction, Dimensions, Point, Position, Positionable, Sizeable};
+pub use position::{align_left_of, align_right_of, align_bottom_of, align_top_of};
+pub use position::{Corner, Depth, Direction, Dimensions, HorizontalAlign, Point, Position,
+                   Positionable, Sizeable, VerticalAlign};
 pub use theme::Theme;
 pub use ui::{Ui, UiId};
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -208,9 +208,13 @@ pub trait Sizeable: Sized {
 /// A corner of a rectangle.
 #[derive(Copy, Clone)]
 pub enum Corner {
+    /// The top left quarter of a rectangle's area.
     TopLeft,
+    /// The top right quarter of a rectangle's area.
     TopRight,
+    /// The bottom left quarter of a rectangle's area.
     BottomLeft,
+    /// The bottom right quarter of a rectangle's area.
     BottomRight,
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -197,6 +197,13 @@ impl<C> Ui<C> {
     pub fn set_widget(&mut self, ui_id: UiId, widget: Widget) {
         if self.widget_cache[ui_id].kind.matches(&widget.kind)
         || self.widget_cache[ui_id].kind.matches(&WidgetKind::NoWidget) {
+            if self.widget_cache[ui_id].element.is_some() {
+                println!("Warning: The widget with UiId {:?} has already been set within the `Ui` \
+                          since the last time that `Ui::draw` was called (you probably don't want \
+                          this). Perhaps check that your UiIds are correct, that you're calling \
+                          `Ui::draw` after constructing your widgets and that you haven't \
+                          accidentally set the same widget twice.");
+            }
             self.widget_cache[ui_id] = widget;
             self.maybe_prev_ui_id = Some(ui_id);
         } else {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -122,13 +122,14 @@ impl<'a, F> Button<'a, F> {
             let text_color = self.maybe_label_color.unwrap_or(ui.theme.label_color);
             let size = self.maybe_label_font_size.unwrap_or(ui.theme.font_size_medium);
             text(Text::from_string(label_text.to_string()).color(text_color).height(size as f64))
+                .shift(xy[0].floor(), xy[1].floor());
         });
 
         // Construct the button's Form.
         let form_chain = Some(frame_form).into_iter()
             .chain(Some(pressable_form).into_iter())
-            .chain(maybe_label_form.into_iter())
-            .map(|form| form.shift(xy[0].floor(), xy[1].floor()));
+            .map(|form| form.shift(xy[0], xy[1]))
+            .chain(maybe_label_form.into_iter());
 
         // Turn the form into a renderable Element.
         let element = collage(dim[0] as i32, dim[1] as i32, form_chain.collect());

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -99,7 +99,7 @@ impl<'a, F> Button<'a, F> {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state().relative_to(xy);
+        let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let is_over = is_over_rect([0.0, 0.0], mouse.xy, dim);
         let new_state = get_new_state(is_over, state, mouse);
 
@@ -122,7 +122,7 @@ impl<'a, F> Button<'a, F> {
             let text_color = self.maybe_label_color.unwrap_or(ui.theme.label_color);
             let size = self.maybe_label_font_size.unwrap_or(ui.theme.font_size_medium);
             text(Text::from_string(label_text.to_string()).color(text_color).height(size as f64))
-                .shift(xy[0].floor(), xy[1].floor());
+                .shift(xy[0].floor(), xy[1].floor())
         });
 
         // Construct the button's Form.

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -172,14 +172,23 @@ impl<'a, F> DropDownList<'a, F> {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state().relative_to(xy);
+        let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let frame_w = self.maybe_frame.unwrap_or(ui.theme.frame_width);
         let is_over_idx = is_over(mouse.xy, frame_w, dim, state, self.strings.len());
         let new_state = get_new_state(is_over_idx, self.strings.len(), state, mouse);
         let selected = self.selected.and_then(|idx| if idx < self.strings.len() { Some(idx) }
                                                     else { None });
 
-        // Call the `callback` closure if mouse was released on one of the DropDownMenu items.
+        // Check whether or not we need to capture or uncapture the mouse.
+        // We need to capture the cursor if the DropDownList has just been opened.
+        // We need to uncapture the cursor if the DropDownList has just been closed.
+        match (state, new_state) {
+            (State::Closed(_), State::Open(_)) => ui.mouse_captured_by(ui_id),
+            (State::Open(_), State::Closed(_)) => ui.mouse_uncaptured_by(ui_id),
+            _ => (),
+        }
+
+        // Call the `callback` closure if mouse was released on one of the DropDownList items.
         if let Some(ref mut callback) = self.maybe_callback {
             if let (State::Open(o_d_state), State::Closed(c_d_state)) = (state, new_state) {
                 if let (DrawState::Clicked(idx, _), DrawState::Normal) = (o_d_state, c_d_state) {

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -263,7 +263,7 @@ impl<'a, F> DropDownList<'a, F> {
                                              .height(t_size as f64));
                     Some(frame_form.shift_y(shift_amt)).into_iter()
                         .chain(Some(inner_form.shift_y(shift_amt)).into_iter())
-                        .chain(Some(text_form.shift_y(shift_amt)).into_iter())
+                        .chain(Some(text_form.shift_y(shift_amt.floor())).into_iter())
                 }).map(|form| form.shift(xy[0].floor(), xy[1].floor()));
 
                 // Collect the Form's into a renderable Element.

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -274,7 +274,7 @@ impl<'a, E, F> EnvelopeEditor<'a, E, F> where E: EnvelopePoint {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state().relative_to(xy);
+        let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let skew = self.skew_y_range;
         let (min_x, max_x, min_y, max_y) = (self.min_x, self.max_x, self.min_y, self.max_y);
         let pt_radius = self.pt_radius;

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -207,7 +207,7 @@ impl<'a, T: Float, F> NumberDialer<'a, T, F> {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state().relative_to(xy);
+        let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let frame_w = self.maybe_frame.unwrap_or(ui.theme.frame_width);
         let frame_w2 = frame_w * 2.0;
         let pad_dim = vec2_sub(dim, [frame_w2; 2]);

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -114,7 +114,7 @@ impl<'a, T, F> Slider<'a, T, F> {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state().relative_to(xy);
+        let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let is_over = is_over_rect([0.0, 0.0], mouse.xy, dim);
         let new_state = get_new_state(is_over, state, mouse);
 

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -103,7 +103,7 @@ impl<'a, F> Toggle<'a, F> {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, self.dim, h_align, v_align);
-        let mouse = ui.get_mouse_state();
+        let mouse = ui.get_mouse_state(ui_id);
         let is_over = is_over_rect(xy, mouse.xy, self.dim);
         let new_state = get_new_state(is_over, state, mouse);
 

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -130,7 +130,7 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.h_align);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.v_align);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state().relative_to(xy);
+        let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let frame_w = self.maybe_frame.unwrap_or(ui.theme.frame_width);
         let frame_w2 = frame_w * 2.0;
         let pad_dim = vec2_sub(dim, [frame_w2; 2]);


### PR DESCRIPTION
- Conrod now prints a warning if a user tries to set the same widget twice.
- `Ui` now has methods for capturing mouse and keyboard - if a widget captures the mouse or keyboard, mouse or keyboard input is blocked from all other widgets until the capturing widget uncaptures the ui. Captured widgets will always render last (on top). This fixes the issue where an open DropDownList's items would draw underneath following widgets.

Closes  #145 and #80 