### PR TITLE
add benchmarks for counter, TextBox, gfx, gl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,26 @@ homepage = "https://github.com/pistondevelopers/conrod"
 name = "conrod"
 path = "./src/lib.rs"
 
+[dev-dependencies.gfx_device_gl]
+git = "https://github.com/gfx-rs/gfx_device_gl"
+
+[dev-dependencies.piston_window]
+git = "https://github.com/PistonDevelopers/piston_window.git"
 
 [dev-dependencies.pistoncore-glutin_window]
 git = "https://github.com/PistonDevelopers/glutin_window.git"
 
+[dev-dependencies.pistoncore-window]
+git = "https://github.com/pistondevelopers/window.git"
+
+[dev-dependencies.piston2d-gfx_graphics]
+git = "https://github.com/PistonDevelopers/gfx_graphics.git"
+
 [dev-dependencies.piston2d-opengl_graphics]
 git = "https://github.com/PistonDevelopers/opengl_graphics.git"
+
+[dependencies.piston-viewport]
+git = "https://github.com/pistondevelopers/viewport"
 
 
 [dependencies.clock_ticks]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ homepage = "https://github.com/pistondevelopers/conrod"
 name = "conrod"
 path = "./src/lib.rs"
 
+[dev-dependencies.gfx]
+git = "https://github.com/gfx-rs/gfx-rs"
+
 [dev-dependencies.gfx_device_gl]
 git = "https://github.com/gfx-rs/gfx_device_gl"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ git = "https://github.com/PistonDevelopers/gfx_graphics.git"
 [dev-dependencies.piston2d-opengl_graphics]
 git = "https://github.com/PistonDevelopers/opengl_graphics.git"
 
-[dependencies.piston-viewport]
+[dev-dependencies.piston-viewport]
 git = "https://github.com/pistondevelopers/viewport"
 
 

--- a/benches/draw.rs
+++ b/benches/draw.rs
@@ -1,0 +1,153 @@
+#![feature(test)]
+
+extern crate conrod;
+extern crate gfx_device_gl;
+extern crate gfx_graphics;
+extern crate glutin_window;
+extern crate opengl_graphics;
+extern crate piston;
+extern crate piston_window;
+extern crate test;
+extern crate viewport;
+extern crate window;
+
+use conrod::{Button, Labelable, Sizeable, TextBox, Theme, Ui};
+use gfx_device_gl::Resources;
+use gfx_graphics::GlyphCache as GfxGlyphCache;
+use glutin_window::GlutinWindow;
+use opengl_graphics::{ GlGraphics, OpenGL };
+use opengl_graphics::glyph_cache::GlyphCache as GlGlyphCache;
+use piston::window::{ WindowSettings, Size };
+use piston_window::PistonWindow;
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+use test::Bencher;
+use viewport::Viewport;
+use window::Window;
+
+const OPENGL_VERSION: OpenGL = OpenGL::_3_2;
+
+fn viewport_from_window(window: &PistonWindow<GlutinWindow>) -> Viewport {
+    let size = window.size();
+    let draw_size = window.draw_size();
+
+    Viewport {
+        rect: [0, 0, draw_size.width as i32, draw_size.height as i32],
+        window_size: [size.width, size.height],
+        draw_size: [draw_size.width, draw_size.height],
+    }
+}
+
+fn init_window() -> PistonWindow<GlutinWindow> {
+    let window = GlutinWindow::new(
+        OPENGL_VERSION,
+        WindowSettings::new("Conrod Bench".to_string(), Size { width: 800, height: 600 })
+    );
+    PistonWindow::new(Rc::new(RefCell::new(window)), piston_window::empty_app())
+}
+
+fn init_gl_ui<'a>() -> Ui<GlGlyphCache<'a>> {
+    let font_path = Path::new("./assets/NotoSans/NotoSans-Regular.ttf");
+    let theme = Theme::default();
+    let glyph_cache = GlGlyphCache::new(&font_path);
+    Ui::new(glyph_cache.unwrap(), theme)
+}
+
+fn init_gfx_ui(window: &mut PistonWindow<GlutinWindow>) -> Ui<GfxGlyphCache<Resources>> {
+    let font_path = Path::new("./assets/NotoSans/NotoSans-Regular.ttf");
+    let theme = Theme::default();
+    let glyph_cache = GfxGlyphCache::new(&font_path, &mut window.canvas.borrow_mut().factory);
+    Ui::new(glyph_cache.unwrap(), theme)
+}
+
+#[bench]
+fn bench_gl_draw_counter(b: &mut Bencher) {
+    let window = init_window();
+    let viewport = viewport_from_window(&window);
+    let ui = &mut init_gl_ui();
+    let mut gl = GlGraphics::new(OPENGL_VERSION);
+
+    b.iter(|| {
+        gl.draw(viewport, |_context, g| {
+            Button::new().dimensions(80.0, 80.0).label("0").react(|| { }).set(0, ui);
+            ui.draw(g);
+        });
+    });
+}
+
+#[bench]
+fn bench_gfx_draw_counter(b: &mut Bencher) {
+    let mut window = init_window();
+    let ui = &mut init_gfx_ui(&mut window);
+
+    b.iter(|| {
+        window.draw_2d(|_context, g| {
+            Button::new().dimensions(80.0, 80.0).label("0").react(|| { }).set(0, ui);
+            ui.draw(g);
+        });
+        ui.character_cache.update(&mut window.canvas.borrow_mut().factory);
+    });
+}
+
+#[bench]
+fn bench_gl_draw_textbox(b: &mut Bencher) {
+    let window = init_window();
+    let viewport = viewport_from_window(&window);
+    let ui = &mut init_gl_ui();
+    let mut gl = GlGraphics::new(OPENGL_VERSION);
+    let mut string = String::new();
+
+    b.iter(|| {
+        gl.draw(viewport, |_context, g| {
+            TextBox::new(&mut string).dimensions(320.0, 40.0).react(|_: &mut String| { }).set(0, ui);
+            ui.draw(g);
+        });
+    });
+}
+
+#[bench]
+fn bench_gfx_draw_textbox(b: &mut Bencher) {
+    let mut window = init_window();
+    let ui = &mut init_gfx_ui(&mut window);
+    let mut string = String::new();
+
+    b.iter(|| {
+        window.draw_2d(|_context, g| {
+            TextBox::new(&mut string).dimensions(320.0, 40.0).react(|_: &mut String| { }).set(0, ui);
+            ui.draw(g);
+        });
+        ui.character_cache.update(&mut window.canvas.borrow_mut().factory);
+    });
+}
+
+#[bench]
+fn bench_gl_draw_textbox_m40(b: &mut Bencher) {
+    let window = init_window();
+    let viewport = viewport_from_window(&window);
+    let ui = &mut init_gl_ui();
+    let mut gl = GlGraphics::new(OPENGL_VERSION);
+    let mut m40 = "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm".to_string();
+
+    b.iter(|| {
+        gl.draw(viewport, |_context, g| {
+            TextBox::new(&mut m40).dimensions(320.0, 40.0).react(|_: &mut String| { }).set(0, ui);
+            ui.draw(g);
+        });
+    });
+}
+
+#[bench]
+fn bench_gfx_draw_textbox_m40(b: &mut Bencher) {
+    let mut window = init_window();
+    let ui = &mut init_gfx_ui(&mut window);
+    let mut m40 = "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm".to_string();
+
+    b.iter(|| {
+        window.draw_2d(|_context, g| {
+            TextBox::new(&mut m40).dimensions(320.0, 40.0).react(|_: &mut String| { }).set(0, ui);
+            ui.draw(g);
+        });
+        ui.character_cache.update(&mut window.canvas.borrow_mut().factory);
+    });
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -56,7 +56,7 @@ pub struct Ui<C, W=()> where W: CustomWidget {
     pub keys_just_released: Vec<input::keyboard::Key>,
     /// Text that has been entered since the end of the last render cycle.
     pub text_just_entered: Vec<String>,
-    character_cache: C,
+    pub character_cache: C,
     prev_event_was_render: bool,
     /// Window width.
     pub win_w: f64,


### PR DESCRIPTION
These are the results I get from running `cargo bench`:
```
     Running target/release/draw-8d18b865e63c0650

running 6 tests
test bench_gfx_draw_counter     ... bench:         3 ns/iter (+/- 4)
test bench_gfx_draw_textbox     ... bench:         3 ns/iter (+/- 5)
test bench_gfx_draw_textbox_m40 ... bench:         3 ns/iter (+/- 2)
test bench_gl_draw_counter      ... bench:   1726785 ns/iter (+/- 632810)
test bench_gl_draw_textbox      ... bench:    957921 ns/iter (+/- 502379)
test bench_gl_draw_textbox_m40  ... bench:   2378596 ns/iter (+/- 1025574)

```
on
```
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                8
On-line CPU(s) list:   0-7
Thread(s) per core:    2
Core(s) per socket:    4
Socket(s):             1
NUMA node(s):          1
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 60
Model name:            Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
Stepping:              3
CPU MHz:               1973.328
CPU max MHz:           3900.0000
CPU min MHz:           800.0000
BogoMIPS:              6799.31
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              8192K
NUMA node0 CPU(s):     0-7
```

Which would suggest gfx is much much faster, but it looks a little unrealistic to me so there is probably something wrong with how I wrote the benchmark. Also, this does not agree with what I was seeing before running all_widgets so maybe I should update that example to work with the recent changes.