### PR TITLE
Made custom widgets use `Box<Any>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
-//! 
+//!
 //! # Conrod
 //!
 //! An easy-to-use, immediate-mode, 2D GUI library featuring a range of useful widgets.
 //!
 
 #![deny(missing_copy_implementations)]
+#![feature(core)]
 #![warn(missing_docs)]
 
 #[macro_use] extern crate bitflags;
@@ -20,7 +21,6 @@ extern crate vecmath;
 
 pub use widget::button::Button;
 pub use widget::custom::Custom as CustomWidget;
-pub use widget::custom::State as CustomWidgetState;
 pub use widget::drop_down_list::DropDownList;
 pub use widget::envelope_editor::EnvelopeEditor;
 pub use widget::envelope_editor::EnvelopePoint;
@@ -31,6 +31,7 @@ pub use widget::text_box::TextBox;
 pub use widget::toggle::Toggle;
 pub use widget::matrix::Matrix as WidgetMatrix;
 pub use widget::xy_pad::XYPad;
+pub use widget::Kind as WidgetKind;
 
 pub use background::Background;
 pub use elmesque::color;
@@ -57,4 +58,3 @@ mod theme;
 mod ui;
 mod utils;
 mod widget;
-

--- a/src/widget/custom.rs
+++ b/src/widget/custom.rs
@@ -1,4 +1,3 @@
-
 use ui::{Ui, UiId};
 
 /// A trait to be implemented for Custom widget types.
@@ -6,30 +5,10 @@ use ui::{Ui, UiId};
 /// If you think your widget might be useful enough for conrod's official widget library, Feel free
 /// to submit a PR at https://github.com/PistonDevelopers/conrod.
 pub trait Custom: Clone + ::std::fmt::Debug {
-    /// State to be stored within the `Ui`s widget cache.
-    type State: State;
-
     /// After building the widget, we use this method to set its current state into the given `Ui`.
     /// The `Ui` will cache this state and use it for rendering the next time `ui.draw(graphics)`
     /// is called.
     ///
     /// See one of the internal widgets for an example of how to implement this method.
     fn set<C>(mut self, ui_id: UiId, ui: &mut Ui<C>);
-
 }
-
-/// The state to be stored within the `Ui`s widget cache.
-pub trait State: Copy + Clone + ::std::fmt::Debug {
-    /// Whether or not the state matches some other state.
-    fn matches(&self, other: &Self) -> bool;
-}
-
-impl Custom for () {
-    type State = ();
-    fn set<C>(self, _ui_id: UiId, _ui: &mut Ui<C>) {}
-}
-
-impl State for () {
-    fn matches(&self, _other: &()) -> bool { true }
-}
-


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/conrod/issues/397

* Removed `State` trait
* Removed `Custom::State`
* Removed `Copy/Clone` on `Kind/Widget`
* Added `#![feature(core)]` to check type id, will be removed when
`Any` gets associated static