### PR TITLE
Implemented `enabled` method for enabling and disabling user input from Widgets.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ pub use widget::slider::Slider;
 pub use widget::text_box::TextBox;
 pub use widget::toggle::Toggle;
 pub use widget::xy_pad::XYPad;
-pub use widget::Toggleable;
 
 pub use background::Background;
 pub use canvas::{Canvas, CanvasId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use widget::slider::Slider;
 pub use widget::text_box::TextBox;
 pub use widget::toggle::Toggle;
 pub use widget::xy_pad::XYPad;
+pub use widget::Toggleable;
 
 pub use background::Background;
 pub use canvas::{Canvas, CanvasId};

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -101,8 +101,9 @@ impl<'a, F> Button<'a, F> {
 
 }
 impl<'a, F> Toggleable for Button<'a, F> {
-    fn enabled(&mut self, flag: bool) {
+    fn enabled(mut self, flag: bool) -> Self {
         self.enabled = flag;
+        self
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -99,6 +99,12 @@ impl<'a, F> Button<'a, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 
@@ -199,10 +205,6 @@ impl<'a, F> Widget for Button<'a, F>
 
         // Turn the form into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
-    }
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@ use mouse::Mouse;
 use position::{Depth, Dimensions, HorizontalAlign, Position, Positionable, VerticalAlign};
 use theme::Theme;
 use ui::{UiId, Ui};
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// A pressable button widget whose reaction is triggered upon release.
@@ -100,12 +100,7 @@ impl<'a, F> Button<'a, F> {
     }
 
 }
-impl<'a, F> Toggleable for Button<'a, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
-}
+
 
 impl<'a, F> Widget for Button<'a, F>
     where
@@ -204,6 +199,10 @@ impl<'a, F> Widget for Button<'a, F>
 
         // Turn the form into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
+    }
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -8,7 +8,7 @@ use mouse::Mouse;
 use position::{Depth, Dimensions, HorizontalAlign, Point, Position, Positionable, VerticalAlign};
 use theme::Theme;
 use ui::{UiId, Ui};
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// Tuple / React params.
@@ -148,13 +148,6 @@ fn get_new_menu_state(is_over_idx: Option<Idx>,
         }
     }
 }
-impl<'a, F> Toggleable for DropDownList<'a, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
-}
-
 
 impl<'a, F> DropDownList<'a, F> {
 
@@ -367,6 +360,11 @@ impl<'a, F> Widget for DropDownList<'a, F>
 
         }
 
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -8,7 +8,7 @@ use mouse::Mouse;
 use position::{Depth, Dimensions, HorizontalAlign, Point, Position, Positionable, VerticalAlign};
 use theme::Theme;
 use ui::{UiId, Ui};
-use widget::{self, Widget};
+use widget::{self, Widget, Toggleable};
 
 
 /// Tuple / React params.
@@ -28,6 +28,7 @@ pub struct DropDownList<'a, F> {
     maybe_react: Option<F>,
     maybe_label: Option<&'a str>,
     style: Style,
+    enabled: bool,
 }
 
 /// Styling for the DropDownList, necessary for constructing its renderable Element.
@@ -147,6 +148,12 @@ fn get_new_menu_state(is_over_idx: Option<Idx>,
         }
     }
 }
+impl<'a, F> Toggleable for DropDownList<'a, F> {
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+}
 
 
 impl<'a, F> DropDownList<'a, F> {
@@ -164,6 +171,7 @@ impl<'a, F> DropDownList<'a, F> {
             maybe_react: None,
             maybe_label: None,
             style: Style::new(),
+            enabled: true,
         }
     }
 
@@ -212,7 +220,12 @@ impl<'a, F> Widget for DropDownList<'a, F>
         let frame = style.frame(&ui.theme);
         let num_strings = self.strings.len();
         let is_over_idx = is_over(mouse.xy, frame, dim, state.menu_state, num_strings);
-        let new_menu_state = get_new_menu_state(is_over_idx, num_strings, state.menu_state, mouse);
+        let new_menu_state = 
+            if self.enabled {
+                get_new_menu_state(is_over_idx, num_strings, state.menu_state, mouse)
+            } else {
+                MenuState::Closed(Interaction::Normal)
+            };
         let selected = self.selected.and_then(|idx| if idx < num_strings { Some(idx) }
                                                     else { None });
 

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -174,6 +174,12 @@ impl<'a, F> DropDownList<'a, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 
@@ -360,11 +366,6 @@ impl<'a, F> Widget for DropDownList<'a, F>
 
         }
 
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -16,7 +16,7 @@ use theme::Theme;
 use ui::{UiId, Ui};
 use utils::{clamp, map_range, percentage, val_to_string};
 use vecmath::vec2_sub;
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// Used for editing a series of 2D Points on a cartesian (X, Y) plane within some given range.
@@ -307,15 +307,6 @@ fn get_x_bounds(envelope_perc: &[(f32, f32, f32)], idx: usize) -> (f32, f32) {
         envelope_perc[idx - 1].0 // X value of point on left.
     } else { 0.0 };
     (left_bound, right_bound)
-}
-impl<'a, E, F> Toggleable for EnvelopeEditor<'a, E, F> 
-    where 
-        E: EnvelopePoint
-{
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
 }
 
 impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
@@ -659,6 +650,11 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
         // Turn the form into a renderable element.
         collage(dim[0] as i32, dim[1] as i32, forms)
 
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -295,6 +295,12 @@ impl<'a, E, F> EnvelopeEditor<'a, E, F> where E: EnvelopePoint {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 
@@ -650,11 +656,6 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
         // Turn the form into a renderable element.
         collage(dim[0] as i32, dim[1] as i32, forms)
 
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -98,6 +98,11 @@ impl<'a> Widget for Label<'a> {
                             .height(size as f64)).shift(xy[0].floor(), xy[1].floor());
         collage(dim[0] as i32, dim[1] as i32, vec![form])
     }
+    
+    fn enabled(mut self, flag: bool) -> Self {
+        //No way to disable inputs, as it doesn't get inputs anyway.
+        self
+    }
 }
 
 

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -99,11 +99,6 @@ impl<'a> Widget for Label<'a> {
         collage(dim[0] as i32, dim[1] as i32, vec![form])
     }
     
-    #[allow(unused_mut, unused_variables)]
-    fn enabled(mut self, flag: bool) -> Self {
-        //No way to disable inputs, as it doesn't get inputs anyway.
-        self
-    }
 }
 
 

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -99,6 +99,7 @@ impl<'a> Widget for Label<'a> {
         collage(dim[0] as i32, dim[1] as i32, vec![form])
     }
     
+    #[allow(unused_mut, unused_variables)]
     fn enabled(mut self, flag: bool) -> Self {
         //No way to disable inputs, as it doesn't get inputs anyway.
         self

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -115,14 +115,10 @@ pub trait Widget: Sized {
                current_style: &Self::Style,
                ui: &mut Ui<C>) -> Element
         where C: CharacterCache;
-}
 
-/// To be implemented by all traits that have an input that should be toggleable.
-pub trait Toggleable {
     /// If true, allows inputs.  If false, disallows inputs.
     fn enabled(mut self, flag: bool) -> Self;
 }
-
 
 /// Represents the unique cached state of a widget.
 #[derive(PartialEq)]

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -117,6 +117,12 @@ pub trait Widget: Sized {
         where C: CharacterCache;
 }
 
+/// To be implemented by all traits that have an input that should be toggleable.
+pub trait Toggleable {
+    /// If true, allows inputs.  If false, disallows inputs.
+    fn enabled(&mut self, flag: bool);
+}
+
 
 /// Represents the unique cached state of a widget.
 #[derive(PartialEq)]

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -120,7 +120,7 @@ pub trait Widget: Sized {
 /// To be implemented by all traits that have an input that should be toggleable.
 pub trait Toggleable {
     /// If true, allows inputs.  If false, disallows inputs.
-    fn enabled(&mut self, flag: bool);
+    fn enabled(mut self, flag: bool) -> Self;
 }
 
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -116,8 +116,6 @@ pub trait Widget: Sized {
                ui: &mut Ui<C>) -> Element
         where C: CharacterCache;
 
-    /// If true, allows inputs.  If false, disallows inputs.
-    fn enabled(mut self, flag: bool) -> Self;
 }
 
 /// Represents the unique cached state of a widget.

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -13,7 +13,7 @@ use std::iter::repeat;
 use theme::Theme;
 use utils::clamp;
 use ui::{UiId, Ui};
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// A widget for precision control over any digit within a value. The reaction is triggered when
@@ -209,12 +209,6 @@ impl<'a, T: Float, F> NumberDialer<'a, T, F> {
         self
     }
 
-}
-impl<'a, T, F> Toggleable for NumberDialer<'a, T, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
 }
 
 impl<'a, T, F> Widget for NumberDialer<'a, T, F>
@@ -432,6 +426,11 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F>
         // Collect the Forms into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
 
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -13,7 +13,7 @@ use std::iter::repeat;
 use theme::Theme;
 use utils::clamp;
 use ui::{UiId, Ui};
-use widget::{self, Widget};
+use widget::{self, Widget, Toggleable};
 
 
 /// A widget for precision control over any digit within a value. The reaction is triggered when
@@ -31,6 +31,7 @@ pub struct NumberDialer<'a, T, F> {
     precision: u8,
     maybe_react: Option<F>,
     style: Style,
+    enabled: bool,
 }
 
 /// Styling for the NumberDialer, necessary for constructing its renderable Element.
@@ -197,6 +198,7 @@ impl<'a, T: Float, F> NumberDialer<'a, T, F> {
             maybe_label: None,
             maybe_react: None,
             style: Style::new(),
+            enabled: true,
         }
     }
 
@@ -208,7 +210,12 @@ impl<'a, T: Float, F> NumberDialer<'a, T, F> {
     }
 
 }
-
+impl<'a, T, F> Toggleable for NumberDialer<'a, T, F> {
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+}
 
 impl<'a, T, F> Widget for NumberDialer<'a, T, F>
     where
@@ -257,7 +264,12 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F>
         let val_string_dim = [val_string_width(font_size, &val_string), font_size as f64];
         let label_x = -val_string_dim[0] / 2.0;
         let is_over_elem = is_over(mouse.xy, dim, pad_dim, label_x, label_dim, val_string_dim, val_string_len);
-        let new_interaction = get_new_interaction(is_over_elem, state.interaction, mouse);
+        let new_interaction = 
+            if self.enabled {
+                get_new_interaction(is_over_elem, state.interaction, mouse)
+            } else {
+                Interaction::Normal
+            };
 
         // Determine new value from the initial state and the new state.
         let mut new_val = self.value;

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -209,6 +209,12 @@ impl<'a, T: Float, F> NumberDialer<'a, T, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 impl<'a, T, F> Widget for NumberDialer<'a, T, F>
@@ -426,11 +432,6 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F>
         // Collect the Forms into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
 
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -112,6 +112,12 @@ impl<'a, T, F> Slider<'a, T, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 impl<'a, T, F> Widget for Slider<'a, T, F>
@@ -296,11 +302,6 @@ impl<'a, T, F> Widget for Slider<'a, T, F>
 
         // Collect the Forms into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -114,8 +114,9 @@ impl<'a, T, F> Slider<'a, T, F> {
 
 }
 impl<'a, T, F> Toggleable for Slider<'a, T, F> {
-    fn enabled(&mut self, flag: bool) {
+    fn enabled(mut self, flag: bool) -> Self {
         self.enabled = flag;
+        self
     }
 }
 

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -10,7 +10,7 @@ use position::{self, Depth, Dimensions, HorizontalAlign, Position, VerticalAlign
 use theme::Theme;
 use ui::{UiId, Ui};
 use utils::{clamp, percentage, value_from_perc};
-use widget::{self, Widget};
+use widget::{self, Widget, Toggleable};
 
 
 /// Linear value selection. If the slider's width is greater than it's height, it will
@@ -29,6 +29,7 @@ pub struct Slider<'a, T, F> {
     maybe_react: Option<F>,
     maybe_label: Option<&'a str>,
     style: Style,
+    enabled: bool,
 }
 
 /// Styling for the Slider, necessary for constructing its renderable Element.
@@ -100,6 +101,7 @@ impl<'a, T, F> Slider<'a, T, F> {
             maybe_react: None,
             maybe_label: None,
             style: Style::new(),
+            enabled: true,
         }
     }
 
@@ -110,6 +112,11 @@ impl<'a, T, F> Slider<'a, T, F> {
         self
     }
 
+}
+impl<'a, T, F> Toggleable for Slider<'a, T, F> {
+    fn enabled(&mut self, flag: bool) {
+        self.enabled = flag;
+    }
 }
 
 
@@ -150,7 +157,13 @@ impl<'a, T, F> Widget for Slider<'a, T, F>
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
         let mouse = ui.get_mouse_state(ui_id).relative_to(xy);
         let is_over = is_over_rect([0.0, 0.0], mouse.xy, dim);
-        let new_interaction = get_new_interaction(is_over, state.interaction, mouse);
+        let new_interaction = 
+            if self.enabled {
+                get_new_interaction(is_over, state.interaction, mouse)
+            } else {
+                //Slider is disabled, so pretend the interaction is normal
+                Interaction::Normal
+            };
 
         let frame = style.frame(&ui.theme);
         let frame_2 = frame * 2.0;

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -10,7 +10,7 @@ use position::{self, Depth, Dimensions, HorizontalAlign, Position, VerticalAlign
 use theme::Theme;
 use ui::{UiId, Ui};
 use utils::{clamp, percentage, value_from_perc};
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// Linear value selection. If the slider's width is greater than it's height, it will
@@ -113,13 +113,6 @@ impl<'a, T, F> Slider<'a, T, F> {
     }
 
 }
-impl<'a, T, F> Toggleable for Slider<'a, T, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
-}
-
 
 impl<'a, T, F> Widget for Slider<'a, T, F>
     where
@@ -303,6 +296,11 @@ impl<'a, T, F> Widget for Slider<'a, T, F>
 
         // Collect the Forms into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -11,7 +11,7 @@ use position::{self, Depth, Dimensions, HorizontalAlign, Point, Position, Vertic
 use theme::Theme;
 use ui::{UiId, Ui};
 use vecmath::vec2_sub;
-use widget::{self, Widget};
+use widget::{self, Widget, Toggleable};
 
 
 pub type Idx = usize;
@@ -31,6 +31,7 @@ pub struct TextBox<'a, F> {
     depth: Depth,
     maybe_react: Option<F>,
     style: Style,
+    enabled: bool,
 }
 
 /// Styling for the TextBox, necessary for constructing its renderable Element.
@@ -298,6 +299,7 @@ impl<'a, F> TextBox<'a, F> {
             depth: 0.0,
             maybe_react: None,
             style: Style::new(),
+            enabled: true,
         }
     }
 
@@ -316,6 +318,11 @@ impl<'a, F> TextBox<'a, F> {
 
 }
 
+impl<'a, F> Toggleable for TextBox<'a, F> {
+    fn enabled(&mut self, flag: bool) {
+        self.enabled = flag;
+    }
+}
 
 impl<'a, F> Widget for TextBox<'a, F>
     where
@@ -355,7 +362,13 @@ impl<'a, F> Widget for TextBox<'a, F>
         let text_x = position::align_left_of(pad_dim[0], text_w) + TEXT_PADDING;
         let text_start_x = text_x - text_w / 2.0;
         let over_elem = over_elem(ui, mouse.xy, dim, pad_dim, text_start_x, text_w, font_size, &self.text);
-        let mut new_interaction = get_new_interaction(over_elem, state.interaction, mouse);
+        let mut new_interaction = 
+            if self.enabled {
+                get_new_interaction(over_elem, state.interaction, mouse)
+            } else {
+                //TextBox is disabled, so pretend the interaction is normal
+                Interaction::Uncaptured(Uncaptured::Normal)
+            };
 
         // Check cursor validity (and update new_interaction if necessary).
         if let Interaction::Captured(view) = new_interaction {

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -316,6 +316,12 @@ impl<'a, F> TextBox<'a, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 impl<'a, F> Widget for TextBox<'a, F>
@@ -550,11 +556,6 @@ impl<'a, F> Widget for TextBox<'a, F>
 
         // Collect the Forms into a renderable `Element`.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -11,7 +11,7 @@ use position::{self, Depth, Dimensions, HorizontalAlign, Point, Position, Vertic
 use theme::Theme;
 use ui::{UiId, Ui};
 use vecmath::vec2_sub;
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 pub type Idx = usize;
@@ -318,13 +318,6 @@ impl<'a, F> TextBox<'a, F> {
 
 }
 
-impl<'a, F> Toggleable for TextBox<'a, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
-}
-
 impl<'a, F> Widget for TextBox<'a, F>
     where
         F: FnMut(&mut String)
@@ -557,6 +550,11 @@ impl<'a, F> Widget for TextBox<'a, F>
 
         // Collect the Forms into a renderable `Element`.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -319,8 +319,9 @@ impl<'a, F> TextBox<'a, F> {
 }
 
 impl<'a, F> Toggleable for TextBox<'a, F> {
-    fn enabled(&mut self, flag: bool) {
+    fn enabled(mut self, flag: bool) -> Self {
         self.enabled = flag;
+        self
     }
 }
 

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -8,7 +8,7 @@ use mouse::Mouse;
 use position::{self, Depth, Dimensions, HorizontalAlign, Position, VerticalAlign};
 use theme::Theme;
 use ui::{UiId, Ui};
-use widget::{self, Widget};
+use widget::{self, Widget, Toggleable};
 
 
 /// A pressable widget for toggling the state of a bool. Like the button widget, it's reaction is
@@ -24,6 +24,7 @@ pub struct Toggle<'a, F> {
     maybe_react: Option<F>,
     maybe_label: Option<&'a str>,
     style: Style,
+    enabled: bool,
 }
 
 /// Styling for the Toggle, necessary for constructing its renderable Element.
@@ -95,6 +96,7 @@ impl<'a, F> Toggle<'a, F> {
             maybe_label: None,
             value: value,
             style: Style::new(),
+            enabled: true,
         }
     }
 
@@ -106,6 +108,11 @@ impl<'a, F> Toggle<'a, F> {
 
 }
 
+impl<'a, F> Toggleable for Toggle<'a, F> {
+    fn enabled(&mut self, flag: bool) {
+        self.enabled = flag;
+    }
+}
 
 impl<'a, F> Widget for Toggle<'a, F>
     where
@@ -141,7 +148,13 @@ impl<'a, F> Widget for Toggle<'a, F>
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
         let mouse = ui.get_mouse_state(ui_id);
         let is_over = is_over_rect(xy, mouse.xy, dim);
-        let new_interaction = get_new_interaction(is_over, state.interaction, mouse);
+        let new_interaction = 
+            if self.enabled {
+                get_new_interaction(is_over, state.interaction, mouse)
+            } else {
+                //This Toggle is disabled, pretend the interaction was normal.
+                Interaction::Normal
+            };
 
         // React.
         let new_value = match (is_over, state.interaction, new_interaction) {

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -106,6 +106,12 @@ impl<'a, F> Toggle<'a, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 impl<'a, F> Widget for Toggle<'a, F>
@@ -216,11 +222,6 @@ impl<'a, F> Widget for Toggle<'a, F>
 
         // Collect the Forms into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -8,7 +8,7 @@ use mouse::Mouse;
 use position::{self, Depth, Dimensions, HorizontalAlign, Position, VerticalAlign};
 use theme::Theme;
 use ui::{UiId, Ui};
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// A pressable widget for toggling the state of a bool. Like the button widget, it's reaction is
@@ -106,13 +106,6 @@ impl<'a, F> Toggle<'a, F> {
         self
     }
 
-}
-
-impl<'a, F> Toggleable for Toggle<'a, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
 }
 
 impl<'a, F> Widget for Toggle<'a, F>
@@ -223,6 +216,11 @@ impl<'a, F> Widget for Toggle<'a, F>
 
         // Collect the Forms into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -109,8 +109,9 @@ impl<'a, F> Toggle<'a, F> {
 }
 
 impl<'a, F> Toggleable for Toggle<'a, F> {
-    fn enabled(&mut self, flag: bool) {
+    fn enabled(mut self, flag: bool) -> Self {
         self.enabled = flag;
+        self
     }
 }
 

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -12,7 +12,7 @@ use theme::Theme;
 use ui::{UiId, Ui};
 use utils::{clamp, map_range, val_to_string};
 use vecmath::vec2_sub;
-use widget::{self, Widget};
+use widget::{self, Widget, Toggleable};
 
 
 /// Used for displaying and controlling a 2D point on a cartesian plane within a given range.
@@ -29,6 +29,7 @@ pub struct XYPad<'a, X, Y, F> {
     maybe_label: Option<&'a str>,
     maybe_react: Option<F>,
     style: Style,
+    enabled: bool,
 }
 
 /// Styling for the XYPad, necessary for constructing its renderable Element.
@@ -104,6 +105,7 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
             maybe_react: None,
             maybe_label: None,
             style: Style::new(),
+            enabled: true,
         }
     }
 
@@ -129,7 +131,12 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
     }
 
 }
-
+impl<'a, X, Y, F> Toggleable for XYPad<'a, X, Y, F> {
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+}
 
 impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
     where
@@ -170,7 +177,12 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
         let frame = style.frame(&ui.theme);
         let pad_dim = vec2_sub(dim, [frame * 2.0; 2]);
         let is_over_pad = is_over_rect([0.0, 0.0], mouse.xy, pad_dim);
-        let new_interaction = get_new_interaction(is_over_pad, state.interaction, mouse);
+        let new_interaction = 
+            if self.enabled {
+                get_new_interaction(is_over_pad, state.interaction, mouse)
+            } else {
+                Interaction::Normal
+            };
         let half_pad_w = pad_dim[0] / 2.0;
         let half_pad_h = pad_dim[1] / 2.0;
 

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -130,6 +130,12 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
         self
     }
 
+    /// If true, will allow user inputs.  If false, will disallow user inputs.
+    pub fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
+    }
+
 }
 
 impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
@@ -293,11 +299,6 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
 
         // Turn the form into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
-    }
-
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
     }
 
 }

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -12,7 +12,7 @@ use theme::Theme;
 use ui::{UiId, Ui};
 use utils::{clamp, map_range, val_to_string};
 use vecmath::vec2_sub;
-use widget::{self, Widget, Toggleable};
+use widget::{self, Widget};
 
 
 /// Used for displaying and controlling a 2D point on a cartesian plane within a given range.
@@ -130,12 +130,6 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
         self
     }
 
-}
-impl<'a, X, Y, F> Toggleable for XYPad<'a, X, Y, F> {
-    fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
-    }
 }
 
 impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
@@ -299,6 +293,11 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
 
         // Turn the form into a renderable Element.
         collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
+    }
+
+    fn enabled(mut self, flag: bool) -> Self {
+        self.enabled = flag;
+        self
     }
 
 }


### PR DESCRIPTION
#205 @cybergeek94 @mitchmindtree 

Implemented for all types that impl Widget (Except calling ```enabled()``` on ```Label`` which will just get ignored.)

Default state is ```true``` for all so it shouldn't break any existing code.

Tested all with examples/all_widgets.rs and it seems to work just fine.