### PR TITLE
Implemented Floating Canvas type, made `Widget::{update, draw}` pure functions and more.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 
 rust:
     - nightly
+    - beta
 
 notifications:
     irc: "irc.mozilla.org#piston-internals"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -24,6 +24,7 @@ use conrod::{
     Colorable,
     DropDownList,
     EnvelopeEditor,
+    Floating,
     Frameable,
     Label,
     Labelable,
@@ -37,6 +38,7 @@ use conrod::{
     Toggle,
     Ui,
     UiId,
+    WidgetId,
     Widget,
     WidgetMatrix,
     XYPad,
@@ -163,6 +165,9 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
     // Draw the background.
     Background::new().color(demo.bg_color).draw(ui, gl);
 
+    // Construct a floating canvas in the centre of the screen.
+    Floating::new().label("Testing...").label_color(white()).set(0, ui);
+
     // Calculate x and y coords for title (temporary until `Canvas`es are implemented, see #380).
     let title_x = demo.title_pad - (ui.win_w / 2.0) + 185.0;
     let title_y = (ui.win_h / 2.0) - 50.0;
@@ -176,7 +181,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
 
     if demo.show_button {
 
-        // Button widget example button(UiId).
+        // Button widget example button(WidgetId).
         Button::new()
             .dimensions(200.0, 50.0)
             .xy(140.0 - (ui.win_w / 2.0), title_y - 70.0)
@@ -200,7 +205,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
             text
         };
 
-        // Slider widget example slider(UiId, value, min, max).
+        // Slider widget example slider(WidgetId, value, min, max).
         Slider::new(pad as f32, 30.0, 700.0)
             .dimensions(200.0, 50.0)
             .xy(140.0 - (ui.win_w / 2.0), title_y - 70.0)
@@ -219,7 +224,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
     // Keep track of the currently shown widget.
     let shown_widget = if demo.show_button { BUTTON } else { TITLE_PAD_SLIDER };
 
-    // Toggle widget example toggle(UiId, value).
+    // Toggle widget example toggle(WidgetId, value).
     Toggle::new(demo.show_button)
         .dimensions(75.0, 75.0)
         .down(20.0)
@@ -258,7 +263,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
         let mut label = value.to_string();
         if label.len() > 4 { label.truncate(4); }
 
-        // Slider widget examples. slider(UiId, value, min, max)
+        // Slider widget examples. slider(WidgetId, value, min, max)
         if i == 0 { Slider::new(value, 0.0, 1.0).down(25.0) }
         else      { Slider::new(value, 0.0, 1.0).right(20.0) }
             .dimensions(40.0, demo.v_slider_height)
@@ -275,10 +280,10 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
 
     }
 
-    // Number Dialer widget example. number_dialer(UiId, value, min, max, precision)
+    // Number Dialer widget example. number_dialer(WidgetId, value, min, max, precision)
     NumberDialer::new(demo.v_slider_height, 25.0, 250.0, 1u8)
         .dimensions(260.0, 60.0)
-        .right_from(shown_widget, 30.0)
+        .right_from(UiId::Widget(shown_widget), 30.0)
         .color(demo.bg_color.invert())
         .frame(demo.frame_width)
         .label("Height (px)")
@@ -286,7 +291,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
         .react(|new_height| demo.v_slider_height = new_height)
         .set(SLIDER_HEIGHT, ui);
 
-    // Number Dialer widget example. number_dialer(UiId, value, min, max, precision)
+    // Number Dialer widget example. number_dialer(WidgetId, value, min, max, precision)
     NumberDialer::new(demo.frame_width, 0.0, 15.0, 2u8)
         .dimensions(260.0, 60.0)
         .down(20.0)
@@ -350,7 +355,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
     // A demonstration using drop_down_list.
     DropDownList::new(&mut demo.ddl_colors, &mut demo.selected_idx)
         .dimensions(150.0, 40.0)
-        .right_from(SLIDER_HEIGHT, 30.0) // Position right from widget 6 by 50 pixels.
+        .right_from(UiId::Widget(SLIDER_HEIGHT), 30.0) // Position right from widget 6 by 50 pixels.
         .color(ddl_color)
         .frame(demo.frame_width)
         .frame_color(ddl_color.plain_contrast())
@@ -365,7 +370,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
     XYPad::new(demo.circle_pos[0], 550.0, 700.0, // x range.
                demo.circle_pos[1], 320.0, 170.0) // y range.
         .dimensions(150.0, 150.0)
-        .right_from(TOGGLE_MATRIX + 63, 30.0)
+        .right_from(UiId::Widget(TOGGLE_MATRIX + 63), 30.0)
         .align_bottom() // Align to the bottom of the last TOGGLE_MATRIX element.
         .color(ddl_color)
         .frame(demo.frame_width)
@@ -385,7 +390,7 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
         let &mut (ref mut env, ref mut text) = &mut demo.envelopes[i];
 
         // Draw a TextBox. text_box(&mut String, FontSize)
-        if i == 0 { TextBox::new(text).right_from(COLOR_SELECT, 30.0) }
+        if i == 0 { TextBox::new(text).right_from(UiId::Widget(COLOR_SELECT), 30.0) }
         else      { TextBox::new(text) }
             .font_size(20)
             .dimensions(320.0, 40.0)
@@ -423,15 +428,15 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
 
 // As each widget must have it's own unique identifier, it can be useful to create these
 // identifiers relative to each other in order to make refactoring easier.
-const TITLE: UiId = 0;
-const BUTTON: UiId = TITLE + 1;
-const TITLE_PAD_SLIDER: UiId = BUTTON + 1;
-const TOGGLE: UiId = TITLE_PAD_SLIDER + 1;
-const COLOR_SLIDER: UiId = TOGGLE + 1;
-const SLIDER_HEIGHT: UiId = COLOR_SLIDER + 3;
-const FRAME_WIDTH: UiId = SLIDER_HEIGHT + 1;
-const TOGGLE_MATRIX: UiId = FRAME_WIDTH + 1;
-const COLOR_SELECT: UiId = TOGGLE_MATRIX + 64;
-const CIRCLE_POSITION: UiId = COLOR_SELECT + 1;
-const ENVELOPE_EDITOR: UiId = CIRCLE_POSITION + 1;
+const TITLE: WidgetId = 0;
+const BUTTON: WidgetId = TITLE + 1;
+const TITLE_PAD_SLIDER: WidgetId = BUTTON + 1;
+const TOGGLE: WidgetId = TITLE_PAD_SLIDER + 1;
+const COLOR_SLIDER: WidgetId = TOGGLE + 1;
+const SLIDER_HEIGHT: WidgetId = COLOR_SLIDER + 3;
+const FRAME_WIDTH: WidgetId = SLIDER_HEIGHT + 1;
+const TOGGLE_MATRIX: WidgetId = FRAME_WIDTH + 1;
+const COLOR_SELECT: WidgetId = TOGGLE_MATRIX + 64;
+const CIRCLE_POSITION: WidgetId = COLOR_SELECT + 1;
+const ENVELOPE_EDITOR: WidgetId = CIRCLE_POSITION + 1;
 

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -24,7 +24,6 @@ use conrod::{
     Colorable,
     DropDownList,
     EnvelopeEditor,
-    Floating,
     Frameable,
     Label,
     Labelable,
@@ -164,9 +163,6 @@ fn draw_ui<'a>(gl: &mut GlGraphics, ui: &mut Ui<GlyphCache<'a>>, demo: &mut Demo
 
     // Draw the background.
     Background::new().color(demo.bg_color).draw(ui, gl);
-
-    // Construct a floating canvas in the centre of the screen.
-    Floating::new().label("Testing...").label_color(white()).set(0, ui);
 
     // Calculate x and y coords for title (temporary until `Canvas`es are implemented, see #380).
     let title_x = demo.title_pad - (ui.win_w / 2.0) + 185.0;

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -10,7 +10,7 @@ extern crate graphics;
 extern crate piston;
 extern crate piston_window;
 
-use conrod::{CanvasId, Theme, Ui, UiId, Widget};
+use conrod::{CanvasId, Floating, Theme, Ui, Widget, WidgetId};
 use gfx_device_gl::Resources;
 use gfx_graphics::{GlyphCache, Texture};
 use glutin_window::{GlutinWindow, OpenGL};
@@ -46,7 +46,7 @@ fn main() {
     for event in window {
         ui.handle_event(&event);
         event.draw_2d(|_c, g| draw_ui(&mut ui, g));
-        ui.character_cache.update(&mut event.canvas.borrow_mut().factory);
+        ui.glyph_cache.borrow_mut().update(&mut event.canvas.borrow_mut().factory);
     }
 
 }
@@ -54,8 +54,8 @@ fn main() {
 
 // Draw the Ui.
 fn draw_ui<G: Graphics<Texture=Texture<Resources>>>(ui: &mut Ui<GlyphCache<Resources>>, g: &mut G) {
-    use conrod::color::{blue, light_orange, orange, dark_orange};
-    use conrod::{Button, Colorable, Label, Positionable, Sizeable, Split, WidgetMatrix};
+    use conrod::color::{blue, light_orange, orange, dark_orange, red, white};
+    use conrod::{Button, Colorable, Label, Labelable, Positionable, Sizeable, Split, WidgetMatrix};
 
     // Construct our Canvas tree.
     Split::new(MASTER).flow_down(&[
@@ -67,6 +67,20 @@ fn draw_ui<G: Graphics<Texture=Texture<Resources>>>(ui: &mut Ui<GlyphCache<Resou
         ]),
         Split::new(FOOTER).color(blue())
     ]).set(ui);
+
+    Floating::new()
+        .label("Blue")
+        .middle_of(LEFT_COLUMN)
+        .color(blue())
+        .label_color(white())
+        .set(FLOATING_A, ui);
+
+    Floating::new()
+        .label("Orange")
+        .middle_of(RIGHT_COLUMN)
+        .color(light_orange())
+        .label_color(white())
+        .set(FLOATING_B, ui);
 
     Label::new("Fancy Title").color(light_orange()).font_size(48).middle_of(HEADER).set(TITLE, ui);
     Label::new("Subtitle").color(blue().complement()).mid_bottom_of(HEADER).set(SUBTITLE, ui);
@@ -97,6 +111,13 @@ fn draw_ui<G: Graphics<Texture=Texture<Resources>>>(ui: &mut Ui<GlyphCache<Resou
                 .react(|| println!("Hey! {:?}", n))
                 .set(BUTTON + n, ui);
         });
+    
+    Button::new().color(red()).dimensions(30.0, 30.0).middle_of(FLOATING_A)
+        .react(|| println!("Bing!"))
+        .set(BING, ui);
+    Button::new().color(red()).dimensions(30.0, 30.0).middle_of(FLOATING_B)
+        .react(|| println!("Bong!"))
+        .set(BONG, ui);
 
     ui.draw(g);
 }
@@ -110,12 +131,15 @@ const LEFT_COLUMN: CanvasId = BODY + 1;
 const MIDDLE_COLUMN: CanvasId = LEFT_COLUMN + 1;
 const RIGHT_COLUMN: CanvasId = MIDDLE_COLUMN + 1;
 const FOOTER: CanvasId = RIGHT_COLUMN + 1;
+const FLOATING_A: CanvasId = FOOTER + 1;
+const FLOATING_B: CanvasId = FLOATING_A + 1;
 
 // Widget IDs.
-const TITLE: UiId = 0;
-const SUBTITLE: UiId = TITLE + 1;
-const TOP_LEFT: UiId = SUBTITLE + 1;
-const MIDDLE: UiId = TOP_LEFT + 1;
-const BOTTOM_RIGHT: UiId = MIDDLE + 1;
-const BUTTON: UiId = BOTTOM_RIGHT + 1;
-
+const TITLE: WidgetId = 0;
+const SUBTITLE: WidgetId = TITLE + 1;
+const TOP_LEFT: WidgetId = SUBTITLE + 1;
+const MIDDLE: WidgetId = TOP_LEFT + 1;
+const BOTTOM_RIGHT: WidgetId = MIDDLE + 1;
+const BUTTON: WidgetId = BOTTOM_RIGHT + 1;
+const BING: WidgetId = BUTTON + 24 * 8;
+const BONG: WidgetId = BING + 1;

--- a/src/canvas/floating.rs
+++ b/src/canvas/floating.rs
@@ -172,7 +172,7 @@ impl<'a> Floating<'a> {
         let maybe_mouse = ui.get_mouse_state(UiId::Canvas(id), Some(id));
         let pad = style.padding(&ui.theme);
         let title_bar_font_size = style.title_bar_font_size(&ui.theme);
-        const TITLE_BAR_LABEL_PADDING: f64 = 2.0;
+        const TITLE_BAR_LABEL_PADDING: f64 = 4.0;
         let (title_bar_h, title_bar_y) = {
             if show_title_bar {
                 let h = title_bar_font_size as f64 + TITLE_BAR_LABEL_PADDING * 2.0;
@@ -182,6 +182,9 @@ impl<'a> Floating<'a> {
                 (0.0, 0.0)
             }
         };
+
+        let widget_area_xy = [xy[0], xy[1] - title_bar_h / 2.0];
+        let widget_area_dim = [dim[0], dim[1] - title_bar_h];
 
         // If there is new mouse state, check for a new interaction.
         let new_interaction = if let Some(mouse) = maybe_mouse {
@@ -202,7 +205,8 @@ impl<'a> Floating<'a> {
         match (interaction, new_interaction) {
             (Interaction::Highlighted(Elem::TitleBar), Interaction::Clicked(Elem::TitleBar, _)) =>
                 ui.mouse_captured_by(UiId::Canvas(id)),
-            (Interaction::Clicked(Elem::TitleBar, _), _) =>
+            (Interaction::Clicked(Elem::TitleBar, _), Interaction::Highlighted(_)) |
+            (Interaction::Clicked(Elem::TitleBar, _), Interaction::Normal)         =>
                 ui.mouse_uncaptured_by(UiId::Canvas(id)),
             _ => (),
         }
@@ -264,7 +268,13 @@ impl<'a> Floating<'a> {
         };
 
         // Update the canvas within the `Ui`'s `canvas_cache`.
-        ui.update_canvas(id, Kind::Floating(new_state), new_xy, pad, Some(element));
+        ui.update_canvas(id,
+                         Kind::Floating(new_state),
+                         new_xy,
+                         widget_area_xy,
+                         widget_area_dim,
+                         pad,
+                         Some(element));
     }
 
 }

--- a/src/canvas/floating.rs
+++ b/src/canvas/floating.rs
@@ -1,0 +1,429 @@
+
+use color::Color;
+use graphics::character::CharacterCache;
+use graphics::math::Scalar;
+use label::{self, FontSize};
+use mouse::Mouse;
+use position::{self, Dimensions, HorizontalAlign, Place, Point, Position, VerticalAlign};
+use theme::Theme;
+use ui::{Ui, UiId};
+
+use super::{CanvasId, Kind};
+//use super::split::Split;
+
+/// The current state of a Floating.
+#[derive(Clone, Debug, PartialEq)]
+pub struct State {
+    interaction: Interaction,
+    xy: Point,
+    dim: Dimensions,
+}
+
+/// Describes an interaction with the Floating Canvas.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Interaction {
+    Normal,
+    Highlighted(Elem),
+    Clicked(Elem, Point),
+}
+
+/// Describes the different Elements that make up the Canvas.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Elem {
+    TitleBar,
+    WidgetArea,
+}
+
+/// A type of Canvas for flexibly designing and guiding widget layout as splits of a window.
+pub struct Floating<'a> {
+    init_dim: Dimensions,
+    init_pos: Position,
+    maybe_h_align: Option<HorizontalAlign>,
+    maybe_v_align: Option<VerticalAlign>,
+    //maybe_splits: Option<(Direction, &'a [Split<'a>])>,
+    maybe_title_bar_label: Option<&'a str>,
+    show_title_bar: bool,
+    style: Style,
+//     maybe_adjustable: Option<Adjustable>,
+}
+
+/// Describes the style of a Canvas Floating.
+#[derive(Clone, Debug, PartialEq, RustcDecodable, RustcEncodable)]
+pub struct Style {
+    maybe_color: Option<Color>,
+    maybe_frame: Option<f64>,
+    maybe_frame_color: Option<Color>,
+    maybe_title_bar_font_size: Option<FontSize>,
+    maybe_title_bar_label_align: Option<HorizontalAlign>,
+    maybe_title_bar_label_color: Option<Color>,
+    padding: Padding,
+}
+
+// /// Adjustable dimensions within these bounds.
+// #[derive(Clone, Copy, Debug, PartialEq)]
+// pub struct Adjustable {
+//     width: Bounds,
+//     height: Bounds,
+// }
+// 
+// /// The minimum and maximum for a dimension of a Floating.
+// #[derive(Clone, Copy, Debug, PartialEq)]
+// pub struct Bounds {
+//     pub min: f64,
+//     pub max: f64,
+// }
+
+/// The distance between the edge of a widget and the inner edge of a Canvas' frame.
+#[derive(Clone, Debug, PartialEq, RustcDecodable, RustcEncodable)]
+pub struct Padding {
+    maybe_top: Option<f64>,
+    maybe_bottom: Option<f64>,
+    maybe_left: Option<f64>,
+    maybe_right: Option<f64>,
+}
+
+
+impl<'a> Floating<'a> {
+
+    /// Construct a default Floating canvas.
+    pub fn new() -> Floating<'a> {
+        Floating {
+            init_dim: [160.0, 80.0],
+            init_pos: Position::Place(Place::Middle, None),
+            maybe_h_align: None,
+            maybe_v_align: None,
+            //maybe_splits: None,
+            maybe_title_bar_label: None,
+            show_title_bar: true,
+            style: Style::new(),
+        }
+    }
+
+    /// Show or hide the title bar.
+    pub fn show_title_bar(mut self, show: bool) -> Floating<'a> {
+        self.show_title_bar = show;
+        self
+    }
+
+    /// Set the padding from the left edge.
+    pub fn pad_left(mut self, pad: Scalar) -> Floating<'a> {
+        self.style.padding.maybe_left = Some(pad);
+        self
+    }
+
+    /// Set the padding from the right edge.
+    pub fn pad_right(mut self, pad: Scalar) -> Floating<'a> {
+        self.style.padding.maybe_right = Some(pad);
+        self
+    }
+
+    /// Set the padding from the top edge.
+    pub fn pad_top(mut self, pad: Scalar) -> Floating<'a> {
+        self.style.padding.maybe_top = Some(pad);
+        self
+    }
+
+    /// Set the padding from the bottom edge.
+    pub fn pad_bottom(mut self, pad: Scalar) -> Floating<'a> {
+        self.style.padding.maybe_bottom = Some(pad);
+        self
+    }
+
+    /// Set the padding for all edges.
+    pub fn pad(self, pad: Scalar) -> Floating<'a> {
+        self.pad_left(pad).pad_right(pad).pad_top(pad).pad_bottom(pad)
+    }
+
+    /// Register the Canvas within the Ui.
+    pub fn set<C>(self, id: CanvasId, ui: &mut Ui<C>)
+        where
+            C: CharacterCache
+    {
+        use elmesque::form::{collage, rect, text};
+
+        let Floating {
+            show_title_bar,
+            //ref maybe_splits,
+            ref style,
+            ref maybe_title_bar_label,
+            ..
+        } = self;
+
+        let State { interaction, xy, dim } = match ui.get_canvas_state(id) {
+            Some(Kind::Floating(state)) => state,
+            _ => {
+                let init_dim = self.init_dim;
+                let h_align = self.maybe_h_align.unwrap_or(ui.theme.align.horizontal);
+                let v_align = self.maybe_v_align.unwrap_or(ui.theme.align.vertical);
+                let init_xy = ui.get_xy(self.init_pos, init_dim, h_align, v_align);
+                State {
+                    interaction: Interaction::Normal, 
+                    xy: init_xy,
+                    dim: init_dim,
+                }
+            },
+        };
+
+        let maybe_mouse = ui.get_mouse_state(UiId::Canvas(id));
+        let pad = style.padding(&ui.theme);
+        let title_bar_font_size = style.title_bar_font_size(&ui.theme);
+        const TITLE_BAR_LABEL_PADDING: f64 = 2.0;
+        let (title_bar_h, title_bar_y) = {
+            if show_title_bar {
+                let h = title_bar_font_size as f64 + TITLE_BAR_LABEL_PADDING * 2.0;
+                let y = position::align_top_of(dim[1], h);
+                (h, y)
+            } else {
+                (0.0, 0.0)
+            }
+        };
+
+        // If there is new mouse state, check for a new interaction.
+        let new_interaction = if let Some(mouse) = maybe_mouse {
+            let is_over_elem = is_over(mouse.relative_to(xy).xy, dim, title_bar_y, title_bar_h);
+            get_new_interaction(is_over_elem, interaction, mouse)
+        } else {
+            interaction
+        };
+
+        // Drag the Canvas.
+        let new_xy = match (interaction, new_interaction) {
+            (Interaction::Clicked(Elem::TitleBar, a), Interaction::Clicked(Elem::TitleBar, b)) =>
+                ::vecmath::vec2_add(xy, ::vecmath::vec2_sub(b, a)),
+            _ => xy,
+        };
+
+        // Draw.
+        let frame = style.frame(&ui.theme);
+        let inner_dim = ::vecmath::vec2_sub(dim, [frame * 2.0; 2]);
+        let color = style.color(&ui.theme);
+        let frame_color = style.frame_color(&ui.theme);
+        let frame_form = rect(dim[0], dim[1]).filled(frame_color.alpha(0.7));
+        let rect_form = rect(inner_dim[0], inner_dim[1]).filled(color.alpha(0.7));
+        let maybe_title_bar_form = if show_title_bar {
+            let inner_dim = ::vecmath::vec2_sub([dim[0], title_bar_h], [frame * 2.0; 2]);
+            let title_bar_frame_form = rect(dim[0], title_bar_h).filled(frame_color);
+            let title_bar_rect_form = rect(inner_dim[0], inner_dim[1]).filled(color);
+            let maybe_label_form = if let Some(label) = *maybe_title_bar_label {
+                use elmesque::text::Text;
+                let label_color = style.title_bar_label_color(&ui.theme);
+                let align = style.title_bar_label_align(&ui.theme);
+                let label_width = label::width(ui, title_bar_font_size, label);
+                let label_x = align.to(inner_dim[0], label_width) + TITLE_BAR_LABEL_PADDING;
+                Some(text(Text::from_string(label.to_string())
+                             .color(label_color)
+                             .height(title_bar_font_size as f64)).shift_x(label_x))
+            } else {
+                None
+            };
+            Some(Some(title_bar_frame_form).into_iter()
+                .chain(Some(title_bar_rect_form).into_iter())
+                .chain(maybe_label_form)
+                .map(|form| form.shift_y(title_bar_y)))
+        } else {
+            None
+        };
+
+        // Chain the Canvas' Forms together.
+        let form_chain = Some(frame_form).into_iter()
+            .chain(Some(rect_form).into_iter())
+            .chain(maybe_title_bar_form.into_iter().flat_map(|it| it))
+            .map(|form| form.shift(new_xy[0], new_xy[1]));
+
+        // Construct the renderable element.
+        let element = collage(dim[0] as i32, dim[1] as i32, form_chain.collect());
+
+        // Construct the new Canvas state.
+        let new_state = State { interaction: new_interaction, xy: new_xy, dim: dim };
+
+        // Update the canvas within the `Ui`'s `canvas_cache`.
+        ui.update_canvas(id, Kind::Floating(new_state), new_xy, pad, Some(element));
+    }
+
+}
+
+
+/// Is the mouse over the canvas, if so which Elem.
+fn is_over(mouse_xy: Point,
+           dim: Dimensions,
+           title_bar_y: f64,
+           title_bar_h: f64) -> Option<Elem> {
+    use utils::is_over_rect;
+    if is_over_rect([0.0, 0.0], mouse_xy, dim) {
+        if is_over_rect([0.0, title_bar_y], mouse_xy, [dim[0], title_bar_h]) {
+            Some(Elem::TitleBar)
+        } else {
+            Some(Elem::WidgetArea)
+        }
+    } else {
+        None
+    }
+}
+
+
+/// Determine the new interaction given the mouse state and previous interaction.
+fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mouse) -> Interaction {
+    use mouse::ButtonState::{Down, Up};
+    use self::Interaction::{Normal, Highlighted, Clicked};
+    match (is_over_elem, prev, mouse.left) {
+        (Some(_),    Normal,          Down)  => Normal,
+        (Some(elem), _,               Up)    => Highlighted(elem),
+        (Some(elem), Highlighted(_),  Down)  => Clicked(elem, mouse.xy),
+        (Some(_),    Clicked(elem, _), Down) => Clicked(elem, mouse.xy),
+        (None,       Clicked(elem, _), Down) => Clicked(elem, mouse.xy),
+        _                                    => Normal,
+    }
+}
+
+
+impl Style {
+
+    /// Construct the default Style.
+    pub fn new() -> Style {
+        Style {
+            maybe_color: None,
+            maybe_frame: None,
+            maybe_frame_color: None,
+            maybe_title_bar_label_color: None,
+            maybe_title_bar_font_size: None,
+            maybe_title_bar_label_align: None,
+            padding: Padding::new()
+        }
+    }
+
+    /// Get the color for the Floating's Element.
+    pub fn color(&self, theme: &Theme) -> Color {
+        self.maybe_color.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+            style.maybe_color.unwrap_or(theme.background_color)
+        })).unwrap_or(theme.background_color)
+    }
+
+    /// Get the frame for an Element.
+    pub fn frame(&self, theme: &Theme) -> f64 {
+        self.maybe_frame.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+            style.maybe_frame.unwrap_or(theme.frame_width)
+        })).unwrap_or(theme.frame_width)
+    }
+
+    /// Get the frame Color for an Element.
+    pub fn frame_color(&self, theme: &Theme) -> Color {
+        self.maybe_frame_color.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+            style.maybe_frame_color.unwrap_or(theme.frame_color)
+        })).unwrap_or(theme.frame_color)
+    }
+
+    /// Get the Padding for the Canvas Floating.
+    pub fn padding(&self, theme: &Theme) -> position::Padding {
+        position::Padding {
+            top: self.padding.maybe_top.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+                style.padding.maybe_top.unwrap_or(theme.padding.top)
+            })).unwrap_or(theme.padding.top),
+            bottom: self.padding.maybe_bottom.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+                style.padding.maybe_bottom.unwrap_or(theme.padding.bottom)
+            })).unwrap_or(theme.padding.bottom),
+            left: self.padding.maybe_left.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+                style.padding.maybe_left.unwrap_or(theme.padding.left)
+            })).unwrap_or(theme.padding.left),
+            right: self.padding.maybe_right.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+                style.padding.maybe_right.unwrap_or(theme.padding.right)
+            })).unwrap_or(theme.padding.right),
+        }
+    }
+
+    /// Get the font size of the title bar.
+    pub fn title_bar_font_size(&self, theme: &Theme) -> FontSize {
+        self.maybe_title_bar_font_size.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+            style.maybe_title_bar_font_size.unwrap_or(theme.font_size_medium)
+        })).unwrap_or(theme.font_size_medium)
+    }
+
+    /// Get the alignment of the title bar label.
+    pub fn title_bar_label_align(&self, theme: &Theme) -> HorizontalAlign {
+        const DEFAULT_ALIGN: HorizontalAlign = HorizontalAlign::Middle;
+        self.maybe_title_bar_label_align.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+            style.maybe_title_bar_label_align.unwrap_or(DEFAULT_ALIGN)
+        })).unwrap_or(DEFAULT_ALIGN)
+    }
+
+    /// Get the color of the title bar label.
+    pub fn title_bar_label_color(&self, theme: &Theme) -> Color {
+        self.maybe_title_bar_label_color.or(theme.maybe_canvas_floating.as_ref().map(|style| {
+            style.maybe_title_bar_label_color.unwrap_or(theme.label_color)
+        })).unwrap_or(theme.label_color)
+    }
+
+}
+
+impl Padding {
+    /// Construct a defualt Padding.
+    pub fn new() -> Padding {
+        Padding {
+            maybe_top: None,
+            maybe_bottom: None,
+            maybe_left: None,
+            maybe_right: None,
+        }
+    }
+}
+
+impl<'a> ::color::Colorable for Floating<'a> {
+    fn color(mut self, color: Color) -> Self {
+        self.style.maybe_color = Some(color);
+        self
+    }
+}
+
+impl<'a> ::frame::Frameable for Floating<'a> {
+    fn frame(mut self, width: f64) -> Self {
+        self.style.maybe_frame = Some(width);
+        self
+    }
+    fn frame_color(mut self, color: Color) -> Self {
+        self.style.maybe_frame_color = Some(color);
+        self
+    }
+}
+
+impl<'a> ::position::Positionable for Floating<'a> {
+    fn position(mut self, pos: Position) -> Self {
+        self.init_pos = pos;
+        self
+    }
+    #[inline]
+    fn horizontal_align(self, h_align: HorizontalAlign) -> Self {
+        Floating { maybe_h_align: Some(h_align), ..self }
+    }
+    #[inline]
+    fn vertical_align(self, v_align: VerticalAlign) -> Self {
+        Floating { maybe_v_align: Some(v_align), ..self }
+    }
+}
+
+impl<'a> ::position::Sizeable for Floating<'a> {
+    #[inline]
+    fn width(self, w: f64) -> Self {
+        let h = self.init_dim[1];
+        Floating { init_dim: [w, h], ..self }
+    }
+    #[inline]
+    fn height(self, h: f64) -> Self {
+        let w = self.init_dim[0];
+        Floating { init_dim: [w, h], ..self }
+    }
+}
+
+impl<'a> ::label::Labelable<'a> for Floating<'a> {
+    fn label(mut self, text: &'a str) -> Self {
+        self.maybe_title_bar_label = Some(text);
+        self
+    }
+    fn label_color(mut self, color: Color) -> Self {
+        self.style.maybe_title_bar_label_color = Some(color);
+        self
+    }
+    fn label_font_size(mut self, size: FontSize) -> Self {
+        self.style.maybe_title_bar_font_size = Some(size);
+        self
+    }
+}
+

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -2,9 +2,12 @@
 use elmesque::Element;
 use position::{Padding, Point};
 
+pub mod floating;
 pub mod split;
 
-/// Unique identifier for Canvasses.
+/// Unique canvas identifier. Each canvas must use a unique `CanvasId` so that it's state can be
+/// cached within the `Ui` type. The reason we use a usize is because canvasses are cached within
+/// a `Vec`, which is limited to a size of `usize` elements.
 pub type CanvasId = usize;
 
 /// The kind of Canvas.
@@ -38,14 +41,14 @@ impl Canvas {
 }
 
 /// The different kinds of Canvases available to the user.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Kind {
     /// Represents a placeholder Canvas.
     NoCanvas,
     /// A split of another Canvas.
     Split(split::State),
-    // /// A floating / draggable Canvas.
-    // Floating(floating::State),
+    /// A floating / draggable Canvas.
+    Floating(floating::State),
 }
 
 impl Kind {
@@ -54,7 +57,9 @@ impl Kind {
         match (self, other) {
             (&Kind::NoCanvas, &Kind::NoCanvas) => true,
             (&Kind::Split(_), &Kind::Split(_)) => true,
+            (&Kind::Floating(_), &Kind::Floating(_)) => true,
             _ => false,
         }
     }
 }
+

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -1,6 +1,6 @@
 
 use elmesque::Element;
-use position::{Padding, Point};
+use position::{Dimensions, Padding, Point};
 
 pub mod floating;
 pub mod split;
@@ -19,6 +19,10 @@ pub struct Canvas {
     pub xy: Point,
     /// The Element used for drawing the Canvas.
     pub element: Element,
+    /// The position of the Widget area.
+    pub widget_area_xy: Point,
+    /// The dimensions of the Widget area.
+    pub widget_area_dim: Dimensions,
     /// Padding for the Canvas describes the distance between each edge and its Widget's.
     pub padding: Padding,
     /// Has the Canvas been set since the last time the Ui was drawn?
@@ -31,6 +35,8 @@ impl Canvas {
     pub fn empty() -> Canvas {
         Canvas {
             xy: [0.0, 0.0],
+            widget_area_xy: [0.0, 0.0],
+            widget_area_dim: [0.0, 0.0],
             element: ::elmesque::element::empty(),
             padding: Padding::none(),
             kind: Kind::NoCanvas,

--- a/src/canvas/split.rs
+++ b/src/canvas/split.rs
@@ -222,7 +222,16 @@ impl<'a> Split<'a> {
 
         let element = collage(frame_dim[0] as i32, frame_dim[1] as i32, form_chain.collect());
 
-        ui.update_canvas(id, Kind::Split(State), xy, pad, Some(element));
+        let widget_area_xy = xy;
+        let widget_area_dim = dim;
+
+        ui.update_canvas(id,
+                         Kind::Split(State),
+                         xy,
+                         widget_area_xy,
+                         widget_area_dim,
+                         pad,
+                         Some(element));
     }
 
 }

--- a/src/canvas/split.rs
+++ b/src/canvas/split.rs
@@ -23,7 +23,6 @@ pub struct Split<'a> {
     //maybe_adjustable: Option<Bounds>,
 }
 
-
 /// Describes the style of a Canvas Split.
 #[derive(Clone, Debug, PartialEq, RustcDecodable, RustcEncodable)]
 pub struct Style {
@@ -52,78 +51,9 @@ pub struct Margin {
     maybe_right: Option<f64>,
 }
 
-// /// The minimum and maximum for a dimension of a Split.
-// pub struct Bounds {
-//     pub min: f64,
-//     pub max: f64,
-// }
-
-
-impl Style {
-
-    /// Get the color for the Split's Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.maybe_canvas_split.as_ref().map(|style| {
-            style.maybe_color.unwrap_or(theme.background_color)
-        })).unwrap_or(theme.background_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.maybe_canvas_split.as_ref().map(|style| {
-            style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.maybe_canvas_split.as_ref().map(|style| {
-            style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the Padding for the Canvas Split.
-    pub fn padding(&self, theme: &Theme) -> position::Padding {
-        position::Padding {
-            top: self.padding.maybe_top.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.padding.maybe_top.unwrap_or(theme.padding.top)
-            })).unwrap_or(theme.padding.top),
-            bottom: self.padding.maybe_bottom.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.padding.maybe_bottom.unwrap_or(theme.padding.bottom)
-            })).unwrap_or(theme.padding.bottom),
-            left: self.padding.maybe_left.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.padding.maybe_left.unwrap_or(theme.padding.left)
-            })).unwrap_or(theme.padding.left),
-            right: self.padding.maybe_right.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.padding.maybe_right.unwrap_or(theme.padding.right)
-            })).unwrap_or(theme.padding.right),
-        }
-    }
-
-    /// Get the Margin for the Canvas Split.
-    pub fn margin(&self, theme: &Theme) -> position::Margin {
-        position::Margin {
-            top: self.margin.maybe_top.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.margin.maybe_top.unwrap_or(theme.margin.top)
-            })).unwrap_or(theme.margin.top),
-            bottom: self.margin.maybe_bottom.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.margin.maybe_bottom.unwrap_or(theme.margin.bottom)
-            })).unwrap_or(theme.margin.bottom),
-            left: self.margin.maybe_left.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.margin.maybe_left.unwrap_or(theme.margin.left)
-            })).unwrap_or(theme.margin.left),
-            right: self.margin.maybe_right.or(theme.maybe_canvas_split.as_ref().map(|style| {
-                style.margin.maybe_right.unwrap_or(theme.margin.right)
-            })).unwrap_or(theme.margin.right),
-        }
-    }
-
-}
-
-
 impl<'a> Split<'a> {
 
-    /// Construct a default Canvas.
+    /// Construct a default Canvas Split.
     pub fn new(id: CanvasId) -> Split<'a> {
         Split {
             id: id,
@@ -299,6 +229,7 @@ impl<'a> Split<'a> {
 
 
 impl Style {
+
     /// Construct a default Style.
     pub fn new() -> Style {
         Style {
@@ -309,6 +240,64 @@ impl Style {
             margin: Margin::new(),
         }
     }
+
+    /// Get the color for the Split's Element.
+    pub fn color(&self, theme: &Theme) -> Color {
+        self.maybe_color.or(theme.maybe_canvas_split.as_ref().map(|style| {
+            style.maybe_color.unwrap_or(theme.background_color)
+        })).unwrap_or(theme.background_color)
+    }
+
+    /// Get the frame for an Element.
+    pub fn frame(&self, theme: &Theme) -> f64 {
+        self.maybe_frame.or(theme.maybe_canvas_split.as_ref().map(|style| {
+            style.maybe_frame.unwrap_or(theme.frame_width)
+        })).unwrap_or(theme.frame_width)
+    }
+
+    /// Get the frame Color for an Element.
+    pub fn frame_color(&self, theme: &Theme) -> Color {
+        self.maybe_frame_color.or(theme.maybe_canvas_split.as_ref().map(|style| {
+            style.maybe_frame_color.unwrap_or(theme.frame_color)
+        })).unwrap_or(theme.frame_color)
+    }
+
+    /// Get the Padding for the Canvas Split.
+    pub fn padding(&self, theme: &Theme) -> position::Padding {
+        position::Padding {
+            top: self.padding.maybe_top.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.padding.maybe_top.unwrap_or(theme.padding.top)
+            })).unwrap_or(theme.padding.top),
+            bottom: self.padding.maybe_bottom.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.padding.maybe_bottom.unwrap_or(theme.padding.bottom)
+            })).unwrap_or(theme.padding.bottom),
+            left: self.padding.maybe_left.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.padding.maybe_left.unwrap_or(theme.padding.left)
+            })).unwrap_or(theme.padding.left),
+            right: self.padding.maybe_right.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.padding.maybe_right.unwrap_or(theme.padding.right)
+            })).unwrap_or(theme.padding.right),
+        }
+    }
+
+    /// Get the Margin for the Canvas Split.
+    pub fn margin(&self, theme: &Theme) -> position::Margin {
+        position::Margin {
+            top: self.margin.maybe_top.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.margin.maybe_top.unwrap_or(theme.margin.top)
+            })).unwrap_or(theme.margin.top),
+            bottom: self.margin.maybe_bottom.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.margin.maybe_bottom.unwrap_or(theme.margin.bottom)
+            })).unwrap_or(theme.margin.bottom),
+            left: self.margin.maybe_left.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.margin.maybe_left.unwrap_or(theme.margin.left)
+            })).unwrap_or(theme.margin.left),
+            right: self.margin.maybe_right.or(theme.maybe_canvas_split.as_ref().map(|style| {
+                style.margin.maybe_right.unwrap_or(theme.margin.right)
+            })).unwrap_or(theme.margin.right),
+        }
+    }
+
 }
 
 impl Padding {

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,19 +1,9 @@
 
 use color::{Color, hsl, hsla, rgb, rgba};
-use graphics::character::CharacterCache;
 use ui::Ui;
 
 /// Font size used throughout Conrod.
 pub type FontSize = u32;
-
-/// Determine the pixel width of the final text bitmap.
-#[inline]
-pub fn width<C: CharacterCache>(ui: &mut Ui<C>, size: FontSize, text: &str) -> f64 {
-    text.chars().fold(0u32, |a, ch| {
-        let character = ui.get_character(size, ch);
-        a + character.width() as u32
-    }) as f64
-}
 
 /// Widgets that may display some label.
 pub trait Labelable<'a>: Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate vecmath;
 
 
 pub use canvas::split::Split;
+pub use canvas::floating::Floating;
 
 pub use widget::button::Button;
 pub use widget::drop_down_list::DropDownList;
@@ -46,7 +47,7 @@ pub use position::{Corner, Depth, Direction, Dimensions, HorizontalAlign, Place,
                    Positionable, Sizeable, VerticalAlign};
 pub use theme::Theme;
 pub use ui::{Ui, UiId};
-pub use widget::Widget;
+pub use widget::{Widget, WidgetId};
 
 
 mod background;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use position::{align_left_of, align_right_of, align_bottom_of, align_top_of}
 pub use position::{Corner, Depth, Direction, Dimensions, HorizontalAlign, Place, Point, Position,
                    Positionable, Sizeable, VerticalAlign};
 pub use theme::Theme;
-pub use ui::{Ui, UiId};
+pub use ui::{GlyphCache, Ui, UiId, UserInput};
 pub use widget::{Widget, WidgetId};
 
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -18,9 +18,9 @@ pub type Point = [Scalar; 2];
 pub enum Position {
     /// A specific position.
     Absolute(Scalar, Scalar),
-    /// A position relative to some other widget.
+    /// A position relative to some other Ui element.
     Relative(Scalar, Scalar, Option<UiId>),
-    /// A direction relative to some other widget.
+    /// A direction relative to some other Ui element.
     Direction(Direction, Scalar, Option<UiId>),
     /// A position at a place on the current Canvas.
     Place(Place, Option<CanvasId>),
@@ -96,6 +96,9 @@ pub trait Positionable: Sized {
 
     /// Set the Position.
     fn position(self, pos: Position) -> Self;
+
+    /// Get the Position.
+    fn get_position(&self) -> Position;
 
     /// Set the position with some Point.
     fn point(self, point: Point) -> Self {

--- a/src/position.rs
+++ b/src/position.rs
@@ -337,6 +337,28 @@ pub fn align_top_of(target_height: Scalar, height: Scalar) -> Scalar {
     target_height / 2.0 - height / 2.0
 }
 
+impl HorizontalAlign {
+    /// Align `width` to the given `target_width`.
+    pub fn to(&self, target_width: Scalar, width: Scalar) -> Scalar {
+        match *self {
+            HorizontalAlign::Left => align_left_of(target_width, width),
+            HorizontalAlign::Right => align_right_of(target_width, width),
+            HorizontalAlign::Middle => 0.0,
+        }
+    }
+}
+
+impl VerticalAlign {
+    /// Align `height` to the given `target_height`.
+    pub fn to(&self, target_height: Scalar, height: Scalar) -> Scalar {
+        match *self {
+            VerticalAlign::Top => align_top_of(target_height, height),
+            VerticalAlign::Bottom => align_bottom_of(target_height, height),
+            VerticalAlign::Middle => 0.0,
+        }
+    }
+}
+
 
 /// The position of a rect with `dim` Dimensions at the middle of the `target` Dimensions.
 pub fn middle_of(_target: Dimensions, _dim: Dimensions) -> Point {
@@ -385,6 +407,23 @@ pub fn mid_left_of(target: Dimensions, dim: Dimensions) -> Point {
 /// the `target` Dimensions.
 pub fn mid_right_of(target: Dimensions, dim: Dimensions) -> Point {
     [align_right_of(target[0], dim[0]), 0.0]
+}
+
+impl Place {
+    /// Place the given `dim` within the `target_dim`.
+    pub fn within(&self, target_dim: Dimensions, dim: Dimensions) -> Point {
+        match *self {
+            Place::Middle      => middle_of(target_dim, dim),
+            Place::TopLeft     => top_left_of(target_dim, dim),
+            Place::TopRight    => top_right_of(target_dim, dim),
+            Place::BottomLeft  => bottom_left_of(target_dim, dim),
+            Place::BottomRight => bottom_right_of(target_dim, dim),
+            Place::MidTop      => mid_top_of(target_dim, dim),
+            Place::MidBottom   => mid_bottom_of(target_dim, dim),
+            Place::MidLeft     => mid_left_of(target_dim, dim),
+            Place::MidRight    => mid_right_of(target_dim, dim),
+        }
+    }
 }
 
 /// The distance between the inner edge of a frame and the outer edge of the inner content.

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,7 +1,9 @@
 
 use canvas::CanvasId;
+use graphics::character::CharacterCache;
 use graphics::math::Scalar;
-use ui::UiId;
+use theme::Theme;
+use ui::{GlyphCache, UiId};
 
 /// The depth at which the widget will be rendered. This determines the order of rendering where
 /// widgets with a greater depth will be rendered first. 0.0 is the default depth.
@@ -178,6 +180,17 @@ pub trait Positionable: Sized {
     /// Align the position vertically (only effective for Left or Right `Direction`s).
     fn vertical_align(self, align: VerticalAlign) -> Self;
 
+    /// Return the horizontal alignment.
+    fn get_horizontal_align(&self, theme: &Theme) -> HorizontalAlign;
+
+    /// Return the vertical alignment.
+    fn get_vertical_align(&self, theme: &Theme) -> VerticalAlign;
+
+    /// Return the alignment of both axis.
+    fn get_alignment(&self, theme: &Theme) -> (HorizontalAlign, VerticalAlign) {
+        (self.get_horizontal_align(theme), self.get_vertical_align(theme))
+    }
+
     /// Align the position to the left (only effective for Up or Down `Direction`s).
     fn align_left(self) -> Self {
         self.horizontal_align(HorizontalAlign::Left)
@@ -269,6 +282,14 @@ pub trait Positionable: Sized {
     /// Place the widget in the middle of the right edge of the current Canvas.
     fn mid_right(self) -> Self { self.place(Place::MidRight, None) }
 
+    ///// Rendering Depth (aka Z axis) /////
+
+    /// The depth at which the widget should be rendered.
+    fn depth(self, depth: Depth) -> Self;
+
+    /// Return the depth.
+    fn get_depth(&self) -> Depth;
+
 }
 
 /// Widgets that support different dimensions.
@@ -278,8 +299,13 @@ pub trait Sizeable: Sized {
     fn width(self, width: Scalar) -> Self;
 
     /// Set the height for the widget.
-    #[inline]
     fn height(self, height: Scalar) -> Self;
+
+    /// Get the width of the widget.
+    fn get_width<C: CharacterCache>(&self, theme: &Theme, glyph_cache: &GlyphCache<C>) -> Scalar;
+
+    /// Get the height of the widget.
+    fn get_height(&self, theme: &Theme) -> Scalar;
 
     /// Set the dimensions for the widget.
     #[inline]
@@ -291,6 +317,13 @@ pub trait Sizeable: Sized {
     #[inline]
     fn dimensions(self, width: Scalar, height: Scalar) -> Self {
         self.dim([width, height])
+    }
+
+    /// Return the dimensions for the widget.
+    fn get_dimensions<C: CharacterCache>(&self,
+                                         theme: &Theme,
+                                         glyph_cache: &GlyphCache<C>) -> Dimensions {
+        [self.get_width(theme, glyph_cache), self.get_height(theme)]
     }
 
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -42,6 +42,8 @@ pub struct Theme {
     pub font_size_small: u32,
     /// Optional style defaults for a Canvas split.
     pub maybe_canvas_split: Option<canvas::split::Style>,
+    /// Optional style defaults for a Floating Canvas.
+    pub maybe_canvas_floating: Option<canvas::floating::Style>,
     /// Optional style defaults for a Button widget.
     pub maybe_button: Option<widget::button::Style>,
     /// Optional style defaults for a DropDownList.
@@ -101,6 +103,7 @@ impl Theme {
             font_size_medium: 18,
             font_size_small: 12,
             maybe_canvas_split: None,
+            maybe_canvas_floating: None,
             maybe_button: None,
             maybe_drop_down_list: None,
             maybe_envelope_editor: None,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,5 @@
 
-use canvas::{Canvas, CanvasId};
-use canvas::Kind as CanvasKind;
+use canvas::{self, Canvas, CanvasId};
 use elmesque::Element;
 use graphics::Graphics;
 use graphics::character::{Character, CharacterCache};
@@ -18,18 +17,22 @@ use piston::event::{
 use position::{Depth, Dimensions, HorizontalAlign, Padding, Point, Position, VerticalAlign};
 use std::any::Any;
 use theme::Theme;
-use widget::{self, Widget};
+use widget::{self, Widget, WidgetId};
 use ::std::io::Write;
 
-/// User interface identifier. Each widget must use a unique `UiId` so that it's state can be
-/// cached within the `Ui` type. The reason we use a usize is because widgets are cached within
-/// a `Vec`, which is limited to a size of `usize` elements.
-pub type UiId = usize;
+/// For functions that may take either a WidgetId or a CanvasId.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
+pub enum UiId {
+    /// The ID for a Canvas.
+    Canvas(CanvasId),
+    /// The ID for a Widget.
+    Widget(WidgetId),
+}
 
 /// Indicates whether or not the Mouse has been captured by a widget.
 #[derive(Copy, Clone, Debug)]
 enum Capturing {
-    /// The Ui is captured by the widget with UiId with the mouse state `Mouse`.
+    /// The Ui is captured by the Ui element with the given UiId.
     Captured(UiId),
     /// The Ui has just been uncaptured.
     JustReleased,
@@ -66,14 +69,15 @@ pub struct Ui<C> {
     /// Window height.
     pub win_h: f64,
     /// The UiId of the previously drawn Widget.
-    maybe_prev_ui_id: Option<UiId>,
+    maybe_prev_widget_id: Option<WidgetId>,
     /// The Id of the current canvas.
     maybe_current_canvas_id: Option<CanvasId>,
     /// The captured Mouse and the UiId of the widget who has captured it.
-    maybe_captured_mouse: Option<(Capturing, Mouse)>,
+    maybe_captured_mouse: Option<Capturing>,
     /// The UiId of the widget currently keyboard input if there is one.
     maybe_captured_keyboard: Option<Capturing>
 }
+
 
 impl<C> Ui<C> {
 
@@ -93,7 +97,7 @@ impl<C> Ui<C> {
             prev_event_was_render: false,
             win_w: 0.0,
             win_h: 0.0,
-            maybe_prev_ui_id: None,
+            maybe_prev_widget_id: None,
             maybe_current_canvas_id: None,
             maybe_captured_mouse: None,
             maybe_captured_keyboard: None,
@@ -101,8 +105,8 @@ impl<C> Ui<C> {
     }
 
     /// Return the dimensions of a Canvas.
-    pub fn widget_size(&self, ui_id: UiId) -> Dimensions {
-        let (w, h) = self.widget_cache[ui_id].element.get_size();
+    pub fn widget_size(&self, id: WidgetId) -> Dimensions {
+        let (w, h) = self.widget_cache[id].element.get_size();
         [w as f64, h as f64]
     }
 
@@ -116,9 +120,9 @@ impl<C> Ui<C> {
     pub fn handle_event<E: GenericEvent>(&mut self, event: &E) {
         if self.prev_event_was_render {
             self.flush_input();
-            self.maybe_prev_ui_id = None;
+            self.maybe_prev_widget_id = None;
             self.prev_event_was_render = false;
-            if let Some((Capturing::JustReleased, _)) = self.maybe_captured_mouse {
+            if let Some(Capturing::JustReleased) = self.maybe_captured_mouse {
                 self.maybe_captured_mouse = None;
             }
             if let Some(Capturing::JustReleased) = self.maybe_captured_keyboard {
@@ -201,16 +205,16 @@ impl<C> Ui<C> {
 
     /// Return the current mouse state. If the Ui has been captured and the given ui_id doesn't
     /// match the captured ui_id, return the captured mouse state.
-    pub fn get_mouse_state(&self, ui_id: UiId) -> Mouse {
+    pub fn get_mouse_state(&self, ui_id: UiId) -> Option<Mouse> {
         match self.maybe_captured_mouse {
-            Some((Capturing::Captured(captured_ui_id), captured_mouse)) => {
+            Some(Capturing::Captured(captured_ui_id)) => {
                 match ui_id == captured_ui_id {
-                    true => self.mouse,
-                    false => captured_mouse,
+                    true => Some(self.mouse),
+                    false => None,
                 }
             },
-            Some((Capturing::JustReleased, captured_mouse)) => captured_mouse,
-            None => self.mouse,
+            Some(Capturing::JustReleased) => None,
+            None => Some(self.mouse),
         }
     }
 
@@ -241,12 +245,12 @@ impl<C> Ui<C> {
     }
 
 
-    /// Get the state of a widget with the given type and UiId.
+    /// Get the state of a widget with the given type and WidgetId.
     ///
     /// If the widget doesn't already have a position within the Cache, Create and initialise a
     /// cache position before returning None.
     pub fn get_widget_state<W>(&mut self,
-                               ui_id: UiId,
+                               id: WidgetId,
                                kind: &'static str) -> Option<widget::PrevState<W>>
         where
             W: Widget,
@@ -255,55 +259,87 @@ impl<C> Ui<C> {
     {
 
         // If the cache is not big enough, extend it.
-        if self.widget_cache.len() <= ui_id {
-            let num_to_extend = ui_id + 1 - self.widget_cache.len();
+        if self.widget_cache.len() <= id {
+            let num_to_extend = id + 1 - self.widget_cache.len();
             let extension = (0..num_to_extend).map(|_| widget::Cached::empty());
             self.widget_cache.extend(extension);
         }
 
         // If the cache is empty, return None.
-        if self.widget_cache[ui_id].kind == "EMPTY" {
+        if self.widget_cache[id].kind == "EMPTY" {
             None
         }
 
         // Else if the cache is already initialised for a widget of a different kind, warn the user.
-        else if self.widget_cache[ui_id].kind != kind {
+        else if self.widget_cache[id].kind != kind {
             writeln!(::std::io::stderr(),
                      "A widget of a different kind already exists at the given UiId ({:?}).
                       You tried to insert a {:?}, however the existing widget is a {:?}.
                       Check your widgets' `UiId`s for errors.",
-                      ui_id, kind, &self.widget_cache[ui_id].kind).unwrap();
+                      id, kind, &self.widget_cache[id].kind).unwrap();
             None
         }
 
         // Otherwise we've successfully found our state!
         else {
-            let cached_widget = &mut self.widget_cache[ui_id];
+            let cached_widget = &mut self.widget_cache[id];
             if let Some(any_state) = cached_widget.maybe_state.take() {
                 let dim = cached_widget.dim;
                 let xy = cached_widget.xy;
                 let depth = cached_widget.depth;
+                let maybe_canvas_id = cached_widget.maybe_canvas_id;
                 let store: Box<widget::Store<W::State, W::Style>> = any_state.downcast()
                     .ok().expect("Failed to downcast from Box<Any> to required widget::Store.");
                 let store: widget::Store<W::State, W::Style> = *store;
                 let widget::Store { state, style } = store;
-                Some(widget::PrevState { state: state, style: style, dim: dim, xy: xy, depth: depth })
+                Some(widget::PrevState {
+                    state: state,
+                    style: style,
+                    dim: dim,
+                    xy: xy,
+                    depth: depth,
+                    maybe_canvas_id: maybe_canvas_id,
+                })
             } else {
                 None
             }
         }
     }
 
+    
+    /// Get the state of a canvas with the given Id.
+    ///
+    /// If the canvas doesn't already have a position within the Cache, Create and initialise a
+    /// cache position before returning None.
+    pub fn get_canvas_state(&mut self, id: CanvasId) -> Option<canvas::Kind> {
+
+        // If the cache is not big enough, extend it.
+        if self.canvas_cache.len() <= id {
+            let num_to_extend = id + 1 - self.canvas_cache.len();
+            let extension = (0..num_to_extend).map(|_| Canvas::empty());
+            self.canvas_cache.extend(extension);
+        }
+
+        // If the cache is empty, return None.
+        if let &canvas::Kind::NoCanvas = &self.canvas_cache[id].kind {
+            None
+        }
+
+        // Otherwise, return the unique state of the Canvas.
+        else {
+            Some(self.canvas_cache[id].kind.clone())
+        }
+    }
 
     /// Update the given canvas.
     pub fn update_canvas(&mut self,
                          id: CanvasId,
-                         kind: CanvasKind,
+                         kind: canvas::Kind,
                          xy: Point,
                          padding: Padding,
                          maybe_new_element: Option<Element>) {
         if self.canvas_cache[id].kind.matches(&kind)
-        || self.canvas_cache[id].kind.matches(&CanvasKind::NoCanvas) {
+        || self.canvas_cache[id].kind.matches(&canvas::Kind::NoCanvas) {
             if self.canvas_cache[id].has_updated {
                 writeln!(::std::io::stderr(),
                          "Warning: The canvas with CanvasId {:?} has already been set within the \
@@ -320,7 +356,6 @@ impl<C> Ui<C> {
                 canvas.element = new_element;
             }
             canvas.has_updated = true;
-            self.maybe_current_canvas_id = Some(id);
         } else {
             panic!("A canvas of a different kind already exists at the given CanvasId ({:?}).
                     You tried to insert a {:?}, however the existing canvas is a {:?}.
@@ -332,7 +367,8 @@ impl<C> Ui<C> {
 
     /// Update the given widget at the given UiId.
     pub fn update_widget<Sta, Sty>(&mut self,
-                                   ui_id: UiId,
+                                   id: WidgetId,
+                                   maybe_canvas_id: Option<CanvasId>,
                                    kind: &'static str,
                                    store: widget::Store<Sta, Sty>,
                                    dim: Dimensions,
@@ -343,33 +379,37 @@ impl<C> Ui<C> {
             Sta: Any + ::std::fmt::Debug + 'static,
             Sty: Any + ::std::fmt::Debug + 'static,
     {
-        if self.widget_cache[ui_id].kind == kind
-        || self.widget_cache[ui_id].kind == "EMPTY" {
-            if self.widget_cache[ui_id].has_updated {
+        if self.widget_cache[id].kind == kind
+        || self.widget_cache[id].kind == "EMPTY" {
+            if self.widget_cache[id].has_updated {
                 writeln!(::std::io::stderr(),
                          "Warning: The widget with UiId {:?} has already been set within the `Ui` \
                           since the last time that `Ui::draw` was called (you probably don't want \
                           this). Perhaps check that your UiIds are correct, that you're calling \
                           `Ui::draw` after constructing your widgets and that you haven't \
-                          accidentally set the same widget twice.", ui_id).unwrap();
+                          accidentally set the same widget twice.", id).unwrap();
             }
-            let cached_widget = &mut self.widget_cache[ui_id];
+            let cached_widget = &mut self.widget_cache[id];
             let state: Box<Any> = Box::new(store);
             cached_widget.maybe_state = Some(state);
             cached_widget.kind = kind;
             cached_widget.xy = xy;
             cached_widget.dim = dim;
             cached_widget.depth = depth;
+            cached_widget.maybe_canvas_id = maybe_canvas_id.or(self.maybe_current_canvas_id);
             if let Some(new_element) = maybe_new_element {
                 cached_widget.element = new_element;
             }
             cached_widget.has_updated = true;
-            self.maybe_prev_ui_id = Some(ui_id);
+            self.maybe_prev_widget_id = Some(id);
+            if let Some(id) = cached_widget.maybe_canvas_id {
+                self.maybe_current_canvas_id = Some(id);
+            }
         } else {
             panic!("A widget of a different kind already exists at the given UiId ({:?}).
                     You tried to insert a {:?}, however the existing widget is a {:?}.
                     Check your widgets' `UiId`s for errors.",
-                    ui_id, &kind, &self.widget_cache[ui_id].kind);
+                    id, &kind, &self.widget_cache[id].kind);
         }
     }
 
@@ -385,71 +425,46 @@ impl<C> Ui<C> {
             Position::Absolute(x, y) => [x, y],
 
             Position::Relative(x, y, maybe_ui_id) => {
-                match maybe_ui_id.or(self.maybe_prev_ui_id) {
+                match maybe_ui_id.or(self.maybe_prev_widget_id.map(|id| UiId::Widget(id))) {
                     None => [0.0, 0.0],
-                    Some(rel_ui_id) => ::vecmath::vec2_add(self.widget_cache[rel_ui_id].xy, [x, y]),
+                    Some(UiId::Widget(id)) => ::vecmath::vec2_add(self.widget_cache[id].xy, [x, y]),
+                    Some(UiId::Canvas(id)) => ::vecmath::vec2_add(self.canvas_cache[id].xy, [x, y]),
                 }
             },
 
             Position::Direction(direction, px, maybe_ui_id) => {
-                use position::{align_left_of, align_right_of, align_top_of, align_bottom_of};
-                match maybe_ui_id.or(self.maybe_prev_ui_id) {
+                match maybe_ui_id.or(self.maybe_prev_widget_id.map(|id| UiId::Widget(id))) {
                     None => [0.0, 0.0],
                     Some(rel_ui_id) => {
                         use position::Direction;
-                        let rel_xy = self.widget_cache[rel_ui_id].xy;
-                        let element = &self.widget_cache[rel_ui_id].element;
+                        let (rel_xy, element) = match rel_ui_id {
+                            UiId::Widget(id) =>
+                                (self.widget_cache[id].xy, &self.widget_cache[id].element),
+                            UiId::Canvas(id) =>
+                                (self.canvas_cache[id].xy, &self.canvas_cache[id].element),
+                        };
                         let (rel_w, rel_h) = element.get_size();
                         let (rel_w, rel_h) = (rel_w as f64, rel_h as f64);
+
                         match direction {
-
-                            Direction::Up => {
-                                let x = rel_xy[0] + match h_align {
-                                    HorizontalAlign::Middle => 0.0,
-                                    HorizontalAlign::Left   => align_left_of(rel_w, dim[0]),
-                                    HorizontalAlign::Right  => align_right_of(rel_w, dim[0]),
-                                };
-                                let y = rel_xy[1] + rel_h / 2.0 + dim[1] / 2.0 + px;
-                                [x, y]
-                            },
-
-                            Direction::Down => {
-                                let x = rel_xy[0] + match h_align {
-                                    HorizontalAlign::Middle => 0.0,
-                                    HorizontalAlign::Left   => align_left_of(rel_w, dim[0]),
-                                    HorizontalAlign::Right  => align_right_of(rel_w, dim[0]),
-                                };
-                                let y = rel_xy[1] - rel_h / 2.0 - dim[1] / 2.0 - px;
-                                [x, y]
-                            },
-
-                            Direction::Left => {
-                                let y = rel_xy[1] + match v_align {
-                                    VerticalAlign::Middle => 0.0,
-                                    VerticalAlign::Bottom => align_bottom_of(rel_h, dim[1]),
-                                    VerticalAlign::Top    => align_top_of(rel_h, dim[1]),
-                                };
-                                let x = rel_xy[0] - rel_w / 2.0 - dim[0] / 2.0 - px;
-                                [x, y]
-                            },
-
-                            Direction::Right => {
-                                let y = rel_xy[1] + match v_align {
-                                    VerticalAlign::Middle => 0.0,
-                                    VerticalAlign::Bottom => align_bottom_of(rel_h, dim[1]),
-                                    VerticalAlign::Top    => align_top_of(rel_h, dim[1]),
-                                };
-                                let x = rel_xy[0] + rel_w / 2.0 + dim[0] / 2.0 + px;
-                                [x, y]
-                            },
-
+                            Direction::Up =>
+                                [rel_xy[0] + h_align.to(rel_w, dim[0]),
+                                 rel_xy[1] + rel_h / 2.0 + dim[1] / 2.0 + px],
+                            Direction::Down =>
+                                [rel_xy[0] + h_align.to(rel_w, dim[0]),
+                                 rel_xy[1] - rel_h / 2.0 - dim[1] / 2.0 - px],
+                            Direction::Left =>
+                                [rel_xy[0] - rel_w / 2.0 - dim[0] / 2.0 - px,
+                                 rel_xy[1] + v_align.to(rel_h, dim[1])],
+                            Direction::Right =>
+                                [rel_xy[0] + rel_w / 2.0 + dim[0] / 2.0 + px,
+                                 rel_xy[1] + v_align.to(rel_h, dim[1])],
                         }
                     },
                 }
             },
 
             Position::Place(place, maybe_canvas_id) => {
-                use position::{self, Place};
                 let (xy, target_dim, pad) = match maybe_canvas_id.or(self.maybe_current_canvas_id) {
                     Some(canvas_id) => {
                         let canvas = &self.canvas_cache[canvas_id];
@@ -458,17 +473,7 @@ impl<C> Ui<C> {
                     },
                     None => ([0.0, 0.0], [self.win_w, self.win_h], Padding::none()),
                 };
-                let place_xy = match place {
-                    Place::Middle      => position::middle_of(target_dim, dim),
-                    Place::TopLeft     => position::top_left_of(target_dim, dim),
-                    Place::TopRight    => position::top_right_of(target_dim, dim),
-                    Place::BottomLeft  => position::bottom_left_of(target_dim, dim),
-                    Place::BottomRight => position::bottom_right_of(target_dim, dim),
-                    Place::MidTop      => position::mid_top_of(target_dim, dim),
-                    Place::MidBottom   => position::mid_bottom_of(target_dim, dim),
-                    Place::MidLeft     => position::mid_left_of(target_dim, dim),
-                    Place::MidRight    => position::mid_right_of(target_dim, dim),
-                };
+                let place_xy = place.within(target_dim, dim);
                 let relative_xy = ::vecmath::vec2_add(place_xy, pad.offset_from(place));
                 ::vecmath::vec2_add(xy, relative_xy)
             },
@@ -479,31 +484,31 @@ impl<C> Ui<C> {
     /// Indicate that the widget with the given UiId has captured the mouse.
     pub fn mouse_captured_by(&mut self, ui_id: UiId) {
         match self.maybe_captured_mouse {
-            Some((Capturing::Captured(captured_ui_id), _)) => if ui_id != captured_ui_id {
+            Some(Capturing::Captured(captured_ui_id)) => if ui_id != captured_ui_id {
                 writeln!(::std::io::stderr(),
                         "Warning: Widget {:?} tried to capture the mouse, however it is \
                          already captured by {:?}.", ui_id, captured_ui_id).unwrap();
             },
-            Some((Capturing::JustReleased, _)) => {
+            Some(Capturing::JustReleased) => {
                 writeln!(::std::io::stderr(),
                         "Warning: Widget {:?} tried to capture the mouse, however it was \
                          already captured.", ui_id).unwrap();
             },
-            None => self.maybe_captured_mouse = Some((Capturing::Captured(ui_id), self.mouse)),
+            None => self.maybe_captured_mouse = Some(Capturing::Captured(ui_id)),
         }
     }
 
     /// Indicate that the widget is no longer capturing the mouse.
     pub fn mouse_uncaptured_by(&mut self, ui_id: UiId) {
         match self.maybe_captured_mouse {
-            Some((Capturing::Captured(captured_ui_id), mouse)) => if ui_id != captured_ui_id {
+            Some(Capturing::Captured(captured_ui_id)) => if ui_id != captured_ui_id {
                 writeln!(::std::io::stderr(),
                         "Warning: Widget {:?} tried to uncapture the mouse, however it is \
                          actually captured by {:?}.", ui_id, captured_ui_id).unwrap();
             } else {
-                self.maybe_captured_mouse = Some((Capturing::JustReleased, mouse));
+                self.maybe_captured_mouse = Some(Capturing::JustReleased);
             },
-            Some((Capturing::JustReleased, _)) => {
+            Some(Capturing::JustReleased) => {
                 writeln!(::std::io::stderr(),
                         "Warning: Widget {:?} tried to uncapture the mouse, however it had \
                          already been released this cycle.", ui_id).unwrap();
@@ -582,63 +587,82 @@ impl<C> Ui<C> {
         } = *self;
 
         // Collect references to the widgets so that we can sort them without changing cache order.
-        let mut widgets: Vec<_> = widget_cache.iter_mut()
-            .filter(|widget| widget.has_updated)
+        let mut widgets: Vec<_> = widget_cache.iter_mut().enumerate()
+            .filter(|&(_, ref widget)| widget.has_updated)
             .collect();
 
-        for widget in widgets.iter_mut() {
+        for &mut (_, ref mut widget) in widgets.iter_mut() {
             widget.has_updated = false;
         }
 
         // Check for captured widgets and take them from the Vec (we want to draw them last).
-        let maybe_mouse = self.maybe_captured_mouse.map(|(capturing, _)| capturing);
+        let maybe_mouse = self.maybe_captured_mouse;
         let maybe_keyboard = self.maybe_captured_keyboard;
-        let (maybe_mouse_widget, maybe_keyboard_widget) = match (maybe_mouse, maybe_keyboard) {
-            (Some(Capturing::Captured(mouse_ui_id)), Some(Capturing::Captured(keyboard_ui_id))) => {
-                if mouse_ui_id == keyboard_ui_id {
-                    (Some(widgets.swap_remove(mouse_ui_id)), None)
-                } else if mouse_ui_id > keyboard_ui_id {
-                    let mouse_widget = widgets.swap_remove(mouse_ui_id);
-                    let keyboard_widget = widgets.swap_remove(keyboard_ui_id);
-                    (Some(mouse_widget), Some(keyboard_widget))
-                }
-                else {
-                    let keyboard_widget = widgets.swap_remove(keyboard_ui_id);
-                    let mouse_widget = widgets.swap_remove(mouse_ui_id);
-                    (Some(mouse_widget), Some(keyboard_widget))
-                }
-            },
-            (Some(Capturing::Captured(mouse_ui_id)), _) => {
-                (Some(widgets.swap_remove(mouse_ui_id)), None)
-            },
-            (_, Some(Capturing::Captured(keyboard_ui_id))) => {
-                (None, Some(widgets.swap_remove(keyboard_ui_id)))
-            },
-            (_, _) => (None, None),
-        };
 
         // Sort the rest of the widgets by rendering depth.
-        widgets.sort_by(|a, b| if      a.depth < b.depth { Ordering::Greater }
-                               else if a.depth > b.depth { Ordering::Less }
-                               else                      { Ordering::Equal });
+        widgets.sort_by(|&(id_a, ref a), &(id_b, ref b)| {
+            match (a.maybe_canvas_id, b.maybe_canvas_id) {
+                (Some(canvas_id_a), Some(canvas_id_b)) => {
+                    match (&canvas_cache[canvas_id_a].kind, &canvas_cache[canvas_id_b].kind) {
+                        (&canvas::Kind::Split(_), &canvas::Kind::Split(_)) => (),
+                        (&canvas::Kind::Split(_), _) => return Ordering::Less,
+                        (_, &canvas::Kind::Split(_)) => return Ordering::Greater,
+                        _ => (),
+                    }
+                },
+                (Some(_), None) => return Ordering::Greater,
+                (None, Some(_)) => return Ordering::Less,
+                _ => (),
+            };
+            if let Some(Capturing::Captured(UiId::Widget(id))) = maybe_mouse {
+                if      id == id_a { return Ordering::Greater }
+                else if id == id_b { return Ordering::Less }
+            }
+            if let Some(Capturing::Captured(UiId::Widget(id))) = maybe_keyboard {
+                if      id == id_a { return Ordering::Greater }
+                else if id == id_b { return Ordering::Less }
+            }
+            if      a.depth < b.depth { Ordering::Greater }
+            else if a.depth > b.depth { Ordering::Less }
+            else                      { Ordering::Equal }
+        });
 
         // Construct the elmesque Renderer for rendering the Elements.
         let mut renderer = Renderer::new(*win_w, *win_h, graphics).character_cache(character_cache);
 
-        // Chain our widgets with the captured widgets and take their Elements.
-        let elements = widgets.iter()
-            .chain(maybe_keyboard_widget.iter())
-            .chain(maybe_mouse_widget.iter())
-            .map(|widget| &widget.element);
-
-        // Draw all Canvas Splits.
+        // First, draw all of the `Split` canvasses.
         for canvas in canvas_cache.iter().filter(|canvas| canvas.has_updated) {
-            canvas.element.draw(&mut renderer);
+            if let canvas::Kind::Split(_) = canvas.kind {
+                canvas.element.draw(&mut renderer);
+            }
         }
 
-        // Draw all Elements.
-        for element in elements {
-            element.draw(&mut renderer);
+        // Is the given widget on a Canvas Split?
+        fn is_on_split(widget: &widget::Cached, canvas_cache: &Vec<Canvas>) -> bool {
+            match widget.maybe_canvas_id {
+                None => true,
+                Some(canvas_id) => match canvas_cache[canvas_id].kind {
+                    canvas::Kind::Split(_) | canvas::Kind::NoCanvas => true,
+                    _ => false,
+                },
+            }
+        }
+
+        // Finally, draw all of the widgets that are placed on a Floating Canvas.
+        for &(_, ref widget) in widgets.iter().take_while(|&&(_, ref w)| is_on_split(w, canvas_cache)) {
+            widget.element.draw(&mut renderer);
+        }
+
+        // Now, draw all of the `Floating` canvasses.
+        for canvas in canvas_cache.iter().filter(|canvas| canvas.has_updated) {
+            if let canvas::Kind::Floating(_) = canvas.kind {
+                canvas.element.draw(&mut renderer);
+            }
+        }
+
+        // Finally, draw all of the widgets that are placed on a Floating Canvas.
+        for &(_, ref widget) in widgets.iter().skip_while(|&&(_, ref w)| is_on_split(w, canvas_cache)) {
+            widget.element.draw(&mut renderer);
         }
 
         // Indicate that the canvasses and widgets have now been drawn since the last time it was set.

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -8,7 +8,7 @@ use label::{FontSize, Labelable};
 use mouse::Mouse;
 use position::{Depth, Dimensions, HorizontalAlign, Position, Positionable, VerticalAlign};
 use theme::Theme;
-use ui::{UiId, Ui};
+use ui::{UiId, Ui, UserInput};
 use widget::{self, Widget, WidgetId};
 
 
@@ -129,13 +129,15 @@ impl<'a, F> Widget for Button<'a, F>
         State { maybe_label: None, interaction: Interaction::Normal }
     }
     fn style(&self) -> Style { self.style.clone() }
+    fn canvas_id(&self) -> Option<CanvasId> { self.maybe_canvas_id }
 
     /// Update the state of the Button.
-    fn update<C>(mut self,
-                 prev_state: &widget::State<State>,
-                 _style: &Style,
-                 id: WidgetId,
-                 ui: &mut Ui<C>) -> widget::State<Option<State>>
+    fn update<'b, C>(mut self,
+                     prev_state: &widget::State<State>,
+                     input: UserInput<'b>,
+                     _style: &Style,
+                     id: WidgetId,
+                     ui: &mut Ui<C>) -> widget::State<Option<State>>
         where
             C: CharacterCache,
     {
@@ -145,7 +147,7 @@ impl<'a, F> Widget for Button<'a, F>
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.align.horizontal);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.align.vertical);
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let maybe_mouse = ui.get_mouse_state(UiId::Widget(id)).map(|m| m.relative_to(xy));
+        let maybe_mouse = input.maybe_mouse.map(|mouse| mouse.relative_to(xy));
 
         // Check whether or not a new interaction has occurred.
         let new_interaction = match (self.enabled, maybe_mouse) {
@@ -177,17 +179,11 @@ impl<'a, F> Widget for Button<'a, F>
         // Construct the new state if there was a change.
         let maybe_new_state = if state_has_changed { Some(new_state()) } else { None };
 
-        // Retrieve the CanvasId.
-        let maybe_canvas_id = self.maybe_canvas_id.or_else(|| {
-            if let Position::Place(_, maybe_canvas_id) = self.pos { maybe_canvas_id } else { None }
-        });
-
         widget::State {
             state: maybe_new_state,
             dim: dim,
             xy: xy,
             depth: self.depth,
-            maybe_canvas_id: maybe_canvas_id,
         }
     }
 
@@ -323,6 +319,7 @@ impl<'a, F> Positionable for Button<'a, F> {
         self.pos = pos;
         self
     }
+    fn get_position(&self) -> Position { self.pos }
     #[inline]
     fn horizontal_align(self, h_align: HorizontalAlign) -> Self {
         Button { maybe_h_align: Some(h_align), ..self }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -6,7 +6,7 @@ use graphics::character::CharacterCache;
 use label::{self, FontSize};
 use position::{Depth, HorizontalAlign, Position, Positionable, VerticalAlign};
 use theme::Theme;
-use ui::Ui;
+use ui::{Ui, UserInput};
 use widget::{self, Widget, WidgetId};
 
 
@@ -72,13 +72,15 @@ impl<'a> Widget for Label<'a> {
     fn unique_kind(&self) -> &'static str { "Label" }
     fn init_state(&self) -> State { State(String::new()) }
     fn style(&self) -> Style { self.style.clone() }
+    fn canvas_id(&self) -> Option<CanvasId> { self.maybe_canvas_id }
 
     /// Update the state of the Label.
-    fn update<C>(self,
-                 prev_state: &widget::State<State>,
-                 style: &Style,
-                 _id: WidgetId,
-                 ui: &mut Ui<C>) -> widget::State<Option<State>>
+    fn update<'b, C>(self,
+                     prev_state: &widget::State<State>,
+                     _input: UserInput<'b>,
+                     style: &Style,
+                     _id: WidgetId,
+                     ui: &mut Ui<C>) -> widget::State<Option<State>>
         where
             C: CharacterCache,
     {
@@ -91,17 +93,11 @@ impl<'a> Widget for Label<'a> {
         let maybe_new_state = if &string[..] != self.text { Some(State(self.text.to_string())) }
                               else { None };
 
-        // Retrieve the CanvasId.
-        let maybe_canvas_id = self.maybe_canvas_id.or_else(|| {
-            if let Position::Place(_, maybe_canvas_id) = self.pos { maybe_canvas_id } else { None }
-        });
-
         widget::State {
             state: maybe_new_state,
             dim: dim,
             xy: xy,
             depth: self.depth,
-            maybe_canvas_id: maybe_canvas_id,
         }
     }
 
@@ -159,6 +155,7 @@ impl<'a> Positionable for Label<'a> {
         self.pos = pos;
         self
     }
+    fn get_position(&self) -> Position { self.pos }
     #[inline]
     fn horizontal_align(self, h_align: HorizontalAlign) -> Self {
         Label { maybe_h_align: Some(h_align), ..self }

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -90,6 +90,7 @@ impl position::Positionable for Matrix {
         self.pos = pos;
         self
     }
+    fn get_position(&self) -> Position { self.pos }
     #[inline]
     fn horizontal_align(self, h_align: HorizontalAlign) -> Self {
         Matrix { maybe_h_align: Some(h_align), ..self }

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -1,6 +1,8 @@
 
-use position::{self, Dimensions, HorizontalAlign, Point, Position, VerticalAlign};
-use ui::Ui;
+use graphics::character::CharacterCache;
+use position::{self, Depth, Dimensions, HorizontalAlign, Point, Position, VerticalAlign};
+use theme::Theme;
+use ui::{GlyphCache, Ui};
 
 /// Reaction params.
 pub type WidgetNum = usize;
@@ -99,6 +101,14 @@ impl position::Positionable for Matrix {
     fn vertical_align(self, v_align: VerticalAlign) -> Self {
         Matrix { maybe_v_align: Some(v_align), ..self }
     }
+    fn get_horizontal_align(&self, theme: &Theme) -> HorizontalAlign {
+        self.maybe_h_align.unwrap_or(theme.align.horizontal)
+    }
+    fn get_vertical_align(&self, theme: &Theme) -> VerticalAlign {
+        self.maybe_v_align.unwrap_or(theme.align.vertical)
+    }
+    fn depth(self, _depth: Depth) -> Self { self }
+    fn get_depth(&self) -> Depth { 0.0 }
 }
 
 impl position::Sizeable for Matrix {
@@ -112,5 +122,7 @@ impl position::Sizeable for Matrix {
         let w = self.dim[0];
         Matrix { dim: [w, h], ..self }
     }
+    fn get_width<C: CharacterCache>(&self, _theme: &Theme, _: &GlyphCache<C>) -> f64 { self.dim[0] }
+    fn get_height(&self, _theme: &Theme) -> f64 { self.dim[1] }
 }
 

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -2,7 +2,7 @@
 use graphics::character::CharacterCache;
 use position::{self, Depth, Dimensions, HorizontalAlign, Point, Position, VerticalAlign};
 use theme::Theme;
-use ui::{GlyphCache, Ui};
+use ui::{self, GlyphCache, Ui};
 
 /// Reaction params.
 pub type WidgetNum = usize;
@@ -56,6 +56,9 @@ impl Matrix {
             F: FnMut(&mut Ui<C>, WidgetNum, ColNum, RowNum, Point, Dimensions)
     {
         use utils::map_range;
+        if let Some(id) = ui.canvas_from_position(self.pos) {
+            ui::set_current_canvas_id(ui, id);
+        }
         let dim = self.dim;
         let h_align = self.maybe_h_align.unwrap_or(ui.theme.align.horizontal);
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.align.vertical);

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -1,4 +1,5 @@
 
+use canvas::CanvasId;
 use color::{Color, Colorable};
 use elmesque::Element;
 use frame::Frameable;
@@ -8,7 +9,7 @@ use mouse::Mouse;
 use position::{self, Depth, Dimensions, HorizontalAlign, Position, VerticalAlign};
 use theme::Theme;
 use ui::{UiId, Ui};
-use widget::{self, Widget};
+use widget::{self, Widget, WidgetId};
 
 
 /// A pressable widget for toggling the state of a bool. Like the button widget, it's reaction is
@@ -25,6 +26,7 @@ pub struct Toggle<'a, F> {
     maybe_label: Option<&'a str>,
     style: Style,
     enabled: bool,
+    maybe_canvas_id: Option<CanvasId>,
 }
 
 /// Styling for the Toggle, necessary for constructing its renderable Element.
@@ -97,6 +99,7 @@ impl<'a, F> Toggle<'a, F> {
             value: value,
             style: Style::new(),
             enabled: true,
+            maybe_canvas_id: None,
         }
     }
 
@@ -109,6 +112,13 @@ impl<'a, F> Toggle<'a, F> {
     /// If true, will allow user inputs.  If false, will disallow user inputs.
     pub fn enabled(mut self, flag: bool) -> Self {
         self.enabled = flag;
+        self
+    }
+
+    /// Set which Canvas to attach the Widget to. Note that you can also attach a widget to a
+    /// Canvas by using the canvas placement `Positionable` methods.
+    pub fn canvas(mut self, id: CanvasId) -> Self {
+        self.maybe_canvas_id = Some(id);
         self
     }
 
@@ -134,7 +144,7 @@ impl<'a, F> Widget for Toggle<'a, F>
     fn update<C>(mut self,
                  prev_state: &widget::State<State>,
                  _style: &Style,
-                 ui_id: UiId,
+                 id: WidgetId,
                  ui: &mut Ui<C>) -> widget::State<Option<State>>
         where
             C: CharacterCache,
@@ -146,19 +156,20 @@ impl<'a, F> Widget for Toggle<'a, F>
         let v_align = self.maybe_v_align.unwrap_or(ui.theme.align.vertical);
         let dim = self.dim;
         let xy = ui.get_xy(self.pos, dim, h_align, v_align);
-        let mouse = ui.get_mouse_state(ui_id);
-        let is_over = is_over_rect(xy, mouse.xy, dim);
-        let new_interaction = 
-            if self.enabled {
-                get_new_interaction(is_over, state.interaction, mouse)
-            } else {
-                //This Toggle is disabled, pretend the interaction was normal.
-                Interaction::Normal
-            };
+        let maybe_mouse = ui.get_mouse_state(UiId::Widget(id)).map(|m| m.relative_to(xy));
 
-        // React.
-        let new_value = match (is_over, state.interaction, new_interaction) {
-            (true, Interaction::Clicked, Interaction::Highlighted) => {
+        // Check whether or not a new interaction has occurred.
+        let new_interaction = match (self.enabled, maybe_mouse) {
+            (false, _) | (true, None) => Interaction::Normal,
+            (true, Some(mouse)) => {
+                let is_over = is_over_rect([0.0, 0.0], mouse.xy, dim);
+                get_new_interaction(is_over, state.interaction, mouse)
+            },
+        };
+
+        // React and determine the new value.
+        let new_value = match (state.interaction, new_interaction) {
+            (Interaction::Clicked, Interaction::Highlighted) => {
                 let new_value = !self.value;
                 if let Some(ref mut react) = self.maybe_react { react(!self.value) }
                 new_value
@@ -183,7 +194,18 @@ impl<'a, F> Widget for Toggle<'a, F>
         // Construct the new state if there was a change.
         let maybe_new_state = if state_has_changed { Some(new_state()) } else { None };
 
-        widget::State { state: maybe_new_state, dim: dim, xy: xy, depth: self.depth }
+        // Retrieve the CanvasId.
+        let maybe_canvas_id = self.maybe_canvas_id.or_else(|| {
+            if let Position::Place(_, maybe_canvas_id) = self.pos { maybe_canvas_id } else { None }
+        });
+
+        widget::State {
+            state: maybe_new_state,
+            dim: dim,
+            xy: xy,
+            depth: self.depth,
+            maybe_canvas_id: maybe_canvas_id,
+        }
     }
 
     /// Construct an Element from the given Toggle State.


### PR DESCRIPTION
The main change here is that we now have a draggable canvas type! See the updated canvas.rs example for a demo. It's still missing a few features (scroll-ability, resizing, position bounds) but it's a nice start :)

Also, #424 has been implemented now so the `Widget` trait's update and draw signatures have changed.

See the commit messages for any more details.

Closes #424, #380 and #430 