### PR TITLE
Expose Scalar from top level, add extra alignment methods to the `Positionable` trait.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -56,19 +56,25 @@ Getting Started
 
 Build the conrod lib like this:
 
-    git clone https://github.com/PistonDevelopers/conrod.git
-    cd conrod
-    cargo build
+```
+git clone https://github.com/PistonDevelopers/conrod.git
+cd conrod
+cargo build
+```
 
 And then build and run the examples like this:
 
-    cargo run --example all_widgets
-    cargo run --example canvas
+```
+cargo run --example all_widgets
+cargo run --example canvas
+```
 
 You can add it to your project by adding this to your Cargo.toml:
 
-    [dependencies]
-    conrod = "*"
+```toml
+[dependencies]
+conrod = "*"
+```
 
 ## Dependencies
 

--- a/src/canvas/floating.rs
+++ b/src/canvas/floating.rs
@@ -5,7 +5,8 @@ use graphics::character::CharacterCache;
 use graphics::math::Scalar;
 use label::FontSize;
 use mouse::Mouse;
-use position::{self, Depth, Dimensions, HorizontalAlign, Place, Point, Position, VerticalAlign};
+use position::{self, Depth, Dimensions, Horizontal, HorizontalAlign, Place, Point, Position,
+               VerticalAlign};
 use theme::Theme;
 use ui::{self, GlyphCache, Ui, UiId};
 
@@ -57,7 +58,7 @@ pub struct Style {
     maybe_frame: Option<f64>,
     maybe_frame_color: Option<Color>,
     maybe_title_bar_font_size: Option<FontSize>,
-    maybe_title_bar_label_align: Option<HorizontalAlign>,
+    maybe_title_bar_label_align: Option<Horizontal>,
     maybe_title_bar_label_color: Option<Color>,
     padding: Padding,
 }
@@ -370,8 +371,8 @@ impl Style {
     }
 
     /// Get the alignment of the title bar label.
-    pub fn title_bar_label_align(&self, theme: &Theme) -> HorizontalAlign {
-        const DEFAULT_ALIGN: HorizontalAlign = HorizontalAlign::Middle;
+    pub fn title_bar_label_align(&self, theme: &Theme) -> Horizontal {
+        const DEFAULT_ALIGN: Horizontal = Horizontal::Middle;
         self.maybe_title_bar_label_align.or(theme.maybe_canvas_floating.as_ref().map(|style| {
             style.maybe_title_bar_label_align.unwrap_or(DEFAULT_ALIGN)
         })).unwrap_or(DEFAULT_ALIGN)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub use elmesque::color;
 pub use elmesque::color::{Color, Colorable};
 pub use frame::{Framing, Frameable};
 pub use graphics::character::CharacterCache;
+pub use graphics::math::Scalar;
 pub use label::{FontSize, Labelable};
 pub use mouse::Mouse;
 pub use mouse::ButtonState as MouseButtonState;
@@ -58,8 +59,9 @@ pub use mouse::Scroll as MouseScroll;
 pub use position::{align_left_of, align_right_of, align_bottom_of, align_top_of};
 pub use position::{middle_of, top_left_of, top_right_of, bottom_left_of, bottom_right_of,
                    mid_top_of, mid_bottom_of, mid_left_of, mid_right_of};
-pub use position::{Corner, Depth, Direction, Dimensions, HorizontalAlign, Margin, Padding,
-                   Place, Point, Position, Positionable, Sizeable, VerticalAlign};
+pub use position::{Corner, Depth, Direction, Dimensions, Horizontal, HorizontalAlign, Margin,
+                   Padding, Place, Point, Position, Positionable, Sizeable, Vertical,
+                   VerticalAlign};
 pub use theme::{Align, Theme};
 pub use ui::{GlyphCache, Ui, UiId, UserInput};
 pub use widget::{Widget, WidgetId};

--- a/src/position.rs
+++ b/src/position.rs
@@ -48,9 +48,13 @@ pub enum Direction {
     Right,
 }
 
-/// The horizontal alignment of a widget positioned relatively to another widget on the y axis.
+/// The horizontal alignment of a widget positioned relatively to another UI element on the y axis.
 #[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable, PartialEq, Eq)]
-pub enum HorizontalAlign {
+pub struct HorizontalAlign(pub Horizontal, pub Option<UiId>);
+
+/// The orientation of a HorizontalAlign.
+#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable, PartialEq, Eq)]
+pub enum Horizontal {
     /// Align the left edges of the widgets.
     Left,
     /// Align the centres of the widgets' closest parallel edges.
@@ -59,9 +63,13 @@ pub enum HorizontalAlign {
     Right,
 }
 
-/// The vertical alignment of a widget positioned relatively to another widget on the x axis.
+/// The vertical alignment of a widget positioned relatively to another UI element on the x axis.
 #[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable, PartialEq, Eq)]
-pub enum VerticalAlign {
+pub struct VerticalAlign(pub Vertical, pub Option<UiId>);
+
+/// The orientation of a VerticalAlign.
+#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable, PartialEq, Eq)]
+pub enum Vertical {
     /// Align the top edges of the widgets.
     Top,
     /// Align the centres of the widgets' closest parallel edges.
@@ -193,33 +201,64 @@ pub trait Positionable: Sized {
 
     /// Align the position to the left (only effective for Up or Down `Direction`s).
     fn align_left(self) -> Self {
-        self.horizontal_align(HorizontalAlign::Left)
+        self.horizontal_align(HorizontalAlign(Horizontal::Left, None))
     }
 
     /// Align the position to the middle (only effective for Up or Down `Direction`s).
     fn align_middle_x(self) -> Self {
-        self.horizontal_align(HorizontalAlign::Middle)
+        self.horizontal_align(HorizontalAlign(Horizontal::Middle, None))
     }
 
     /// Align the position to the right (only effective for Up or Down `Direction`s).
     fn align_right(self) -> Self {
-        self.horizontal_align(HorizontalAlign::Right)
+        self.horizontal_align(HorizontalAlign(Horizontal::Right, None))
     }
 
     /// Align the position to the top (only effective for Left or Right `Direction`s).
     fn align_top(self) -> Self {
-        self.vertical_align(VerticalAlign::Top)
+        self.vertical_align(VerticalAlign(Vertical::Top, None))
     }
 
     /// Align the position to the middle (only effective for Left or Right `Direction`s).
     fn align_middle_y(self) -> Self {
-        self.vertical_align(VerticalAlign::Middle)
+        self.vertical_align(VerticalAlign(Vertical::Middle, None))
     }
 
     /// Align the position to the bottom (only effective for Left or Right `Direction`s).
     fn align_bottom(self) -> Self {
-        self.vertical_align(VerticalAlign::Bottom)
+        self.vertical_align(VerticalAlign(Vertical::Bottom, None))
     }
+
+    /// Align the position to the left (only effective for Up or Down `Direction`s).
+    fn align_left_of(self, other: UiId) -> Self {
+        self.horizontal_align(HorizontalAlign(Horizontal::Left, Some(other)))
+    }
+
+    /// Align the position to the middle (only effective for Up or Down `Direction`s).
+    fn align_middle_x_of(self, other: UiId) -> Self {
+        self.horizontal_align(HorizontalAlign(Horizontal::Middle, Some(other)))
+    }
+
+    /// Align the position to the right (only effective for Up or Down `Direction`s).
+    fn align_right_of(self, other: UiId) -> Self {
+        self.horizontal_align(HorizontalAlign(Horizontal::Right, Some(other)))
+    }
+
+    /// Align the position to the top (only effective for Left or Right `Direction`s).
+    fn align_top_of(self, other: UiId) -> Self {
+        self.vertical_align(VerticalAlign(Vertical::Top, Some(other)))
+    }
+
+    /// Align the position to the middle (only effective for Left or Right `Direction`s).
+    fn align_middle_y_of(self, other: UiId) -> Self {
+        self.vertical_align(VerticalAlign(Vertical::Middle, Some(other)))
+    }
+
+    /// Align the position to the bottom (only effective for Left or Right `Direction`s).
+    fn align_bottom_of(self, other: UiId) -> Self {
+        self.vertical_align(VerticalAlign(Vertical::Bottom, Some(other)))
+    }
+
 
     ///// `Place` methods. /////
 
@@ -373,24 +412,24 @@ pub fn align_top_of(target_height: Scalar, height: Scalar) -> Scalar {
     target_height / 2.0 - height / 2.0
 }
 
-impl HorizontalAlign {
+impl Horizontal {
     /// Align `width` to the given `target_width`.
     pub fn to(&self, target_width: Scalar, width: Scalar) -> Scalar {
         match *self {
-            HorizontalAlign::Left => align_left_of(target_width, width),
-            HorizontalAlign::Right => align_right_of(target_width, width),
-            HorizontalAlign::Middle => 0.0,
+            Horizontal::Left => align_left_of(target_width, width),
+            Horizontal::Right => align_right_of(target_width, width),
+            Horizontal::Middle => 0.0,
         }
     }
 }
 
-impl VerticalAlign {
+impl Vertical {
     /// Align `height` to the given `target_height`.
     pub fn to(&self, target_height: Scalar, height: Scalar) -> Scalar {
         match *self {
-            VerticalAlign::Top => align_top_of(target_height, height),
-            VerticalAlign::Bottom => align_bottom_of(target_height, height),
-            VerticalAlign::Middle => 0.0,
+            Vertical::Top => align_top_of(target_height, height),
+            Vertical::Bottom => align_bottom_of(target_height, height),
+            Vertical::Middle => 0.0,
         }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,7 +5,7 @@
 use canvas;
 use color::{Color, black, white};
 use json_io;
-use position::{Margin, Padding, Position, HorizontalAlign, VerticalAlign};
+use position::{Margin, Padding, Position, Horizontal, HorizontalAlign, Vertical, VerticalAlign};
 use rustc_serialize::Encodable;
 use std::error::Error;
 use std::path::Path;
@@ -92,8 +92,8 @@ impl Theme {
             },
             position: Position::default(),
             align: Align {
-                horizontal: HorizontalAlign::Left,
-                vertical: VerticalAlign::Top,
+                horizontal: HorizontalAlign(Horizontal::Left, None),
+                vertical: VerticalAlign(Vertical::Top, None),
             },
             background_color: black(),
             shape_color: white(),


### PR DESCRIPTION
See #490 and #495.