### PR TITLE
Fix issue where cursor idx would be outside of text range if text cleared during react function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -163,6 +163,7 @@ fn cursor_position<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
                                       font_size: FontSize,
                                       text: &str) -> CursorX {
     assert!(idx <= text.chars().count());
+
     if idx == 0 {
          return text_start_x;
     }
@@ -472,6 +473,10 @@ impl<'a, F> Widget for TextBox<'a, F>
                 }
             }
 
+            // In case the string text was mutated with the `react` function, we need to make sure
+            // the cursor is limited to the current number of chars.
+            cursor.limit_end_to(self.text.chars().count());
+
             new_interaction = Interaction::Captured(View { cursor: cursor, .. captured });
         }
 
@@ -522,6 +527,7 @@ impl<'a, F> Widget for TextBox<'a, F>
                 Anchor::End => cursor.start,
                 Anchor::Start | Anchor::None => cursor.end,
             };
+
             let cursor_x = cursor_position(glyph_cache, cursor_idx, text_start_x, font_size, &state.text);
 
             let cursor_form = if cursor.is_cursor() {


### PR DESCRIPTION
Closes #517 