### PR TITLE
Added `Ui::draw_if_changed` (big speedup!), updated examples and readme. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.7.2"
+version = "0.7.3"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Available Widgets
 -----------------
 
 - Button
+- Canvas (Can be positioned manually or by using Splits or Tabs)
 - Drop Down List
 - Envelope Editor
 - Label
@@ -33,7 +34,7 @@ Available Widgets
 - TextBox
 - Toggle
 - XYPad
-- Custom: Conrod also provides a `Widget` trait for designing and implementing custom widgets. All [internal widgets](https://github.com/PistonDevelopers/conrod/blob/master/src/widget) also use this same trait so they should make for decent examples. If you feel like your widget is useful enough to be included within the internal widget library, feel free add them in a pull request :)
+- Custom: Conrod also provides a `Widget` trait for designing and implementing custom widgets. You can find an annotated demonstration of designing a custom widget implementation [here](https://github.com/PistonDevelopers/conrod/blob/master/examples/custom_widget.rs). All [internal widgets](https://github.com/PistonDevelopers/conrod/blob/master/src/widget) also use this same trait so they should make for decent examples. If you feel like your widget is useful enough to be included within the internal widget library, feel free to add them in a pull request :)
 
 **To-do:**
 - [Menu Bar / Tool Bar](https://github.com/PistonDevelopers/conrod/issues/417)
@@ -44,6 +45,8 @@ Available Widgets
 - [Advanced graph visualisation and control](https://github.com/PistonDevelopers/mush)
 
 If conrod is missing anything you really wish it had, let us know with an issue describing the widget's style, behaviour and functionality - or even better, submit a pull request :D
+
+Make sure you check the [`widget` label](https://github.com/PistonDevelopers/conrod/labels/widget) for your desired widget first as it may have already been requested.
 
 Dependencies
 ------------
@@ -82,7 +85,6 @@ conrod = "*"
 
 ## Conrod uses Elmesque
 
-Conrod uses [Elmesque](https://github.com/mitchmindtree/elmesque) under the hood. You
-don't need to know about Elmesque to use Conrod. But if you want to combine Conrod with
-your own custom Elmesque drawing, see
-[the example](https://github.com/PistonDevelopers/conrod/blob/master/examples/elmesque.rs).
+Conrod uses [Elmesque](https://github.com/mitchmindtree/elmesque) under the hood for its 2D
+graphics and layout. You don't need to know about Elmesque to use Conrod. But if you want to
+combine Conrod with your own custom Elmesque drawing, see [the example](https://github.com/PistonDevelopers/conrod/blob/master/examples/elmesque.rs).

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -165,8 +165,8 @@ fn main() {
 /// Draw the User Interface.
 fn draw_ui(c: Context, gl: &mut GlGraphics, ui: &mut Ui, demo: &mut DemoApp) {
 
-    // Draw the background.
-    Background::new().color(demo.bg_color).draw(ui, gl);
+    // Sets a color to clear the background with before the Ui draws the widgets.
+    Background::new().color(demo.bg_color).set(ui);
 
     // Calculate x and y coords for title (temporary until `Canvas`es are implemented, see #380).
     let title_x = demo.title_pad - (ui.win_w / 2.0) + 185.0;
@@ -345,13 +345,6 @@ fn draw_ui(c: Context, gl: &mut GlGraphics, ui: &mut Ui, demo: &mut DemoApp) {
         None => purple(),
     };
 
-    // Draw the circle that's controlled by the XYPad.
-    graphics::Ellipse::new(ddl_color.to_fsa())
-        .draw([demo.circle_pos[0], demo.circle_pos[1], 30.0, 30.0],
-              graphics::default_draw_state(),
-              graphics::math::abs_transform(ui.win_w, ui.win_h),
-              gl);
-
     // A demonstration using drop_down_list.
     DropDownList::new(&mut demo.ddl_colors, &mut demo.selected_idx)
         .dimensions(150.0, 40.0)
@@ -422,7 +415,18 @@ fn draw_ui(c: Context, gl: &mut GlGraphics, ui: &mut Ui, demo: &mut DemoApp) {
     }
 
     // Draw our Ui!
-    ui.draw(c, gl);
+    // The `draw_if_changed` method only re-draws the GUI if some state has changed or if
+    // `ui.needs_redraw();` was called.
+    // If you need to re-draw your conrod GUI every frame, use `Ui::draw`.
+    ui.draw_if_changed(c, gl);
+
+
+    // Draw the circle that's controlled by the XYPad.
+    graphics::Ellipse::new(ddl_color.to_fsa())
+        .draw([demo.circle_pos[0], demo.circle_pos[1], 30.0, 30.0],
+              graphics::default_draw_state(),
+              graphics::math::abs_transform(ui.win_w, ui.win_h),
+              gl);
 
 }
 

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -117,7 +117,7 @@ fn draw_ui(ui: &mut Ui, c: Context, g: &mut G2d) {
         .react(|| println!("Bong!"))
         .set(BONG, ui);
 
-    ui.draw(c, g);
+    ui.draw_if_changed(c, g);
 }
 
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -40,8 +40,8 @@ fn main() {
         if let Some(args) = event.render_args() {
             gl.draw(args.viewport(), |c, gl| {
 
-                // Draw the background.
-                Background::new().rgb(0.2, 0.25, 0.4).draw(ui, gl);
+                // Set the background color to use for clearing the screen.
+                Background::new().rgb(0.2, 0.25, 0.4).set(ui);
 
                 // Draw the button and increment count if pressed..
                 Button::new()
@@ -52,7 +52,7 @@ fn main() {
                     .set(0, ui);
 
                 // Draw our Ui!
-                ui.draw(c, gl);
+                ui.draw_if_changed(c, gl);
 
             });
         }

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -523,7 +523,7 @@ fn main() {
                 // drawn when we call Ui::draw.
                 .set(CIRCLE_BUTTON, &mut ui);
             
-            ui.draw(c, g);
+            ui.draw_if_changed(c, g);
         });
     }
 }

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! Demonstration of custom widgets. Although this file is long, much of the code is
 //! boilerplate that can be copied to almost any custom widget. For the most interesting
 //! parts, search for:
@@ -8,10 +8,10 @@
 //! - `fn update`
 //! - `fn is_over_circ`
 //! - `fn get_new_interaction`
-//! 
+//!
 //! As of July 28, 2015, this is broken on retina displays due to
 //! https://github.com/tomaka/glutin/issues/503.
-//! 
+//!
 
 extern crate piston_window;
 extern crate graphics;
@@ -25,12 +25,12 @@ extern crate rustc_serialize;
 use conrod::WidgetId;
 
 mod circular_button {
-    use elmesque::{self, Element};
     use conrod::{
         Color,
         Colorable,
         CommonBuilder,
         DrawArgs,
+        Element,
         FontSize,
         GlyphCache,
         Labelable,
@@ -46,7 +46,7 @@ mod circular_button {
     use vecmath::{vec2_sub, vec2_len};
     use graphics::math::Scalar;
 
-    
+
     pub struct CircularButton<'a, F> {
         /// An object that handles some of the dirty work of rendering a GUI. We don't
         /// really have to worry about it.
@@ -62,7 +62,7 @@ mod circular_button {
         /// user input.
         enabled: bool
     }
-    
+
     #[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
     pub struct Style {
         /// Color of the button.
@@ -74,7 +74,7 @@ mod circular_button {
         /// Font size of the button's label.
         pub maybe_label_font_size: Option<u32>,
     }
-    
+
     /// Represents the state of the CircularButton widget.
     #[derive(Clone, Debug, PartialEq)]
     pub struct State {
@@ -84,7 +84,7 @@ mod circular_button {
         /// between interaction states.
         interaction: Interaction,
     }
-    
+
     impl State {
         /// Alter the widget color depending on the state.
         fn color(&self, color: Color) -> Color {
@@ -101,7 +101,7 @@ mod circular_button {
             }
         }
     }
-    
+
     /// Represents an interaction with the CircularButton widget.
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub enum Interaction {
@@ -109,7 +109,7 @@ mod circular_button {
         Highlighted,
         Clicked,
     }
-    
+
     /// Check the current state of the button. Takes into account whether the mouse is
     /// over the button and the previous interaction state.
     fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
@@ -120,29 +120,29 @@ mod circular_button {
             // update. This means the user clicked somewhere outside the button and
             // moved over the button holding LMB down. We do nothing in this case.
             (true,  Normal,  Down) => Normal,
-            
+
             // LMB is down over the button. The button was either Highlighted or Clicked
             // last update. If it was highlighted before, that means the user clicked
             // just now, and we transition to the Clicked state. If it was clicked
             // before, that means the user is still holding LMB down from a previous
             // click, in which case the state remains Clicked.
             (true,  _,       Down) => Clicked,
-            
+
             // LMB is up. The mouse is hovering over the button. Regardless of what the
             // state was last update, the state should definitely be Highlighted now.
             (true,  _,       Up)   => Highlighted,
-            
+
             // LMB is down, the mouse is not over the button, but the previous state was
             // Clicked. That means the user clicked the button and then moved the mouse
             // outside the button while holding LMB down. The button stays Clicked.
             (false, Clicked, Down) => Clicked,
-            
+
             // If none of the above applies, then nothing interesting is happening with
             // this button.
             _                      => Normal,
         }
     }
-    
+
     impl<'a, F> CircularButton<'a, F> {
         /// Create a button context to be built upon.
         pub fn new() -> CircularButton<'a, F> {
@@ -171,20 +171,20 @@ mod circular_button {
             self
         }
     }
-    
+
     /// Return whether or not a given point is over a circle at a given point on a
     /// Cartesian plane. We use this to determine whether the mouse is over the button.
     pub fn is_over_circ(circ_center: Point, mouse_point: Point, dim: Dimensions) -> bool {
         // Offset vector from the center of the circle to the mouse.
         let offset = vec2_sub(mouse_point, circ_center);
-        
+
         // If the length of the offset vector is less than or equal to the circle's
         // radius, then the mouse is inside the circle. We assume that dim is a square
         // bounding box around the circle, thus 2 * radius == dim[0] == dim[1].
         vec2_len(offset) <= dim[0] / 2.0
     }
 
-    
+
     /// A custom Conrod widget must implement the Widget trait. See
     /// conrod/src/widget/mod.rs for comments on each required type and method.
     impl<'a, F> Widget for CircularButton<'a, F>
@@ -192,10 +192,10 @@ mod circular_button {
     {
         /// The State struct that we defined above.
         type State = State;
-        
+
         /// The Style struct that we defined above.
         type Style = Style;
-        
+
         fn common(&self) -> &CommonBuilder { &self.common }
         fn common_mut(&mut self) -> &mut CommonBuilder { &mut self.common }
         fn unique_kind(&self) -> &'static str { "CircularButton" }
@@ -216,7 +216,7 @@ mod circular_button {
                 _ => false,
             }
         }
-        
+
         /// Whether the button should uncapture the mouse.
         fn uncapture_mouse(prev: &State, new: &State) -> bool {
             match (prev.interaction, new.interaction) {
@@ -227,12 +227,12 @@ mod circular_button {
                 _ => false,
             }
         }
-        
+
         /// Default width of the widget. This method is optional. The Widget trait
         /// provides a default implementation that always returns zero.
         fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
             const DEFAULT_WIDTH: Scalar = 64.0;
-            
+
             // Defaults can come from several places. Here, we define how certain defaults
             // take precedence over others.
             self.common.maybe_width
@@ -246,7 +246,7 @@ mod circular_button {
         /// provides a default implementation that always returns zero.
         fn default_height(&self, theme: &Theme) -> Scalar {
             const DEFAULT_HEIGHT: Scalar = 64.0;
-            
+
             // See default_width for comments on this logic.
             self.common.maybe_height
                 .or(theme.maybe_button.as_ref().map(|default| {
@@ -273,10 +273,10 @@ mod circular_button {
                     // local coordinate system. Because mouse.xy is in local coords,
                     // we must also pass the circle center in local coords. Thus we pass
                     // [0.0, 0.0] as the center.
-                    // 
+                    //
                     // See above where we define is_over_circ.
                     let is_over = is_over_circ([0.0, 0.0], mouse.xy, dim);
-                    
+
                     // See above where we define get_new_interaction.
                     get_new_interaction(is_over, state.interaction, mouse)
                 },
@@ -303,7 +303,7 @@ mod circular_button {
                     // stores either an &str or None. If there's something there, we
                     // copy the &str into an owned String for the State object.
                     maybe_label: self.maybe_label.as_ref().map(|label| label.to_string()),
-                    
+
                     // We constructed new_interaction above. This is the interaction state
                     // as of this update.
                     interaction: new_interaction,
@@ -322,7 +322,7 @@ mod circular_button {
                     .map(|string| &string[..])
                     // Compare the current Option<&str> to the previous one.
                     != self.maybe_label;
-            
+
             // Construct and return the new state if there was a change. Recall that we
             // defined new_state above.
             if state_has_changed { Some(new_state()) } else { None }
@@ -333,21 +333,22 @@ mod circular_button {
         fn draw<'b, C>(args: DrawArgs<'b, Self, C>) -> Element
             where C: CharacterCache,
         {
+            use elmesque;
             use elmesque::form::{collage, circle, text};
-            
+
             // Unwrap the args and state structs into individual variables.
             let DrawArgs { state, style, theme, .. } = args;
             let WidgetState { ref state, dim, xy, .. } = *state;
-            
+
             // Retrieve the styling for the Element.
             let color = state.color(style.color(theme));
-            
+
             // Construct the frame and inner rectangle forms. We assume that dim is a
             // square bounding box, thus 2 * radius == dim[0] == dim[1].
             let radius = dim[0] / 2.0;
             let pressable_form: elmesque::Form =
                 circle(radius).filled(color);
-            
+
             // Construct the label's Form. Recall that State has maybe_label,
             // which stores either a String or None.
             let maybe_label_form: Option<elmesque::Form> =
@@ -363,7 +364,7 @@ mod circular_button {
                         .color(label_color).height(size as f64))
                         .shift(xy[0].floor(), xy[1].floor())
                 });
-            
+
             // Construct the button's Form.
             let form_chain =
                 // An Option can be converted into an Iterator. We do this because we want
@@ -380,7 +381,7 @@ mod circular_button {
                 // maybe_label_form as the last element. If our widget had more forms,
                 // we could add them with additional calls to chain.
                 .chain(maybe_label_form);
-            
+
             // We now have an Iterator containing all our Option<elmesque::Form>s. Turn
             // the forms into a renderable elmesque::Element.
             collage(
@@ -395,7 +396,7 @@ mod circular_button {
         }
 
     }
-    
+
     impl Style {
         /// Construct the default Style.
         pub fn new() -> Style {
@@ -428,7 +429,7 @@ mod circular_button {
             })).unwrap_or(theme.font_size_medium)
         }
     }
-    
+
     /// Provide the chainable color() configuration method.
     impl<'a, F> Colorable for CircularButton<'a, F> {
         fn color(mut self, color: Color) -> Self {
@@ -436,7 +437,7 @@ mod circular_button {
             self
         }
     }
-    
+
     /// Provide the chainable label(), label_color(), and label_font_size()
     /// configuration methods.
     impl<'a, F> Labelable<'a> for CircularButton<'a, F> {
@@ -469,24 +470,24 @@ fn main() {
         Widget
     };
     use gfx_graphics::GlyphCache;
-    
+
     use circular_button::CircularButton;
-    
+
     let opengl_version = piston_window::OpenGL::V3_2;
-    
+
     let window_settings = WindowSettings::new(
           "Control Panel",
             [1200, 800]
         )
         .opengl(opengl_version)
         .exit_on_esc(true);
-    
+
     // PistonWindow has two type parameters, but the default type is
     // PistonWindow<T = (), W: Window = GlutinWindow>. To change the Piston backend,
     // specify a different type in the let binding, e.g.
     // let window: PistonWindow<(), Sdl2Window>.
     let window: PistonWindow = window_settings.into();
-    
+
     // Load a font. GlyphCache is provided by gfx_graphics. Other Piston backends provide
     // similar types.
     let assets = find_folder::Search::ParentsThenKids(3, 3)
@@ -496,24 +497,24 @@ fn main() {
         &font_path,
         window.factory.borrow().clone()
     ).unwrap();
-    
+
     // Conrod's main object.
-    let mut ui = conrod::Ui::new(
-        glyph_cache, conrod::Theme::default()
-    );
-    
+    let mut ui = conrod::Ui::new(glyph_cache, conrod::Theme::default());
+
     for e in window {
         // Invoke Conrod's user input handler.
-        ui.handle_event(&e.event.clone().unwrap());
-        
+        ui.handle_event(e.event.as_ref().unwrap());
+
         e.draw_2d(|c, g| {
+
+            // Sets a color to clear the background with before the Ui draws our widget.
+            conrod::Background::new().color(conrod::color::rgb(0.2, 0.1, 0.1)).set(&mut ui);
+
             // Create an instance of our custom widget.
             CircularButton::new()
-                // elmesque::color is also re-exported as conrod::color, so we could use
-                // it by that name too.
-                .color(elmesque::color::rgb(0.0, 0.3, 0.1))
+                .color(conrod::color::rgb(0.0, 0.3, 0.1))
                 .dimensions(256.0, 256.0)
-                .label_color(elmesque::color::white())
+                .label_color(conrod::color::white())
                 .label("Circular Button")
                 .react(|| {
                     // This is called when the user clicks the button.
@@ -522,10 +523,12 @@ fn main() {
                 // Add the widget to the conrod::Ui. This schedules the widget it to be
                 // drawn when we call Ui::draw.
                 .set(CIRCLE_BUTTON, &mut ui);
-            
+
+            // Draws the whole Ui (in this case, just our widget) whenever a change occurs.
             ui.draw_if_changed(c, g);
         });
     }
 }
 
+// The WidgetId we'll use to plug our widget into the `Ui`.
 const CIRCLE_BUTTON: WidgetId = 0;

--- a/examples/elmesque.rs
+++ b/examples/elmesque.rs
@@ -118,7 +118,7 @@ fn main() {
                 .set(SLIDER, &mut ui);
             
             // Draw all Conrod widgets. (We only have one in this instance.)
-            ui.draw(c, g); 
+            ui.draw_if_changed(c, g); 
         });
         
         e.update(|args| {

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,8 +1,7 @@
 
 use color::{Color, Colorable};
-use graphics::{self, Graphics};
 use graphics::character::CharacterCache;
-use ui::Ui;
+use ui::{self, Ui};
 
 /// A type for drawing a colored window background.
 #[derive(Copy, Clone)]
@@ -19,14 +18,10 @@ impl Background {
         }
     }
 
-    /// Draw the background.
-    pub fn draw<B, C>(&mut self, ui: &mut Ui<C>, graphics: &mut B)
-        where
-            B: Graphics<Texture = <C as CharacterCache>::Texture>,
-            C: CharacterCache
-    {
+    /// Set the color used clear the background with before drawing widgets.
+    pub fn set<C>(&mut self, ui: &mut Ui<C>) where C: CharacterCache {
         let color = self.maybe_color.unwrap_or(ui.theme.background_color);
-        graphics::clear(color.to_fsa(), graphics);
+        ui::clear_with(ui, color);
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use widget::xy_pad::Style as XYPadStyle;
 
 
 pub use background::Background;
-pub use elmesque::color;
+pub use elmesque::{color, Element};
 pub use elmesque::color::{Color, Colorable};
 pub use frame::{Framing, Frameable};
 pub use graphics::character::CharacterCache;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,6 +72,9 @@ pub struct Ui<C> {
     maybe_captured_mouse: Option<Capturing>,
     /// The WidgetId of the widget currently capturing keyboard input if there is one.
     maybe_captured_keyboard: Option<Capturing>,
+    /// The number of frames that that will be used for the `redraw_count` when `need_redraw` is
+    /// triggered.
+    num_redraw_frames: u8,
     /// Whether or not the `Ui` needs to be re-drawn to screen.
     redraw_count: u8,
     /// A background color to clear the screen with before drawing if one was given.
@@ -145,6 +148,7 @@ impl<C> Ui<C> {
             maybe_widget_under_mouse: None,
             maybe_captured_mouse: None,
             maybe_captured_keyboard: None,
+            num_redraw_frames: SAFE_REDRAW_COUNT,
             redraw_count: SAFE_REDRAW_COUNT,
             maybe_background_color: None,
         }
@@ -336,11 +340,17 @@ impl<C> Ui<C> {
     }
 
 
+    /// Set the number of frames that the `Ui` should draw in the case that `needs_redraw` is
+    /// called. The default is `3` (see the SAFE_REDRAW_COUNT docs for details).
+    pub fn set_num_redraw_frames(&mut self, num_frames: u8) {
+        self.num_redraw_frames = num_frames;
+    }
+
     /// Tells the `Ui` that it needs to be re-draw everything. It does this by setting the redraw
     /// count to a `SAFE_REDRAW_COUNT`. See the docs for SAFE_REDRAW_COUNT or `draw_if_changed` for
     /// more info on how/why the redraw count is used.
     pub fn needs_redraw(&mut self) {
-        self.redraw_count = SAFE_REDRAW_COUNT;
+        self.redraw_count = self.num_redraw_frames;
     }
 
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -434,6 +434,10 @@ pub trait Widget: Sized {
 
         // Construct the widget's element.
         let maybe_new_element = if style_has_changed || state_has_changed {
+
+            // Inform the `Ui` that we'll need a redraw.
+            ui.needs_redraw();
+
             let args = DrawArgs {
                 state: &new_state,
                 style: &new_style,


### PR DESCRIPTION
Using `draw_if_changed` (in --release mode), both `canvas` and `all_widgets` examples avg at about %6.5 on my machine now as opposed to the ~25% when using `.draw` (yaaay :tada:)

Also added some hefty docs to `.draw` and `.draw_if_changed` to clarify the use case for each.

I also changed the behaviour of `Background` so that rather than drawing at its call site, it just stores the color in the `Ui` to be used for clearing the screen when `Ui::draw` is called. This stops it from drawing over the top of the widgets when using `ui.draw_if_needed`.

Closes #530 