### PR TITLE
Add documentation link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
+documentation = "http://docs.piston.rs/conrod/conrod/"
 
 
 [lib]


### PR DESCRIPTION
The documentation link is currently not available on the crates.io page. This commit should add the proper link to the project page on crates.io.