### PR TITLE
Massively simplify `DropDownList` by composing it from other `Widget`s. Tweak Widget API with lessons learned.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.15.1"
+version = "0.16.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -355,7 +355,7 @@ fn draw_ui(c: Context, gl: &mut GlGraphics, ui: &mut Ui, demo: &mut DemoApp) {
         .frame_color(ddl_color.plain_contrast())
         .label("Colors")
         .label_color(ddl_color.plain_contrast())
-        .react(|selected_idx: &mut Option<usize>, new_idx, _string| {
+        .react(|selected_idx: &mut Option<usize>, new_idx, _string: &str| {
             *selected_idx = Some(new_idx)
         })
         .set(COLOR_SELECT, ui);

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -112,9 +112,9 @@ mod circular_button {
     /// Check the current state of the button. Takes into account whether the mouse is
     /// over the button and the previous interaction state.
     fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
-        use conrod::MouseButtonState::{Down, Up};
+        use conrod::MouseButtonPosition::{Down, Up};
         use self::Interaction::{Normal, Highlighted, Clicked};
-        match (is_over, prev, mouse.left) {
+        match (is_over, prev, mouse.left.position) {
             // LMB is down over the button. But the button wasn't Highlighted last
             // update. This means the user clicked somewhere outside the button and
             // moved over the button holding LMB down. We do nothing in this case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub use graphics::math::Scalar;
 pub use label::{FontSize, Labelable};
 pub use mouse::Mouse;
 pub use mouse::ButtonState as MouseButtonState;
+pub use mouse::ButtonPosition as MouseButtonPosition;
 pub use mouse::Scroll as MouseScroll;
 pub use position::{align_left_of, align_right_of, align_bottom_of, align_top_of};
 pub use position::{middle_of, top_left_of, top_right_of, bottom_left_of, bottom_right_of,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub use background::Background;
 pub use elmesque::{color, Element};
 pub use elmesque::color::{Color, Colorable};
 pub use frame::{Framing, Frameable};
+pub use graph::NodeIndex;
 pub use graphics::character::CharacterCache;
 pub use graphics::math::Scalar;
 pub use label::{FontSize, Labelable};

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -6,12 +6,23 @@
 
 use position::Point;
 
+/// The current state of a Mouse button.
+#[derive(Copy, Clone, Debug)]
+pub struct ButtonState {
+    /// The button has been pressed since the last update.
+    pub was_just_pressed: bool,
+    /// The button has been released since the last update.
+    pub was_just_released: bool,
+    /// The current position of the button.
+    pub position: ButtonPosition,
+}
+
 /// Represents the current state of a mouse button.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ButtonState {
-    /// The mouse is currently up.
+pub enum ButtonPosition {
+    /// The mouse button is currently up.
     Up,
-    /// The mouse is currently down (pressed).
+    /// The mouse button is currently down (pressed).
     Down,
 }
 
@@ -41,19 +52,37 @@ pub struct Scroll {
     pub y: f64,
 }
 
+
+impl ButtonState {
+
+    /// Constructor for a default ButtonState.
+    pub fn new() -> ButtonState {
+        ButtonState {
+            was_just_released: false,
+            was_just_pressed: false,
+            position: ButtonPosition::Up,
+        }
+    }
+
+    /// Reset the `was_just_released` and `was_just_pressed` flags.
+    pub fn reset_pressed_and_released(&mut self) {
+        self.was_just_released = false;
+        self.was_just_pressed = false;
+    }
+
+}
+
+
 impl Mouse {
 
-    /// Constructor for a Mouse struct.
-    pub fn new(xy: Point,
-               left: ButtonState,
-               middle: ButtonState,
-               right: ButtonState) -> Mouse {
+    /// Constructor for a default Mouse struct.
+    pub fn new() -> Mouse {
         Mouse {
-            xy: xy,
-            left: left,
-            middle: middle,
-            right: right,
-            unknown: ButtonState::Up,
+            xy: [0.0, 0.0],
+            left: ButtonState::new(),
+            middle: ButtonState::new(),
+            right: ButtonState::new(),
+            unknown: ButtonState::new(),
             scroll: Scroll { x: 0.0, y: 0.0 },
         }
     }
@@ -64,3 +93,4 @@ impl Mouse {
     }
 
 }
+

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -275,12 +275,10 @@ impl<C> Ui<C> {
                     None => [0.0, 0.0],
                     Some(rel_idx) => {
                         use position::Direction;
-                        let (rel_xy, element) = {
+                        let (rel_xy, rel_w, rel_h) = {
                             let widget = &self.widget_graph[rel_idx];
-                            (widget.xy, &widget.element)
+                            (widget.xy, widget.dim[0], widget.dim[1])
                         };
-                        let (rel_w, rel_h) = element.get_size();
-                        let (rel_w, rel_h) = (rel_w as f64, rel_h as f64);
 
                         match direction {
 
@@ -660,14 +658,14 @@ pub fn get_mouse_state<C>(ui: &Ui<C>, idx: widget::Index) -> Option<Mouse> {
 pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
     match ui.maybe_captured_mouse {
         Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
-            writeln!(::std::io::stderr(),
-                    "Warning: {:?} tried to capture the mouse, however it is \
-                     already captured by {:?}.", idx, captured_idx).unwrap();
+            //writeln!(::std::io::stderr(),
+            //        "Warning: {:?} tried to capture the mouse, however it is \
+            //         already captured by {:?}.", idx, captured_idx).unwrap();
         },
         Some(Capturing::JustReleased) => {
-            writeln!(::std::io::stderr(),
-                    "Warning: {:?} tried to capture the mouse, however it was \
-                     already captured.", idx).unwrap();
+            //writeln!(::std::io::stderr(),
+            //        "Warning: {:?} tried to capture the mouse, however it was \
+            //         already captured.", idx).unwrap();
         },
         None => ui.maybe_captured_mouse = Some(Capturing::Captured(idx)),
     }
@@ -678,21 +676,21 @@ pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
 pub fn mouse_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
     match ui.maybe_captured_mouse {
         Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
-            writeln!(::std::io::stderr(),
-                    "Warning: {:?} tried to uncapture the mouse, however it is \
-                     actually captured by {:?}.", idx, captured_idx).unwrap();
+            //writeln!(::std::io::stderr(),
+            //        "Warning: {:?} tried to uncapture the mouse, however it is \
+            //         actually captured by {:?}.", idx, captured_idx).unwrap();
         } else {
             ui.maybe_captured_mouse = Some(Capturing::JustReleased);
         },
         Some(Capturing::JustReleased) => {
-            writeln!(::std::io::stderr(),
-                    "Warning: {:?} tried to uncapture the mouse, however it had \
-                     already been released this cycle.", idx).unwrap();
+            //writeln!(::std::io::stderr(),
+            //        "Warning: {:?} tried to uncapture the mouse, however it had \
+            //         already been released this cycle.", idx).unwrap();
         },
         None => {
-            writeln!(::std::io::stderr(),
-                    "Warning: {:?} tried to uncapture the mouse, however the mouse \
-                     was not captured", idx).unwrap();
+            //writeln!(::std::io::stderr(),
+            //        "Warning: {:?} tried to uncapture the mouse, however the mouse \
+            //         was not captured", idx).unwrap();
         },
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,7 +5,7 @@ use graph::Graph;
 use graphics::{Context, Graphics};
 use graphics::character::CharacterCache;
 use label::FontSize;
-use mouse::{ButtonState, Mouse, Scroll};
+use mouse::{self, Mouse};
 use input;
 use input::{
     GenericEvent,
@@ -24,7 +24,7 @@ use widget::{self, Widget, WidgetId};
 
 
 /// Indicates whether or not the Mouse has been captured by a widget.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Capturing {
     /// The Ui is captured by the Ui element with the given WidgetId.
     Captured(widget::Index),
@@ -87,8 +87,10 @@ pub struct Ui<C> {
 /// A wrapper over the current user input state.
 #[derive(Clone, Debug)]
 pub struct UserInput<'a> {
-    /// Mouse state if it is available.
+    /// Mouse state only if it is currently available to the widget after considering capturing.
     pub maybe_mouse: Option<Mouse>,
+    /// The universal state of the Mouse, regardless of capturing.
+    pub global_mouse: Mouse,
     /// Keys pressed since the last cycle.
     pub pressed_keys: &'a [input::keyboard::Key],
     /// Keys released since the last cycle.
@@ -139,7 +141,7 @@ impl<C> Ui<C> {
         Ui {
             widget_graph: Graph::with_capacity(GRAPH_CAPACITY),
             theme: theme,
-            mouse: Mouse::new([0.0, 0.0], ButtonState::Up, ButtonState::Up, ButtonState::Up),
+            mouse: Mouse::new(),
             keys_just_pressed: Vec::with_capacity(10),
             keys_just_released: Vec::with_capacity(10),
             text_just_entered: Vec::with_capacity(10),
@@ -172,16 +174,25 @@ impl<C> Ui<C> {
 
         // The `Ui` tracks various things during a frame - we'll reset those things here.
         if self.prev_event_was_render {
+            self.prev_event_was_render = false;
 
-            // Flush input.
+            // Clear text and key buffers.
             self.keys_just_pressed.clear();
             self.keys_just_released.clear();
             self.text_just_entered.clear();
-            self.mouse.scroll = Scroll { x: 0.0, y: 0.0 };
+
+            // Reset the mouse state.
+            self.mouse.scroll = mouse::Scroll { x: 0.0, y: 0.0 };
+            self.mouse.left.reset_pressed_and_released();
+            self.mouse.middle.reset_pressed_and_released();
+            self.mouse.right.reset_pressed_and_released();
+            self.mouse.unknown.reset_pressed_and_released();
 
             self.maybe_prev_widget_idx = None;
             self.maybe_current_parent_idx = None;
-            self.prev_event_was_render = false;
+
+            // If the mouse / keyboard capturing was just released by a widget, reset to None ready
+            // for capturing once again.
             if let Some(Capturing::JustReleased) = self.maybe_captured_mouse {
                 self.maybe_captured_mouse = None;
             }
@@ -215,12 +226,14 @@ impl<C> Ui<C> {
 
             match button_type {
                 Button::Mouse(button) => {
-                    *match button {
+                    let mouse_button = match button {
                         Left => &mut self.mouse.left,
                         Right => &mut self.mouse.right,
                         Middle => &mut self.mouse.middle,
                         _ => &mut self.mouse.unknown,
-                    } = ButtonState::Down;
+                    };
+                    mouse_button.position = mouse::ButtonPosition::Down;
+                    mouse_button.was_just_pressed = true;
                 },
                 Button::Keyboard(key) => self.keys_just_pressed.push(key),
             }
@@ -228,14 +241,17 @@ impl<C> Ui<C> {
 
         event.release(|button_type| {
             use input::Button;
-            use input::MouseButton::Left;
+            use input::MouseButton::{Left, Middle, Right};
             match button_type {
                 Button::Mouse(button) => {
-                    *match button {
+                    let mouse_button = match button {
                         Left => &mut self.mouse.left,
-                        _/*input::mouse::Right*/ => &mut self.mouse.right,
-                        //Middle => &mut self.mouse.middle,
-                    } = ButtonState::Up;
+                        Right => &mut self.mouse.right,
+                        Middle => &mut self.mouse.middle,
+                        _ => &mut self.mouse.unknown,
+                    };
+                    mouse_button.position = mouse::ButtonPosition::Up;
+                    mouse_button.was_just_released = true;
                 },
                 Button::Keyboard(key) => self.keys_just_released.push(key),
             }
@@ -606,8 +622,10 @@ pub fn parent_from_position<C>(ui: &Ui<C>, position: Position) -> Option<widget:
 /// Take into consideration whether or not each input type is captured.
 pub fn user_input<'a, C>(ui: &'a Ui<C>, idx: widget::Index) -> UserInput<'a> {
     let maybe_mouse = get_mouse_state(ui, idx);
+    let global_mouse = ui.mouse;
     let without_keys = || UserInput {
         maybe_mouse: maybe_mouse,
+        global_mouse: global_mouse,
         pressed_keys: &[],
         released_keys: &[],
         entered_text: &[],
@@ -615,6 +633,7 @@ pub fn user_input<'a, C>(ui: &'a Ui<C>, idx: widget::Index) -> UserInput<'a> {
     };
     let with_keys = || UserInput {
         maybe_mouse: maybe_mouse,
+        global_mouse: global_mouse,
         pressed_keys: &ui.keys_just_pressed,
         released_keys: &ui.keys_just_released,
         entered_text: &ui.text_just_entered,
@@ -656,42 +675,18 @@ pub fn get_mouse_state<C>(ui: &Ui<C>, idx: widget::Index) -> Option<Mouse> {
 
 /// Indicate that the widget with the given WidgetId has captured the mouse.
 pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
-    match ui.maybe_captured_mouse {
-        Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
-            //writeln!(::std::io::stderr(),
-            //        "Warning: {:?} tried to capture the mouse, however it is \
-            //         already captured by {:?}.", idx, captured_idx).unwrap();
-        },
-        Some(Capturing::JustReleased) => {
-            //writeln!(::std::io::stderr(),
-            //        "Warning: {:?} tried to capture the mouse, however it was \
-            //         already captured.", idx).unwrap();
-        },
-        None => ui.maybe_captured_mouse = Some(Capturing::Captured(idx)),
+    // If the mouse isn't already captured, set idx as the capturing widget.
+    if let None = ui.maybe_captured_mouse {
+        ui.maybe_captured_mouse = Some(Capturing::Captured(idx));
     }
 }
 
 
 /// Indicate that the widget is no longer capturing the mouse.
 pub fn mouse_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
-    match ui.maybe_captured_mouse {
-        Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
-            //writeln!(::std::io::stderr(),
-            //        "Warning: {:?} tried to uncapture the mouse, however it is \
-            //         actually captured by {:?}.", idx, captured_idx).unwrap();
-        } else {
-            ui.maybe_captured_mouse = Some(Capturing::JustReleased);
-        },
-        Some(Capturing::JustReleased) => {
-            //writeln!(::std::io::stderr(),
-            //        "Warning: {:?} tried to uncapture the mouse, however it had \
-            //         already been released this cycle.", idx).unwrap();
-        },
-        None => {
-            //writeln!(::std::io::stderr(),
-            //        "Warning: {:?} tried to uncapture the mouse, however the mouse \
-            //         was not captured", idx).unwrap();
-        },
+    // Check that we are indeed the widget that is currently capturing the Mouse before releasing.
+    if ui.maybe_captured_mouse == Some(Capturing::Captured(idx)) {
+        ui.maybe_captured_mouse = Some(Capturing::JustReleased)
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -17,7 +17,8 @@ pub struct Button<'a, F> {
     common: widget::CommonBuilder,
     maybe_label: Option<&'a str>,
     maybe_react: Option<F>,
-    style: Style,
+    /// Unique styling for the Button.
+    pub style: Style,
     enabled: bool,
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -68,9 +68,9 @@ impl State {
 
 /// Check the current state of the button.
 fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left) {
+    match (is_over, prev, mouse.left.position) {
         (true,  Normal,  Down) => Normal,
         (true,  _,       Down) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -421,9 +421,9 @@ fn is_over(mouse_xy: Point,
 
 /// Determine the new interaction given the mouse state and previous interaction.
 fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over_elem, prev, mouse.left) {
+    match (is_over_elem, prev, mouse.left.position) {
         (Some(_),    Normal,          Down)  => Normal,
         (Some(elem), _,               Up)    => Highlighted(elem),
         (Some(elem), Highlighted(_),  Down)  => Clicked(elem, mouse.xy),

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -34,7 +34,7 @@ pub fn drag_widget(xy: Point,
                    mouse: Mouse) -> (Point, State)
 {
     use self::State::{Normal, Highlighted, Clicked};
-    use mouse::ButtonState::{Up, Down};
+    use mouse::ButtonPosition::{Up, Down};
     use utils::is_over_rect;
 
     // Find the absolute position of the draggable area.
@@ -44,7 +44,7 @@ pub fn drag_widget(xy: Point,
     let is_over = is_over_rect(abs_area_xy, mouse.xy, area.dim);
 
     // Determine the new drag state.
-    let new_state = match (is_over, state, mouse.left) {
+    let new_state = match (is_over, state, mouse.left.position) {
         (true,  Normal,     Down) => Normal,
         (true,  _,          Up)   => Highlighted,
         (true,  _,          Down) |

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -25,9 +25,6 @@ pub type Idx = usize;
 /// The number of items in a list.
 pub type Len = usize;
 
-/// The width of the scrollbar when visible.
-pub const SCROLLBAR_WIDTH: f64 = 10.0;
-
 /// Displays a given `Vec<String>` as a selectable drop down menu. It's reaction is triggered upon
 /// selection of a list item.
 pub struct DropDownList<'a, F> {

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -1,4 +1,10 @@
 
+use ::{
+    Button,
+    ButtonStyle,
+    Canvas,
+    NodeIndex,
+};
 use color::{Color, Colorable};
 use elmesque::Element;
 use frame::Frameable;
@@ -6,7 +12,7 @@ use graphics::character::CharacterCache;
 use graphics::math::Scalar;
 use label::{FontSize, Labelable};
 use mouse::Mouse;
-use position::{self, Dimensions, Point, Positionable};
+use position::{self, Dimensions, Point, Positionable, Sizeable};
 use theme::Theme;
 use ui::GlyphCache;
 use widget::{self, Widget};
@@ -55,19 +61,9 @@ pub struct Style {
 pub struct State {
     menu_state: MenuState,
     maybe_label: Option<String>,
-    strings: Vec<String>,
+    buttons: Vec<(NodeIndex, String)>,
     maybe_selected: Option<Idx>,
-}
-
-/// Position of the scroll bar and the height at which it appears.
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Scroll {
-    /// The current position of the scroll bar as y-axis offset from top.
-    y_offset: Scalar,
-    /// The maximum offset for the handle given the number of items.
-    max_offset: Scalar,
-    /// The maximum height for the display before scrollbar appears.
-    max_visible_height: Scalar,
+    maybe_canvas_idx: Option<NodeIndex>,
 }
 
 /// Representations of the max height of the visible area of the DropDownList.
@@ -80,235 +76,8 @@ pub enum MaxHeight {
 /// Whether the DropDownList is currently open or closed.
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum MenuState {
-    Closed(Interaction),
-    Open(Interaction, Option<Scroll>),
-}
-
-/// Describes how the DropDownList is currently being interacted with.
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub enum Interaction {
-    Normal,
-    Highlighted(Elem),
-    Clicked(Elem),
-}
-
-/// The different elements that make up the Open DropDownList.
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub enum Elem {
-    ScrollBar(ScrollBar),
-    Item(Idx)
-}
-
-/// The elements that make up a ScrollBar.
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub enum ScrollBar {
-    /// The draggable bar and the mouse's position.
-    Handle(Point),
-    /// The track along which the bar can be dragged.
-    Track(Point),
-}
-
-impl Interaction {
-    fn color(&self, color: Color) -> Color {
-        match *self {
-            Interaction::Normal => color,
-            Interaction::Highlighted(_) => color.highlighted(),
-            Interaction::Clicked(_) => color.clicked(),
-        }
-    }
-}
-
-
-/// Is the cursor currently over the widget? If so, which Elem?
-fn is_over(mouse_pos: Point,
-           frame_w: f64,
-           dim: Dimensions,
-           menu_state: MenuState,
-           len: Len,
-           maybe_scroll: Option<(Scalar, Scalar, Scalar)>) -> Option<Elem> {
-    use utils::is_over_rect;
-    match menu_state {
-
-        MenuState::Closed(_) => match is_over_rect([0.0, 0.0], mouse_pos, dim) {
-            false => None,
-            true => Some(Elem::Item(0)),
-        },
-
-        MenuState::Open(ref interaction, _) => {
-            let item_h = dim[1] - frame_w;
-            let total_h = item_h * len as f64;
-
-            // If the menu is scrollable.
-            if let Some((y_offset, track_h, max_offset)) = maybe_scroll {
-                //let centre_y = -(track_h - item_h) / 2.0;
-                let middle_y = item_h / 2.0 - track_h / 2.0;
-                match *interaction {
-                    Interaction::Highlighted(_) | Interaction::Clicked(_) => {
-                        let scroll_x = position::align_right_of(dim[0], SCROLLBAR_WIDTH);
-                        let handle_h = (track_h / total_h) * track_h;
-                        let handle_y = middle_y + position::align_top_of(track_h, handle_h) - y_offset;
-                        let handle_dim = [SCROLLBAR_WIDTH, handle_h];
-                        let track_dim = [SCROLLBAR_WIDTH, track_h];
-                        if is_over_rect([scroll_x, handle_y], mouse_pos, handle_dim) {
-                            return Some(Elem::ScrollBar(ScrollBar::Handle(mouse_pos)));
-                        } else if is_over_rect([scroll_x, middle_y], mouse_pos, track_dim) {
-                            return Some(Elem::ScrollBar(ScrollBar::Track(mouse_pos)));
-                        }
-                    }
-                    _ => (),
-                }
-                match is_over_rect([0.0, middle_y], mouse_pos, [dim[0], track_h]) {
-                    false => None,
-                    true => {
-                        let scroll_amt = (y_offset / max_offset) * (total_h - track_h);
-                        let idx = ((mouse_pos[1] - scroll_amt - item_h / 2.0).abs() / item_h) as Idx;
-                        Some(Elem::Item(idx))
-                    },
-                }
-            }
-
-            // If the menu is not scrollable.
-            else {
-                let centre_y = -(total_h - item_h) / 2.0;
-                match is_over_rect([0.0, centre_y], mouse_pos, [dim[0], total_h]) {
-                    false => None,
-                    true => {
-                        let idx = ((mouse_pos[1] - item_h / 2.0).abs() / item_h) as Idx;
-                        Some(Elem::Item(idx))
-                    },
-                }
-            }
-        },
-
-    }
-}
-
-
-/// Determine and return the new State by comparing the mouse state
-/// and position to the previous State.
-fn get_new_menu_state(is_over_elem: Option<Elem>,
-                      menu_state: MenuState,
-                      num_strings: usize,
-                      height: Scalar,
-                      mouse: Mouse,
-                      maybe_scroll: Option<(Scalar, Scalar, Scalar)>) -> MenuState
-{
-    use self::Interaction::{Normal, Clicked, Highlighted};
-    use self::Elem::{Item, ScrollBar};
-    use self::ScrollBar::{Handle, Track};
-    use self::MenuState::{Closed, Open};
-    use mouse::ButtonState::{Down, Up};
-
-    let new_scroll = || maybe_scroll.map(|(y_offset, max_height, max_offset)| Scroll {
-        y_offset: y_offset,
-        max_offset: max_offset,
-        max_visible_height: max_height,
-    });
-
-    let shift_scroll = |prev_mouse_xy: Point| {
-        maybe_scroll.map(|(y_offset, max_height, max_offset)| {
-            let y_offset = y_offset + (prev_mouse_xy[1] - mouse.xy[1]);
-            let y_offset = ::utils::clamp(y_offset, 0.0, max_offset);
-            Scroll {
-                y_offset: y_offset,
-                max_offset: max_offset,
-                max_visible_height: max_height,
-            }
-        })
-    };
-
-    let scroll_with_mouse = |maybe_scroll: Option<Scroll>| {
-        maybe_scroll.map(|scroll| {
-            let y_offset = scroll.y_offset;
-            let new_y_offset = ::utils::clamp(y_offset - mouse.scroll.y, 0.0, scroll.max_offset);
-            Scroll { y_offset: new_y_offset, ..scroll }
-        })
-    };
-
-    match menu_state {
-
-        MenuState::Closed(draw_state) => match is_over_elem {
-            Some(_) => match (draw_state, mouse.left) {
-                (Normal,         Down) => Closed(Normal),
-                (Normal,         Up)   |
-                (Highlighted(_), Up)   => Closed(Highlighted(Item(0))),
-                (Highlighted(_), Down) => Closed(Clicked(Item(0))),
-                (Clicked(_),     Down) => Closed(Clicked(Item(0))),
-                (Clicked(_),     Up)   => match num_strings {
-                    0 => Closed(Highlighted(Item(0))),
-                    _ => Open(Normal, new_scroll()),
-                },
-            },
-            None => MenuState::Closed(Normal),
-        },
-
-        MenuState::Open(draw_state, _prev_maybe_scroll) => {
-            match is_over_elem {
-                Some(elem) => match (draw_state, mouse.left, elem) {
-                    (Normal,         Down, _) => Open(Normal, new_scroll()),
-                    (Normal,         Up,   _) |
-                    (Highlighted(_), Up,   _) =>
-                        Open(Highlighted(elem), scroll_with_mouse(new_scroll())),
-
-                    // Scroll bar has just been clicked.
-                    (Highlighted(_), Down, ScrollBar(bar)) => {
-                        match bar {
-                            Handle(_) =>
-                                Open(Clicked(ScrollBar(Handle(mouse.xy))), new_scroll()),
-                            Track(_) => {
-                                let maybe_scroll = maybe_scroll.map(|(_y_offset, max_height, max_offset)| {
-                                    let top = height / 2.0;
-                                    let handle_h = max_height - max_offset;
-                                    let picked_y = (mouse.xy[1] - top).abs() - handle_h / 2.0;
-                                    let y_offset = ::utils::clamp(picked_y, 0.0, max_offset);
-                                    Scroll {
-                                        y_offset: y_offset,
-                                        max_visible_height: max_height,
-                                        max_offset: max_offset,
-                                    }
-                                });
-                                Open(Clicked(ScrollBar(Handle(mouse.xy))), maybe_scroll)
-                            },
-                        }
-                    },
-
-                    // An item has just been clicked.
-                    (Highlighted(_), Down, _) => Open(Clicked(elem), new_scroll()),
-
-                    // The scroll bar handle has just been dragged.
-                    (Clicked(ScrollBar(Handle(xy))), Down, _) =>
-                        Open(Clicked(ScrollBar(Handle(mouse.xy))), shift_scroll(xy)),
-
-                    // An item remains clicked.
-                    (Clicked(elem), Down, _)           => Open(Clicked(elem), new_scroll()),
-
-                    // The scrollbar, previously clicked, was released above an item.
-                    (Clicked(ScrollBar(_)), Up, Elem::Item(idx)) =>
-                        Open(Highlighted(Elem::Item(idx)), new_scroll()),
-
-                    // An item was selected.
-                    (Clicked(_),    Up, Elem::Item(_)) => Closed(Normal),
-
-                    // The scrollbar was released but remains highlighted.
-                    // TODO
-                    (Clicked(_),    Up, scroll)        =>
-                        Open(Highlighted(scroll), new_scroll()),
-                },
-
-                None => match (draw_state, mouse.left) {
-                    (Highlighted(_), Up)  => Open(Normal, new_scroll()),
-                    (Clicked(ScrollBar(Handle(xy))), Down) =>
-                        Open(Clicked(ScrollBar(Handle(mouse.xy))), shift_scroll(xy)),
-                    (Clicked(_), Up)      => Open(Normal, new_scroll()),
-                    (Clicked(elem), Down) => Open(Clicked(elem), new_scroll()),
-                    (Normal, Up)          => Open(Normal, new_scroll()),
-                    (Normal, Down)        => Closed(Normal),
-                    _                     => Closed(Normal),
-                },
-            }
-        }
-
-    }
+    Closed,
+    Open,
 }
 
 impl<'a, F> DropDownList<'a, F> {
@@ -357,7 +126,7 @@ impl<'a, F> DropDownList<'a, F> {
 
 impl<'a, F> Widget for DropDownList<'a, F>
     where
-        F: FnMut(&mut Option<Idx>, Idx, String),
+        F: FnMut(&mut Option<Idx>, Idx, &str),
 {
     type State = State;
     type Style = Style;
@@ -366,10 +135,11 @@ impl<'a, F> Widget for DropDownList<'a, F>
     fn unique_kind(&self) -> &'static str { "DropDownList" }
     fn init_state(&self) -> State {
         State {
-            menu_state: MenuState::Closed(Interaction::Normal),
-            strings: Vec::new(),
+            menu_state: MenuState::Closed,
+            buttons: Vec::new(),
             maybe_label: None,
             maybe_selected: None,
+            maybe_canvas_idx: None,
         }
     }
     fn style(&self) -> Style { self.style.clone() }
@@ -391,7 +161,7 @@ impl<'a, F> Widget for DropDownList<'a, F>
     /// Capture the mouse if the menu was opened.
     fn capture_mouse(prev: &State, new: &State) -> bool {
         match (prev.menu_state, new.menu_state) {
-            (MenuState::Closed(_), MenuState::Open(_, _)) => true,
+            (MenuState::Closed, MenuState::Open) => true,
             _ => false,
         }
     }
@@ -399,7 +169,7 @@ impl<'a, F> Widget for DropDownList<'a, F>
     /// Uncapture the mouse if the menu was closed.
     fn uncapture_mouse(prev: &State, new: &State) -> bool {
         match (prev.menu_state, new.menu_state) {
-            (MenuState::Open(_, _), MenuState::Closed(_)) => true,
+            (MenuState::Open, MenuState::Closed) => true,
             _ => false,
         }
     }
@@ -408,7 +178,9 @@ impl<'a, F> Widget for DropDownList<'a, F>
     fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
         where C: CharacterCache
     {
-        let widget::UpdateArgs { prev_state, xy, dim, style, ui, .. } = args;
+        use std::borrow::Cow;
+
+        let widget::UpdateArgs { idx, prev_state, xy, dim, style, mut ui } = args;
         let widget::State { ref state, .. } = *prev_state;
         let (window_dim, maybe_mouse) = {
             let input = ui.input();
@@ -417,263 +189,142 @@ impl<'a, F> Widget for DropDownList<'a, F>
         };
         let frame = style.frame(ui.theme());
         let num_strings = self.strings.len();
-
-        // Check for a new interaction with the DropDownList.
-        let (new_menu_state, is_over_elem) = match (self.enabled, maybe_mouse) {
-            (false, _) | (true, None) => (MenuState::Closed(Interaction::Normal), None),
-            (true, Some(mouse)) => {
-
-                // Determine the maximum visible height before the scrollbar should appear.
-                let bottom_win_y = (-window_dim[1]) / 2.0;
-                const WINDOW_PADDING: Scalar = 20.0;
-                let max_max_visible_height = xy[1] + dim[1] / 2.0 - bottom_win_y - WINDOW_PADDING;
-                let max_visible_height = match style.max_visible_height(ui.theme()) {
-                    Some(max_height) => {
-                        let height = match max_height {
-                            MaxHeight::Items(num) => (dim[1] - frame) * num as Scalar + frame,
-                            MaxHeight::Scalar(height) => height,
-                        };
-                        ::utils::partial_min(height, max_max_visible_height)
-                    },
-                    None => max_max_visible_height,
-                };
-
-                // Determine whether or not there should be a scrollbar. If we do need one, and we
-                // also had one last update, then carry the y_offset across from the last update.
-                let item_h = dim[1] - frame;
-                let total_h = item_h * (num_strings as Scalar) + frame;
-                let maybe_scrollbar = {
-                    if total_h <= max_visible_height { None } else {
-                        let y_offset = match state.menu_state {
-                            MenuState::Open(_, Some(ref scroll)) => scroll.y_offset,
-                            _ => 0.0,
-                        };
-                        let max_offset = max_visible_height - (max_visible_height / total_h) * max_visible_height;
-                        Some((y_offset, max_visible_height, max_offset))
-                    }
-                };
-                let is_over_elem = is_over(mouse.xy, frame, dim, state.menu_state,
-                                           num_strings, maybe_scrollbar);
-                let new_menu_state = get_new_menu_state(is_over_elem, state.menu_state, num_strings,
-                                                        dim[1], mouse, maybe_scrollbar);
-                (new_menu_state, is_over_elem)
-            },
-        };
+        let mut buttons = Cow::Borrowed(&state.buttons[..]);
+        let canvas_idx = state.maybe_canvas_idx.unwrap_or_else(|| ui.new_unique_node_index());
 
         // Check that the selected index, if given, is not greater than the number of strings.
         let selected = self.selected.and_then(|idx| if idx < num_strings { Some(idx) }
                                                     else { None });
 
-        // Call the `react` closure if mouse was released on one of the DropDownList items.
-        if let Some(ref mut react) = self.maybe_react {
-            if let (MenuState::Open(o_d_state, _), MenuState::Closed(c_d_state)) =
-                (state.menu_state, new_menu_state) {
-                if let (Some(Elem::Item(idx_a)), Interaction::Clicked(Elem::Item(idx_b)), Interaction::Normal) =
-                    (is_over_elem, o_d_state, c_d_state) {
-                    if idx_a == idx_b {
-                        *self.selected = selected;
-                        react(self.selected, idx_a, self.strings[idx_a].clone())
-                    }
-                }
-            }
+        // If the number of buttons that we have in our previous state doesn't match the number of
+        // strings we've just been given, we need to resize our buttons Vec.
+        if buttons.len() < num_strings {
+            let num_buttons = buttons.len();
+            buttons.to_mut().extend((num_buttons..num_strings).map(|i| {
+                (ui.new_unique_node_index(), self.strings[i].to_owned())
+            }));
         }
 
+        // Determine the new menu state by checking whether or not any of our Button's reactions
+        // are triggered.
+        let new_menu_state = match state.menu_state {
+
+            // If closed, we only want the button at the selected index to be drawn.
+            MenuState::Closed => {
+
+                // Get the button index and the label for the closed menu's button.
+                let (button_idx, label) = selected
+                    .map(|i| (buttons[i].0, &self.strings[i][..]))
+                    .unwrap_or_else(|| (buttons[0].0, self.maybe_label.unwrap_or("")));
+
+                // Use the pre-existing button widget to act as our button.
+                let mut was_clicked = false;
+                {
+                    let mut button = Button::new()
+                        .point(xy)
+                        .dim(dim)
+                        .label(label)
+                        .parent(Some(idx))
+                        .react(|| was_clicked = true);
+                    let is_selected = false;
+                    button.style = style.button_style(is_selected);
+                    button.set_internal(button_idx, &mut ui);
+                }
+
+                // If the closed menu was clicked, we want to open it.
+                if was_clicked { MenuState::Open } else { MenuState::Closed }
+            },
+
+            // Otherwise if open, we want to set all the buttons that would be currently visible.
+            MenuState::Open => {
+
+                let max_visible_height = {
+                    let bottom_win_y = (-window_dim[1]) / 2.0;
+                    const WINDOW_PADDING: Scalar = 20.0;
+                    let max = xy[1] + dim[1] / 2.0 - bottom_win_y - WINDOW_PADDING;
+                    style.max_visible_height(ui.theme()).map(|max_height| {
+                        let height = match max_height {
+                            MaxHeight::Items(num) => (dim[1] - frame) * num as Scalar + frame,
+                            MaxHeight::Scalar(height) => height,
+                        };
+                        ::utils::partial_min(height, max)
+                    }).unwrap_or(max)
+                };
+                let canvas_dim = [dim[0], max_visible_height];
+                let canvas_shift_y = ::position::align_top_of(dim[1], canvas_dim[1]);
+                let canvas_xy = [xy[0], xy[1] + canvas_shift_y];
+                Canvas::new()
+                    .color(::color::black().alpha(0.0))
+                    .frame_color(::color::black().alpha(0.0))
+                    .dim([dim[0], max_visible_height])
+                    .point(canvas_xy)
+                    .vertical_scrolling(true)
+                    .set(canvas_idx, &mut ui);
+
+                let labels = self.strings.iter();
+                let button_indices = state.buttons.iter().map(|&(idx, _)| idx);
+                let xys = (0..num_strings).map(|i| [xy[0], xy[1] - i as f64 * (dim[1] - frame)]);
+                let iter = labels.zip(button_indices).zip(xys).enumerate();
+                let mut was_clicked = None;
+                for (i, ((label, button_node_idx), button_xy)) in iter {
+                    let mut button = Button::new()
+                        .dim(dim)
+                        .label(label)
+                        .parent(Some(canvas_idx))
+                        .point(button_xy)
+                        .react(|| was_clicked = Some(i));
+                    button.style = style.button_style(Some(i) == selected);
+                    button.set_internal(button_node_idx, &mut ui);
+                }
+
+                // If one of the buttons was clicked, we want to close the menu.
+                if let Some(i) = was_clicked {
+
+                    // If we were given some react function, we'll call it.
+                    if let Some(ref mut react) = self.maybe_react {
+                        *self.selected = selected;
+                        react(self.selected, i, &self.strings[i])
+                    }
+
+                    MenuState::Closed
+                } else if let Some(mouse) = maybe_mouse {
+                    // TODO: Check if the mouse was just released.
+                } else {
+                    MenuState::Open
+                }
+            },
+
+        };
+
         // Function for constructing a new DropDownList State.
-        let new_state = || {
+        let new_state = |buttons: Cow<[(NodeIndex, String)]>| {
             State {
                 menu_state: new_menu_state,
                 maybe_label: self.maybe_label.as_ref().map(|label| label.to_string()),
-                strings: self.strings.clone(),
+                buttons: buttons.into_owned(),
                 maybe_selected: *self.selected,
+                maybe_canvas_idx: Some(canvas_idx),
             }
         };
 
         // Check whether or not the state has changed since the previous update.
         let state_has_changed = state.menu_state != new_menu_state
-            || &state.strings[..] != &(*self.strings)[..]
+            || &state.buttons[..] != &buttons[..]
             || state.maybe_selected != *self.selected
-            || state.maybe_label.as_ref().map(|string| &string[..]) != self.maybe_label;
+            || state.maybe_label.as_ref().map(|string| &string[..]) != self.maybe_label
+            || state.maybe_canvas_idx != Some(canvas_idx);
 
         // Construct the new state if there was a change.
-        if state_has_changed { Some(new_state()) } else { None }
+        if state_has_changed { Some(new_state(buttons)) } else { None }
     }
 
 
     /// Construct an Element from the given DropDownList State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<'b, C>(_args: widget::DrawArgs<'b, Self, C>) -> Element
         where C: CharacterCache,
     {
-        use elmesque::form::{collage, rect, text};
-        use elmesque::text::Text;
-
-        let widget::DrawArgs { state, style, theme, .. } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
-
-        // Retrieve the styling for the Element.
-        let color = style.color(theme);
-        let frame = style.frame(theme);
-        let frame_color = style.frame_color(theme);
-        let label_color = style.label_color(theme);
-        let font_size = style.label_font_size(theme);
-        let pad_dim = ::vecmath::vec2_sub(dim, [frame * 2.0; 2]);
-
-        // Construct the DropDownList's Element.
-        match state.menu_state {
-
-            MenuState::Closed(draw_state) => {
-                let string = match state.maybe_selected {
-                    Some(idx) => state.strings[idx].clone(),
-                    None => match state.maybe_label {
-                        Some(ref label) => label.clone(),
-                        None => match state.strings.len() {
-                            0 => "-----".to_owned(),
-                            _ => state.strings[0].clone(),
-                        },
-                    },
-                };
-                let frame_form = rect(dim[0], dim[1]).filled(frame_color);
-                let inner_form = rect(pad_dim[0], pad_dim[1]).filled(draw_state.color(color));
-                let text_form = text(Text::from_string(string)
-                                         .color(label_color)
-                                         .height(font_size as f64));
-
-                // Chain and shift the Forms into position.
-                let form_chain = Some(frame_form).into_iter()
-                    .chain(Some(inner_form))
-                    .chain(Some(text_form))
-                    .map(|form| form.shift(xy[0].floor(), xy[1].floor()));
-
-                // Collect the Form's into a renderable Element.
-                collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
-            },
-
-            MenuState::Open(interaction, maybe_scroll) => {
-
-                // Determine the visible index range and the height of the first and last items.
-                let item_h = dim[1] - frame;
-                let num_strings = state.strings.len();
-                let total_h = item_h * num_strings as f64 + frame;
-                let (start_idx, end_idx, scroll_amt) = if let Some(scroll) = maybe_scroll {
-                    let Scroll { max_visible_height, y_offset, max_offset } = scroll;
-                    let num_items_that_fit = (max_visible_height - frame) / item_h;
-                    let scroll_perc = y_offset / (max_offset + frame);
-                    let num_hidden_items = num_strings as f64 - num_items_that_fit;
-                    let num_items_scrolled_past = scroll_perc * num_hidden_items;
-                    let start_idx = num_items_scrolled_past.floor() as usize;
-                    let last_visible_item = num_items_scrolled_past + num_items_that_fit;
-                    let end_idx = last_visible_item.floor() as usize;
-                    // Make sure the resulting end_idx is smaller than the number of strings.
-                    let end_idx = if end_idx >= num_strings { num_strings - 1 } else { end_idx };
-                    let scroll_amt = (y_offset / max_offset) * (total_h - max_visible_height);
-                    (start_idx, end_idx, scroll_amt)
-                } else {
-                    let len = state.strings.len();
-                    let end_idx = if len == 0 { 0 } else { len - 1 };
-                    (0, end_idx, 0.0)
-                };
-
-                // Chain and shift the Forms into position.
-                let visible_range = match state.strings.len() {
-                    0 => &state.strings[0..0],
-                    _ => &state.strings[start_idx..end_idx + 1],
-                };
-
-                let item_form_chain = visible_range.iter().enumerate().flat_map(|(i, string)| {
-                    let i = i + start_idx;
-                    let color = match state.maybe_selected {
-                        None => match interaction {
-                            Interaction::Highlighted(Elem::Item(idx)) =>
-                                if i == idx { color.highlighted() } else { color },
-                            Interaction::Clicked(Elem::Item(idx)) =>
-                                if i == idx { color.clicked() } else { color },
-                            _ => color,
-                        },
-                        Some(sel_idx) => {
-                            if sel_idx == i { color.clicked() }
-                            else {
-                                match interaction {
-                                    Interaction::Highlighted(Elem::Item(idx)) =>
-                                        if i == idx { color.highlighted() } else { color },
-                                    Interaction::Clicked(Elem::Item(idx)) =>
-                                        if i == idx { color.clicked() } else { color },
-                                    _ => color,
-                                }
-                            }
-                        },
-                    };
-                    let frame_form = rect(dim[0], dim[1]).filled(frame_color);
-                    let inner_form = rect(pad_dim[0], pad_dim[1]).filled(color);
-                    let text_form = text(Text::from_string(string.clone())
-                                             .color(label_color)
-                                             .height(font_size as f64));
-                    let shift_amt = -(i as f64 * dim[1] - i as f64 * frame).floor() + scroll_amt;
-                    let forms = Some(frame_form).into_iter()
-                        .chain(Some(inner_form))
-                        .map(move |form| form.shift_y(shift_amt))
-                        .chain(Some(text_form.shift_y(shift_amt.floor())));
-                    forms
-                });
-
-                let maybe_scroll_forms = match interaction {
-                    Interaction::Highlighted(_) | Interaction::Clicked(Elem::ScrollBar(_)) => {
-                        Some(maybe_scroll.iter().flat_map(|scroll| {
-                            let Scroll { y_offset, max_visible_height, .. } = *scroll;
-                            let scroll_x = position::align_right_of(dim[0], SCROLLBAR_WIDTH);
-                            let track_dim = [SCROLLBAR_WIDTH, max_visible_height];
-                            let middle_y = item_h / 2.0 - max_visible_height / 2.0;
-                            let track_xy = [scroll_x, middle_y];
-
-                            let handle_h = (max_visible_height / total_h) * max_visible_height;
-                            let handle_dim = [SCROLLBAR_WIDTH, handle_h];
-                            let handle_top = position::align_top_of(track_dim[1], handle_h);
-                            let handle_y = track_xy[1] + handle_top - y_offset;
-                            let handle_xy = [scroll_x, handle_y];
-
-                            let track_color = match interaction {
-                                Interaction::Clicked(Elem::ScrollBar(ScrollBar::Track(_))) =>
-                                    color.plain_contrast().plain_contrast().alpha(0.3).clicked(),
-                                Interaction::Highlighted(Elem::ScrollBar(ScrollBar::Track(_))) =>
-                                    color.plain_contrast().plain_contrast().alpha(0.3).highlighted(),
-                                _ => color.plain_contrast().plain_contrast().alpha(0.3),
-                            };
-                            let handle_color = match interaction {
-                                Interaction::Clicked(Elem::ScrollBar(ScrollBar::Handle(_))) =>
-                                    color.plain_contrast().alpha(0.9).clicked(),
-                                Interaction::Highlighted(Elem::ScrollBar(ScrollBar::Handle(_))) =>
-                                    color.plain_contrast().alpha(0.75).highlighted(),
-                                _ => color.plain_contrast().alpha(0.6),
-                            };
-
-                            let track_form = rect(track_dim[0], track_dim[1])
-                                .filled(track_color)
-                                .shift(track_xy[0], track_xy[1]);
-                            let handle_form = rect(handle_dim[0], handle_dim[1])
-                                .filled(handle_color)
-                                .shift(handle_xy[0], handle_xy[1]);
-                            Some(track_form).into_iter().chain(Some(handle_form))
-                        }))
-                    },
-                    _ => None,
-                }.into_iter().flat_map(|forms| forms);
-
-                let form_chain = item_form_chain.chain(maybe_scroll_forms)
-                    .map(|form| form.shift(xy[0].floor(), xy[1].floor()));
-
-                // Collect the Form's into a renderable Element.
-                let element = collage(dim[0] as i32, dim[1] as i32, form_chain.collect());
-
-                match maybe_scroll {
-                    Some(scroll) => {
-                        let x = xy[0];
-                        let y = xy[1] + dim[1] / 2.0 - scroll.max_visible_height / 2.0;
-                        element.crop(x, y, dim[0], scroll.max_visible_height)
-                    },
-                    None => element,
-                }
-            },
-
-        }
-
+        // We don't need to draw anything, as DropDownList is entirely composed of other widgets.
+        ::elmesque::element::empty()
     }
 
 }
@@ -734,6 +385,17 @@ impl Style {
         else if let Some(Some(height)) = theme.maybe_drop_down_list.as_ref()
             .map(|default| default.style.maybe_max_visible_height) { Some(height) }
         else { None }
+    }
+
+    /// Style for a `Button` given this `Style`'s current state.
+    pub fn button_style(&self, is_selected: bool) -> ButtonStyle {
+        ButtonStyle {
+            maybe_color: self.maybe_color.map(|c| if is_selected { c.highlighted() } else { c }),
+            maybe_frame: self.maybe_frame,
+            maybe_frame_color: self.maybe_frame_color,
+            maybe_label_color: self.maybe_label_color,
+            maybe_label_font_size: self.maybe_label_font_size,
+        }
     }
 
 }

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -210,7 +210,7 @@ impl<'a, F> Widget for DropDownList<'a, F>
                         .react(|| was_clicked = true);
                     let is_selected = false;
                     button.style = style.button_style(is_selected);
-                    button.set_internal(button_idx, &mut ui);
+                    button.set(button_idx, &mut ui);
                 }
 
                 // If the closed menu was clicked, we want to open it.
@@ -257,7 +257,7 @@ impl<'a, F> Widget for DropDownList<'a, F>
                         .point(button_xy)
                         .react(|| was_clicked = Some(i));
                     button.style = style.button_style(Some(i) == selected);
-                    button.set_internal(button_node_idx, &mut ui);
+                    button.set(button_node_idx, &mut ui);
                 }
 
                 // If one of the buttons was clicked, we want to close the menu.

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -271,7 +271,7 @@ impl<'a, F> Widget for DropDownList<'a, F>
 
                     MenuState::Closed
                 // Otherwise if the mouse was released somewhere else we should close the menu.
-                } else if global_mouse.left.was_just_released
+                } else if global_mouse.left.was_just_pressed
                 && !::utils::is_over_rect(canvas_xy, global_mouse.xy, canvas_dim) {
                     MenuState::Closed
                 } else {

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -198,11 +198,11 @@ fn closest_elem(mouse_xy: Point, pad_dim: Dimensions, perc_env: &[(f32, f32, f32
 fn get_new_interaction(is_over_elem: Option<Elem>,
                        prev: Interaction,
                        mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Elem::{EnvPoint};//, CurvePoint};
     use self::MouseButton::{Left, Right};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over_elem, prev, mouse.left, mouse.right) {
+    match (is_over_elem, prev, mouse.left.position, mouse.right.position) {
         (Some(_), Normal, Down, Up) => Normal,
         (Some(elem), _, Up, Up) => Highlighted(elem),
         (Some(elem), Highlighted(_), Down, Up) => Clicked(elem, Left),

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -52,13 +52,13 @@ pub struct UpdateArgs<'a, W, C: 'a> where W: Widget {
     pub style: &'a W::Style,
     /// Restricted access to the `Ui`.
     /// Provides methods for immutably accessing the `Ui`'s `Theme` and `GlyphCache`.
-    /// Also allows calling `Widget::set_internal` within the `Widget::update` method.
+    /// Also allows calling `Widget::set` within the `Widget::update` method.
     pub ui: UiCell<'a, C>,
 }
 
 /// A wrapper around a `Ui` that only exposes the functionality necessary for the `Widget::update`
 /// method. Its primary role is to allow for widget designers to compose their own unique `Widget`s
-/// from other `Widget`s by calling the `Widget::set_internal` method within their own `Widget`'s
+/// from other `Widget`s by calling the `Widget::set` method within their own `Widget`'s
 /// update method. It also provides methods for accessing the `Ui`'s `Theme`, `GlyphCache` and
 /// `UserInput` via immutable reference.
 ///
@@ -219,7 +219,6 @@ impl<'a, C> UiRefMut<C> for UiCell<'a, C> {
 /// Methods that should not be overridden:
 /// - parent
 /// - set
-/// - set_internal
 pub trait Widget: Sized {
     /// State to be stored within the `Ui`s widget cache. Take advantage of this type for any large
     /// allocations that you would like to avoid repeating between updates, or any calculations
@@ -408,17 +407,6 @@ pub trait Widget: Sized {
         U: UiRefMut<C>,
     {
         set_widget(self, idx.into(), ui.ui_ref_mut());
-    }
-
-    /// Set the widget within the `Ui` that is stored within the given `UiCell` without occupying
-    /// the `WidgetId` space.
-    ///
-    /// This method is designed to be an alternative to `Widget::set`, to be used by Widget
-    /// designers when composing `Widget`s out of other `Widgets`.
-    fn set_internal<'a, C>(self, idx: NodeIndex, ui_cell: &mut UiCell<'a, C>)
-        where C: CharacterCache
-    {
-        set_widget(self, Index::Internal(idx), ui_cell.ui);
     }
 
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -561,7 +561,7 @@ fn set_widget<'a, W, C>(widget: W, idx: Index, ui: &mut Ui<C>) where
             let maybe_mouse = ui::get_mouse_state(ui, idx);
             match (prev.maybe_floating, maybe_mouse) {
                 (Some(prev_floating), Some(mouse)) => {
-                    if mouse.left == ::mouse::ButtonState::Down {
+                    if mouse.left.position == ::mouse::ButtonPosition::Down {
                         Some(new_floating())
                     } else {
                         Some(prev_floating)
@@ -847,6 +847,12 @@ impl<'a, C> UiCell<'a, C> {
     /// A struct representing the user input that has occurred since the last update.
     pub fn input(&self) -> UserInput {
         ui::user_input(self.ui, self.idx)
+    }
+
+    /// A struct representing the user input that has occurred since the last update for the
+    /// `Widget` with the given index..
+    pub fn input_for<I: Into<Index>>(&self, idx: I) -> UserInput {
+        ui::user_input(self.ui, idx.into())
     }
 
     /// Generate a new, unique NodeIndex into a Placeholder node within the `Ui`'s widget graph.

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -153,10 +153,10 @@ fn is_over(mouse_xy: Point,
 
 /// Check and return the current state of the NumberDialer.
 fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Elem::ValueGlyph;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over_elem, prev, mouse.left) {
+    match (is_over_elem, prev, mouse.left.position) {
         (Some(_),    Normal,          Down) => Normal,
         (Some(elem), _,               Up)   => Highlighted(elem),
         (Some(elem), Highlighted(_),  Down) => Clicked(elem),

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -154,8 +154,8 @@ pub fn update(kid_area: &widget::KidArea,
                                mouse_scalar: Scalar| -> Interaction
     {
         if let Some(mouse) = maybe_mouse {
-            use mouse::ButtonState::{Down, Up};
-            match (is_over_elem, bar.interaction, mouse.left) {
+            use mouse::ButtonPosition::{Down, Up};
+            match (is_over_elem, bar.interaction, mouse.left.position) {
                 (Some(_),    Normal,             Down) => Normal,
                 (Some(elem), _,                  Up)   => Highlighted(elem),
                 (Some(_),    Highlighted(_),     Down) |

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -73,9 +73,9 @@ impl<T> State<T> {
 
 /// Check the current state of the slider.
 fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left) {
+    match (is_over, prev, mouse.left.position) {
         (true,  Normal,  Down) => Normal,
         (true,  _,       Down) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -315,9 +315,9 @@ impl<'a> Widget for Tabs<'a> {
 
         // Determine the new current `Interaction` for the widget.
         let new_interaction = if let Some(mouse) = maybe_mouse {
-            use mouse::ButtonState::{Down, Up};
+            use mouse::ButtonPosition::{Down, Up};
             use self::Interaction::{Normal, Highlighted, Clicked};
-            match (is_over_elem(), state.interaction, mouse.left) {
+            match (is_over_elem(), state.interaction, mouse.left.position) {
                 (Some(_),    Normal,          Down) => Normal,
                 (Some(elem), _,               Up)   => Highlighted(elem),
                 (Some(elem), Highlighted(_),  Down) => Clicked(elem),

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -222,12 +222,12 @@ fn closest_idx<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
 
 /// Check and return the current state of the TextBox.
 fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Captured, Uncaptured};
     use self::Uncaptured::{Normal, Highlighted};
 
     match prev_interaction {
-        Interaction::Captured(mut prev) => match mouse.left {
+        Interaction::Captured(mut prev) => match mouse.left.position {
             Down => match over_elem {
                 Elem::Nill => if prev.cursor.anchor == Anchor::None {
                     Uncaptured(Normal)
@@ -255,7 +255,7 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
             },
         },
 
-        Interaction::Uncaptured(prev) => match mouse.left {
+        Interaction::Uncaptured(prev) => match mouse.left.position {
             Down => match over_elem {
                 Elem::Nill => Uncaptured(Normal),
                 Elem::Rect => match prev {

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -67,9 +67,9 @@ impl State {
 fn get_new_interaction(is_over: bool,
                        prev: Interaction,
                        mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left) {
+    match (is_over, prev, mouse.left.position) {
         (true,  Normal,  Down) => Normal,
         (true,  _,       Down) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -75,9 +75,9 @@ impl<X, Y> State<X, Y> {
 fn get_new_interaction(is_over: bool,
                        prev: Interaction,
                        mouse: Mouse) -> Interaction {
-    use mouse::ButtonState::{Down, Up};
+    use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left) {
+    match (is_over, prev, mouse.left.position) {
         (true,  Normal,  Down) => Normal,
         (true,  _,       Down) => Clicked,
         (true,  _,       Up)   => Highlighted,


### PR DESCRIPTION
`DropDownList` is now roughly half the size (its `update` method is much shorter, and it's `draw` method is now a one-liner) with all the same behaviour! I think this is a nice proof-of-concept and a good example of how easy it should be to compose new `Widget`s from other `Widget`s.

As expected, I had to make some tweaks to the widget module as I ran into different issues doing this for the first time:
- Turns out `set_internal` is totally unnecessary! By making `Widget::set` generic over any type that impls `Into<Index>`, we can use it for setting both `Public` (`WidgetId`) and `Internal` (`NodeIndex`) indices. This should keep the API much cleaner and consistent between widget designing and widget using.
- Sometimes a parent `Widget` needs to know whether or not the mouse was released, even though it may not be capturing it or hovered - thus I added a `global_mouse` field to the `UserInput` struct.
- In some occasions it can be annoying for a `Widget` to track whether or not a mouse was pressed or released, so I added `was_pressed` and `was_released` flags to the mouse's `ButtonState`.
- The std::error messages when two widgets simultaneously try to capture input is unnecessary and can be annoying even if the resulting behaviour is correct, so I removed it.

This is a slight **breaking change** due to the removal of the `set_internal` method (despite its brief life) and the change to the `mouse::ButtonState` struct.

Note: there is still an issue where the `DropDownList` doesn't crop properly to its scroll area - it now also eternally captures the mouse if you click one of the buttons outside the proper scroll area. The over-arching bug existed before this however, so it will be addressed in a separate PR.

EDIT: Also, I changed the last arg  of `DropDownList`'s `react` function to take a `&str` instead of a `String` - it was an unnecessary allocation seeing as a user can easily call `.to_owned()` if they require a `String`. Oddly however, this does now require that the user writes the type for the `&str` argument when calling `DropDownList::react` with a closure (otherwise the compiler seems to complain about the closure's lifetimes not matching that of the FnMut bound required by `DropDownList::react`'s arg type).

Closes #566 