### PR TITLE
Change WidgetId from a `usize` type alias to a newtype around a `usize` for type safety.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/graph/index_map.rs
+++ b/src/graph/index_map.rs
@@ -2,7 +2,8 @@
 use std::collections::HashMap;
 use std::ops::Index;
 use super::NodeIndex;
-use widget::{self, WidgetId};
+use widget;
+use widget::Id as WidgetId;
 
 
 /// Maps a WidgetId given by the user to a NodeIndex into the Graph (and vice versa).

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -8,7 +8,7 @@ use position::{Depth, Dimensions, Point};
 use self::index_map::IndexMap;
 use std::any::Any;
 use std::fmt::Debug;
-use widget::{self, Widget, WidgetId};
+use widget::{self, Widget};
 
 
 pub use self::index_map::GraphIndex;
@@ -266,7 +266,7 @@ impl Graph {
     }
 
 
-    /// Calculate the total scroll offset for the widget with the given WidgetId.
+    /// Calculate the total scroll offset for the widget with the given widget::Index.
     pub fn scroll_offset<I: GraphIndex>(&self, idx: I) -> Point {
         let Graph { ref graph, ref index_map, .. } = *self;
         
@@ -451,7 +451,7 @@ impl Graph {
     /// index is given). Return the NodeIndex for the Widget's position within the Graph.
     pub fn add_widget<I: GraphIndex>(&mut self,
                                      container: Container,
-                                     maybe_id: Option<WidgetId>,
+                                     maybe_id: Option<widget::Id>,
                                      maybe_parent_idx: Option<I>) -> NodeIndex
     {
         let node_idx = self.graph.add_node(Node::Widget(container));
@@ -463,8 +463,8 @@ impl Graph {
     }
 
 
-    /// Update the state of the widget with the given WidgetId.
-    /// If there is no widget for the given WidgetId, add it to the graph.
+    /// Update the state of the widget with the given widget::Index.
+    /// If there is no widget for the given widget::Index, add it to the graph.
     pub fn update_widget<I, P, W>(&mut self,
                                   idx: I,
                                   maybe_parent_idx: Option<P>,
@@ -566,7 +566,7 @@ impl Graph {
         // Otherwise if there is no Widget for the given index we need to add one.
         } else {
             // If there is no widget for the given index we can assume that the index is a
-            // `WidgetId`, as the only way to procure a NodeIndex is by adding a Widget to the
+            // `widget::Id`, as the only way to procure a NodeIndex is by adding a Widget to the
             // Graph.
             let id = idx.to_widget_id(&self.index_map)
                 .expect("Expected a `WidgetId` but the given idx was not one, nor did it match any \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,8 @@ pub use position::{Corner, Depth, Direction, Dimensions, Horizontal, HorizontalA
                    VerticalAlign};
 pub use theme::{Align, Theme};
 pub use ui::{GlyphCache, Ui, UserInput};
-pub use widget::{drag, scroll, CommonBuilder, DrawArgs, UiCell, UpdateArgs, Widget, WidgetId};
+pub use widget::{drag, scroll, CommonBuilder, DrawArgs, UiCell, UpdateArgs, Widget};
+pub use widget::Id as WidgetId;
 pub use widget::Index as WidgetIndex;
 pub use widget::State as WidgetState;
 
@@ -124,26 +125,26 @@ macro_rules! widget_ids {
 
     // Handle the first ID.
     ( $widget_id:ident , $($rest:tt)* ) => (
-        const $widget_id: $crate::WidgetId = 0;
-        widget_ids!($widget_id => $($rest)*);
+        const $widget_id: $crate::WidgetId = $crate::WidgetId(0);
+        widget_ids!($widget_id.0 => $($rest)*);
     );
 
     // Handle the first ID with some given step between it and the next ID.
     ( $widget_id:ident with $step:expr , $($rest:tt)* ) => (
-        const $widget_id: $crate::WidgetId = 0;
-        widget_ids!($widget_id + $step => $($rest)*);
+        const $widget_id: $crate::WidgetId = $crate::WidgetId(0);
+        widget_ids!($widget_id.0 + $step => $($rest)*);
     );
 
     // Handle some consecutive ID.
     ( $prev_id:expr => $widget_id:ident , $($rest:tt)* ) => (
-        const $widget_id: $crate::WidgetId = $prev_id + 1;
-        widget_ids!($widget_id => $($rest)*);
+        const $widget_id: $crate::WidgetId = $crate::WidgetId($prev_id + 1);
+        widget_ids!($widget_id.0 => $($rest)*);
     );
 
     // Handle some consecutive ID with some given step between it and the next ID.
     ( $prev_id:expr => $widget_id:ident with $step:expr , $($rest:tt)* ) => (
-        const $widget_id: $crate::WidgetId = $prev_id + 1;
-        widget_ids!($widget_id + $step => $($rest)*);
+        const $widget_id: $crate::WidgetId = $crate::WidgetId($prev_id + 1);
+        widget_ids!($widget_id.0 + $step => $($rest)*);
     );
 
 
@@ -162,22 +163,22 @@ macro_rules! widget_ids {
 
     // Handle a single ID without a trailing comma.
     ( $widget_id:ident ) => (
-        const $widget_id: $crate::WidgetId = 0;
+        const $widget_id: $crate::WidgetId = $crate::WidgetId(0);
     );
 
     // Handle a single ID with some given step without a trailing comma.
     ( $widget_id:ident with $step:expr ) => (
-        const $widget_id: $crate::WidgetId = 0;
+        const $widget_id: $crate::WidgetId = $crate::WidgetId(0);
     );
 
     // Handle the last ID without a trailing comma.
     ( $prev_id:expr => $widget_id:ident ) => (
-        const $widget_id: $crate::WidgetId = $prev_id + 1;
+        const $widget_id: $crate::WidgetId = $crate::WidgetId($prev_id + 1);
     );
 
     // Handle the last ID with some given step without a trailing comma.
     ( $prev_id:expr => $widget_id:ident with $step:expr ) => (
-        const $widget_id: $crate::WidgetId = $prev_id + 1;
+        const $widget_id: $crate::WidgetId = $crate::WidgetId($prev_id + 1);
     );
 
 }
@@ -192,9 +193,9 @@ fn test() {
         D,
         E with 8,
     }
-    assert_eq!(A, 0);
-    assert_eq!(B, 1);
-    assert_eq!(C, 66);
-    assert_eq!(D, 99);
-    assert_eq!(E, 100);
+    assert_eq!(A, WidgetId(0));
+    assert_eq!(B, WidgetId(1));
+    assert_eq!(C, WidgetId(66));
+    assert_eq!(D, WidgetId(99));
+    assert_eq!(E, WidgetId(100));
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,13 +20,13 @@ use position::{Dimensions, HorizontalAlign, Padding, Point, Position, VerticalAl
 use std::cell::RefCell;
 use std::io::Write;
 use theme::Theme;
-use widget::{self, Widget, WidgetId};
+use widget::{self, Widget};
 
 
 /// Indicates whether or not the Mouse has been captured by a widget.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Capturing {
-    /// The Ui is captured by the Ui element with the given WidgetId.
+    /// The Ui is captured by the Ui element with the given widget::Index.
     Captured(widget::Index),
     /// The Ui has just been uncaptured.
     JustReleased,
@@ -35,7 +35,7 @@ enum Capturing {
 /// `Ui` is the most important type within Conrod and is necessary for rendering and maintaining
 /// widget state.
 /// # Ui Handles the following:
-/// * Contains the state of all widgets which can be indexed via their WidgetId.
+/// * Contains the state of all widgets which can be indexed via their widget::Index.
 /// * Stores rendering state for each widget until the end of each render cycle.
 /// * Contains the theme used for default styling of the widgets.
 /// * Maintains the latest user input state (for mouse and keyboard).
@@ -61,17 +61,17 @@ pub struct Ui<C> {
     text_just_entered: Vec<String>,
     /// Tracks whether or not the previous event was a Render event.
     prev_event_was_render: bool,
-    /// The WidgetId of the widget that was last updated/set.
+    /// The widget::Index of the widget that was last updated/set.
     maybe_prev_widget_idx: Option<widget::Index>,
-    /// The WidgetId of the last widget used as a parent for another widget.
+    /// The widget::Index of the last widget used as a parent for another widget.
     maybe_current_parent_idx: Option<widget::Index>,
     /// If the mouse is currently over a widget, its ID will be here.
     maybe_widget_under_mouse: Option<widget::Index>,
     /// The ID of the top-most scrollable widget under the cursor (if there is one).
     maybe_top_scrollable_widget_under_mouse: Option<widget::Index>,
-    /// The WidgetId of the widget currently capturing mouse input if there is one.
+    /// The widget::Index of the widget currently capturing mouse input if there is one.
     maybe_captured_mouse: Option<Capturing>,
-    /// The WidgetId of the widget currently capturing keyboard input if there is one.
+    /// The widget::Index of the widget currently capturing keyboard input if there is one.
     maybe_captured_keyboard: Option<Capturing>,
     /// The number of frames that that will be used for the `redraw_count` when `need_redraw` is
     /// triggered.
@@ -164,7 +164,7 @@ impl<C> Ui<C> {
 
 
     /// Return the dimensions of a widget.
-    pub fn widget_size(&self, id: WidgetId) -> Dimensions {
+    pub fn widget_size(&self, id: widget::Id) -> Dimensions {
         self.widget_graph[id].dim
     }
 
@@ -673,7 +673,7 @@ pub fn get_mouse_state<C>(ui: &Ui<C>, idx: widget::Index) -> Option<Mouse> {
 }
 
 
-/// Indicate that the widget with the given WidgetId has captured the mouse.
+/// Indicate that the widget with the given widget::Index has captured the mouse.
 pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
     // If the mouse isn't already captured, set idx as the capturing widget.
     if let None = ui.maybe_captured_mouse {
@@ -690,7 +690,7 @@ pub fn mouse_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
     }
 }
 
-/// Indicate that the widget with the given WidgetId has captured the keyboard.
+/// Indicate that the widget with the given widget::Index has captured the keyboard.
 pub fn keyboard_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
     match ui.maybe_captured_keyboard {
         Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
@@ -732,7 +732,7 @@ pub fn keyboard_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
 }
 
 
-/// Update the given widget at the given WidgetId.
+/// Update the given widget at the given widget::Index.
 pub fn update_widget<C, W>(ui: &mut Ui<C>,
                            idx: widget::Index,
                            maybe_parent_idx: Option<widget::Index>,

--- a/src/widget/id.rs
+++ b/src/widget/id.rs
@@ -1,0 +1,26 @@
+
+
+/// Unique, public widget identifier. Each widget must use a unique `WidgetId` so that it's state
+/// can be cached within the `Ui` type. The reason we use a usize is because widgets are cached
+/// within a `Graph` whose max number of `Node`s is indexed by usize.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, RustcEncodable, RustcDecodable)]
+pub struct Id(pub usize);
+
+
+impl From<usize> for Id {
+    #[inline]
+    fn from(u: usize) -> Id { Id(u) }
+}
+
+
+/// Simplify the incrementation of an Id in `for` loops i.e. this allows:
+///
+/// for i in 0..num_widgets {
+///     MyWidget::new().set(MY_WIDGET + i, ui);
+/// }
+///
+impl ::std::ops::Add<usize> for Id {
+    type Output = Id;
+    fn add(self, rhs: usize) -> Id { Id(self.0 + rhs) }
+}
+

--- a/src/widget/index.rs
+++ b/src/widget/index.rs
@@ -1,7 +1,6 @@
 
-use graph::NodeIndex;
+use ::{NodeIndex, WidgetId};
 use rustc_serialize::{Encodable, Decodable, Encoder, Decoder};
-use widget::WidgetId;
 
 
 /// An index either given in the form of a publicly instantiated `Widget`'s `WidgetId`, or an
@@ -34,7 +33,7 @@ impl Encodable for Index {
             match *self {
                 Index::Public(id) =>
                     encoder.emit_enum_variant("Public", 0, 2, |encoder| {
-                        encoder.emit_enum_variant_arg(0, |encoder| encoder.emit_usize(id))
+                        encoder.emit_enum_variant_arg(0, |encoder| encoder.emit_usize(id.0))
                     }),
                 Index::Internal(idx) =>
                     encoder.emit_enum_variant("Internal", 1, 2, |encoder| {
@@ -51,7 +50,7 @@ impl Decodable for Index {
             decoder.read_enum_variant(&["Public", "Internal"], |decoder, i| {
                 Ok(match i {
                     0 => Index::Public(try!(decoder.read_enum_variant_arg(0, |decoder| {
-                        decoder.read_usize()
+                        Ok(WidgetId(try!(decoder.read_usize())))
                     }))),
                     1 => Index::Internal(try!(decoder.read_enum_variant_arg(0, |decoder| {
                         Ok(NodeIndex::new(try!(decoder.read_usize())))

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -6,7 +6,7 @@ use graphics::character::CharacterCache;
 use label::FontSize;
 use theme::Theme;
 use ui::GlyphCache;
-use widget::{self, Widget, WidgetId};
+use widget::{self, Widget};
 
 
 /// Displays some given text centred within a rectangle.
@@ -15,7 +15,6 @@ pub struct Label<'a> {
     common: widget::CommonBuilder,
     text: &'a str,
     style: Style,
-    maybe_parent_id: Option<WidgetId>,
 }
 
 /// The styling for a Label's renderable Element.
@@ -39,7 +38,6 @@ impl<'a> Label<'a> {
             common: widget::CommonBuilder::new(),
             text: text,
             style: Style::new(),
-            maybe_parent_id: None,
         }
     }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -10,9 +10,11 @@ use std::any::Any;
 use theme::Theme;
 use ui::{self, GlyphCache, Ui, UserInput};
 
+pub use self::id::Id;
 pub use self::index::Index;
 
 pub mod drag;
+mod id;
 mod index;
 pub mod scroll;
 
@@ -30,12 +32,6 @@ pub mod tabs;
 pub mod text_box;
 pub mod toggle;
 pub mod xy_pad;
-
-
-/// Unique widget identifier. Each widget must use a unique `WidgetId` so that it's state can be
-/// cached within the `Ui` type. The reason we use a usize is because widgets are cached within
-/// a `Vec`, which is limited to a size of `usize` elements.
-pub type WidgetId = usize;
 
 
 /// Arguments for the `Widget::update` method in a struct to simplify the method signature.

--- a/src/widget/split.rs
+++ b/src/widget/split.rs
@@ -4,13 +4,13 @@ use color::Color;
 use graphics::character::CharacterCache;
 use position::{Dimensions, Direction, Point, Positionable, Sizeable};
 use super::canvas;
-use widget::{Widget, WidgetId};
+use widget::{self, Widget};
 use ui::Ui;
 
 
 /// A type of Canvas for flexibly designing and guiding widget layout as splits of a window.
 pub struct Split<'a> {
-    id: WidgetId,
+    id: widget::Id,
     style: canvas::Style,
     maybe_splits: Option<(Direction, &'a [Split<'a>])>,
     maybe_length: Option<Scalar>,
@@ -23,7 +23,7 @@ pub struct Split<'a> {
 impl<'a> Split<'a> {
 
     /// Construct a default Canvas Split.
-    pub fn new(id: WidgetId) -> Split<'a> {
+    pub fn new(id: widget::Id) -> Split<'a> {
         Split {
             id: id,
             style: canvas::Style::new(),
@@ -150,7 +150,7 @@ impl<'a> Split<'a> {
     fn into_ui<C>(&self,
                   dim: Dimensions,
                   xy: Point,
-                  maybe_parent: Option<WidgetId>,
+                  maybe_parent: Option<widget::Id>,
                   ui: &mut Ui<C>)
         where
             C: CharacterCache,
@@ -264,7 +264,7 @@ impl<'a> Split<'a> {
         canvas.style = style.clone();
         match maybe_parent {
             Some(parent_id) => canvas.parent(Some(parent_id)),
-            None            => canvas.parent(None::<WidgetId>),
+            None            => canvas.parent(None::<widget::Id>),
         }.point(xy)
             .dim(dim)
             .vertical_scrolling(is_v_scrollable)

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -7,12 +7,12 @@ use label::FontSize;
 use position::{Dimensions, Point};
 use super::canvas::{self, Canvas};
 use theme::Theme;
-use widget::{self, WidgetId, Widget};
+use widget::{self, Widget};
 
 
 /// A wrapper around a list of canvasses that displays thema s a list of selectable tabs.
 pub struct Tabs<'a> {
-    tabs: &'a [(WidgetId, &'a str)],
+    tabs: &'a [(widget::Id, &'a str)],
     style: Style,
     common: widget::CommonBuilder,
     maybe_starting_tab_idx: Option<usize>,
@@ -22,8 +22,8 @@ pub struct Tabs<'a> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct State {
     /// An owned, ordered list of the Widget/String pairs.
-    tabs: Vec<(WidgetId, String)>,
-    /// The WidgetId of the currently selected Canvas.
+    tabs: Vec<(widget::Id, String)>,
+    /// The widget::Id of the currently selected Canvas.
     maybe_selected_tab_idx: Option<usize>,
     /// The current interaction with the Tabs.
     interaction: Interaction,
@@ -88,7 +88,7 @@ pub enum Layout {
 impl<'a> Tabs<'a> {
 
     /// Construct some new Canvas Tabs.
-    pub fn new(tabs: &'a [(WidgetId, &'a str)]) -> Tabs<'a> {
+    pub fn new(tabs: &'a [(widget::Id, &'a str)]) -> Tabs<'a> {
         Tabs {
             common: widget::CommonBuilder::new(),
             tabs: tabs,
@@ -109,8 +109,8 @@ impl<'a> Tabs<'a> {
         self
     }
 
-    /// Set the initially selected tab with a Canvas via its WidgetId.
-    pub fn starting_canvas(mut self, canvas_id: WidgetId) -> Self {
+    /// Set the initially selected tab with a Canvas via its widget::Id.
+    pub fn starting_canvas(mut self, canvas_id: widget::Id) -> Self {
         let maybe_idx = self.tabs.iter().enumerate()
             .find(|&(_, &(id, _))| canvas_id == id)
             .map(|(idx, &(_, _))| idx);


### PR DESCRIPTION
This *shouldn't* cause any breakage in the wild (none of the examples broke as a result of this) as everyone should be using the `widget_ids!` macro by now. However, technically this is a **breaking change** which brings us to 0.17.0 :)