### PR TITLE
Fix various scrolling issues. Add scrolling to the canvas in all_widgets. Changed WidgetMatrix. Added Range and Rect. Improved `set_widget` order. (See comments and commits for deets).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,16 +22,16 @@ path = "./src/lib.rs"
 
 
 [dependencies]
-bitflags = "*"
+bitflags = "0.3.2"
 clock_ticks = "0.0.6"
 elmesque = "0.9.0"
 json_io = "0.1.2"
 petgraph = "0.1.10"
 pistoncore-input = "0.8.0"
 piston2d-graphics = "0.10.0"
-num = "*"
-rand = "*"
-rustc-serialize = "*"
+num = "0.1.27"
+rand = "0.3.11"
+rustc-serialize = "0.3.16"
 vecmath = "0.2.0"
 
 [dev-dependencies]

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -48,6 +48,7 @@ use piston::event_loop::{Events, EventLoop};
 use piston::input::{RenderEvent};
 use piston::window::{WindowSettings, Size};
 
+
 type Ui = conrod::Ui<GlyphCache<'static>>;
 
 /// This struct holds all of the variables used to demonstrate
@@ -128,6 +129,7 @@ impl DemoApp {
     }
 
 }
+
 
 fn main() {
     let opengl = OpenGL::V3_2;

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -198,7 +198,7 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
     // the canvas.rs example for a demonstration of this). However, when only one `Split` is used
     // (as in this case) a single `Canvas` will simply fill the screen.
     // We can use this `Canvas` as a parent Widget upon which we can place other widgets.
-    Split::new(CANVAS).frame(demo.frame_width).color(demo.bg_color).set(ui);
+    Split::new(CANVAS).frame(demo.frame_width).color(demo.bg_color).scrolling(true).set(ui);
 
     // Calculate x and y coords for title (temporary until `Canvas`es are implemented, see #380).
     let title_x = demo.title_pad - (ui.win_w / 2.0) + 185.0;
@@ -335,7 +335,6 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
         .label_color(demo.bg_color.plain_contrast())
         .react(|new_width| demo.frame_width = new_width)
         .set(FRAME_WIDTH, ui);
-
 
     // A demonstration using widget_matrix to easily draw
     // a matrix of any kind of widget.

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -342,7 +342,7 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
     WidgetMatrix::new(cols, rows)
         .down(20.0)
         .dimensions(260.0, 260.0) // matrix width and height.
-        .each_widget(ui, |ui, num, col, row, pos, dim| { // This is called for every widget.
+        .each_widget(|_n, col: usize, row: usize| { // called for every matrix elem.
 
             // Color effect for fun.
             let (r, g, b, a) = (
@@ -352,17 +352,13 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
                 1.0
             );
 
-            // Now draw the widgets with the given.react.
-            let val = demo.bool_matrix[col][row];
-            Toggle::new(val)
-                .dim(dim)
-                .point(pos)
+            // Now return the widget we want to set in each element position.
+            Toggle::new(demo.bool_matrix[col][row])
                 .rgba(r, g, b, a)
                 .frame(demo.frame_width)
                 .react(|new_val: bool| demo.bool_matrix[col][row] = new_val)
-                .set(TOGGLE_MATRIX + num, ui);
-
-        });
+        })
+        .set(TOGGLE_MATRIX, ui);
 
     // A demonstration using a DropDownList to select its own color.
     let mut ddl_color = demo.ddl_color;
@@ -393,7 +389,7 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
     XYPad::new(demo.circle_pos[0], 550.0, 700.0, // x range.
                demo.circle_pos[1], 320.0, 170.0) // y range.
         .dimensions(150.0, 150.0)
-        .right_from(TOGGLE_MATRIX + 63, 30.0)
+        .right_from(TOGGLE_MATRIX, 30.0)
         .align_bottom() // Align to the bottom of the last TOGGLE_MATRIX element.
         .color(ddl_color)
         .frame(demo.frame_width)
@@ -443,7 +439,6 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
 
     }
 
-
 }
 
 
@@ -463,7 +458,7 @@ widget_ids! {
     COLOR_SLIDER with 3,
     SLIDER_HEIGHT,
     FRAME_WIDTH,
-    TOGGLE_MATRIX with 64,
+    TOGGLE_MATRIX,
     COLOR_SELECT,
     CIRCLE_POSITION,
     ENVELOPE_EDITOR with 4

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -313,8 +313,8 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
 
     }
 
-    // Number Dialer widget example. number_dialer(value, min, max, precision)
-    NumberDialer::new(demo.v_slider_height, 25.0, 250.0, 1u8)
+    // Number Dialer widget example. (value, min, max, precision)
+    NumberDialer::new(demo.v_slider_height, 25.0, 250.0, 1)
         .dimensions(260.0, 60.0)
         .right_from(shown_widget, 30.0)
         .color(demo.bg_color.invert())
@@ -324,8 +324,8 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
         .react(|new_height| demo.v_slider_height = new_height)
         .set(SLIDER_HEIGHT, ui);
 
-    // Number Dialer widget example. number_dialer(value, min, max, precision)
-    NumberDialer::new(demo.frame_width, 0.0, 15.0, 2u8)
+    // Number Dialer widget example. (value, min, max, precision)
+    NumberDialer::new(demo.frame_width, 0.0, 15.0, 2)
         .dimensions(260.0, 60.0)
         .down(20.0)
         .color(demo.bg_color.invert().plain_contrast())
@@ -353,6 +353,9 @@ fn set_widgets(ui: &mut Ui, demo: &mut DemoApp) {
             );
 
             // Now return the widget we want to set in each element position.
+            // You can return any type that implements `Widget`.
+            // The returned widget will automatically be positioned and sized to the matrix
+            // element's rectangle.
             Toggle::new(demo.bool_matrix[col][row])
                 .rgba(r, g, b, a)
                 .frame(demo.frame_width)

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -103,14 +103,12 @@ fn draw_ui(ui: &mut Ui, c: Context, g: &mut G2d) {
     WidgetMatrix::new(COLS, ROWS)
         .dimensions(footer_dim[0], footer_dim[1] * 2.0)
         .mid_top_of(FOOTER)
-        .each_widget(ui, |ui, n, _col, _row, xy, dim| {
+        .each_widget(|n, _col, _row| {
             Button::new()
                 .color(blue().with_luminance(n as f32 / (COLS * ROWS) as f32))
-                .dim(dim)
-                .point(xy)
-                .react(|| println!("Hey! {:?}", n))
-                .set(BUTTON + n, ui);
-        });
+                .react(move || println!("Hey! {:?}", n))
+        })
+        .set(BUTTON_MATRIX, ui);
 
     Button::new().color(red()).dimensions(30.0, 30.0).middle_of(FLOATING_A)
         .react(|| println!("Bing!"))
@@ -154,7 +152,7 @@ widget_ids! {
     FOO_LABEL,
     BAR_LABEL,
     BAZ_LABEL,
-    BUTTON with COLS * ROWS,
+    BUTTON_MATRIX,
     BING,
     BONG,
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,65 +1,51 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate glutin_window;
-extern crate opengl_graphics;
-extern crate piston;
+extern crate piston_window;
 
-use conrod::{Background, Button, color, Colorable, Labelable, Sizeable, Theme, Ui, Widget};
-use glutin_window::GlutinWindow;
-use opengl_graphics::{GlGraphics, OpenGL};
-use opengl_graphics::glyph_cache::GlyphCache;
-use piston::event_loop::{Events, EventLoop};
-use piston::input::{RenderEvent};
-use piston::window::{WindowSettings, Size};
+use conrod::{Colorable, Labelable, Sizeable, Theme, Ui, Widget};
+use piston_window::*;
 
 fn main() {
 
-    let opengl = OpenGL::V3_2;
-    let window: GlutinWindow =
-        WindowSettings::new(
-            "Hello Conrod".to_string(),
-            Size { width: 200, height: 100 }
-        )
-        .opengl(opengl)
-        .exit_on_esc(true)
-        .samples(4)
-        .build()
-        .unwrap();
-    let event_iter = window.events().ups(180).max_fps(60);
-    let mut gl = GlGraphics::new(opengl);
-    let assets = find_folder::Search::ParentsThenKids(3, 3)
-        .for_folder("assets").unwrap();
-    let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
-    let theme = Theme::default();
-    let glyph_cache = GlyphCache::new(&font_path).unwrap();
-    let ui = &mut Ui::new(glyph_cache, theme);
+    // Construct the window.
+    let window: PistonWindow =
+        WindowSettings::new("Click me!", [200, 100])
+            .exit_on_esc(true).build().unwrap();
 
-    let mut count: u32 = 0;
+    // construct our `Ui`.
+    let mut ui = {
+        let assets = find_folder::Search::ParentsThenKids(3, 3)
+            .for_folder("assets").unwrap();
+        let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
+        let theme = Theme::default();
+        let glyph_cache = Glyphs::new(&font_path, window.factory.borrow().clone());
+        Ui::new(glyph_cache.unwrap(), theme)
+    };
 
-    for event in event_iter {
+    let mut count = 0;
+
+    // Poll events from the window.
+    for event in window {
         ui.handle_event(&event);
-        if let Some(args) = event.render_args() {
-            gl.draw(args.viewport(), |c, gl| {
+        event.draw_2d(|c, g| {
 
-                // Set the background color to use for clearing the screen.
-                Background::new().rgb(0.2, 0.25, 0.4).set(ui);
+            // Set the background color to use for clearing the screen.
+            conrod::Background::new().rgb(0.2, 0.25, 0.4).set(&mut ui);
 
-                // Generate the ID for BUTTON.
-                widget_ids!(COUNTER);
+            // Generate the ID for BUTTON.
+            widget_ids!(COUNTER);
 
-                // Draw the button and increment count if pressed..
-                Button::new()
-                    .color(color::red())
-                    .dimensions(80.0, 80.0)
-                    .label(&count.to_string())
-                    .react(|| count += 1)
-                    .set(COUNTER, ui);
+            // Draw the button and increment `count` if pressed.
+            conrod::Button::new()
+                .color(conrod::color::red())
+                .dimensions(80.0, 80.0)
+                .label(&count.to_string())
+                .react(|| count += 1)
+                .set(COUNTER, &mut ui);
 
-                // Draw our Ui!
-                ui.draw_if_changed(c, gl);
-
-            });
-        }
+            // Draw our Ui!
+            ui.draw_if_changed(c, g);
+        });
     }
 
 }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -32,7 +32,7 @@ fn main() {
             // Set the background color to use for clearing the screen.
             conrod::Background::new().rgb(0.2, 0.25, 0.4).set(&mut ui);
 
-            // Generate the ID for BUTTON.
+            // Generate the ID for the Button COUNTER.
             widget_ids!(COUNTER);
 
             // Draw the button and increment `count` if pressed.

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -8,9 +8,8 @@ use piston_window::*;
 fn main() {
 
     // Construct the window.
-    let window: PistonWindow =
-        WindowSettings::new("Click me!", [200, 100])
-            .exit_on_esc(true).build().unwrap();
+    let window: PistonWindow = WindowSettings::new("Click me!", [200, 100])
+        .exit_on_esc(true).build().unwrap();
 
     // construct our `Ui`.
     let mut ui = {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -260,8 +260,9 @@ mod circular_button {
         fn update<'b, C>(mut self, args: UpdateArgs<'b, Self, C>) -> Option<State>
             where C: CharacterCache,
         {
-            let UpdateArgs { prev_state, xy, dim, ui, .. } = args;
+            let UpdateArgs { prev_state, rect, ui, .. } = args;
             let WidgetState { ref state, .. } = *prev_state;
+            let (xy, dim) = rect.xy_dim();
             let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
 
             // Check whether or not a new interaction has occurred.
@@ -336,7 +337,8 @@ mod circular_button {
             use elmesque::form::{collage, circle, text};
 
             // Unwrap the args and state structs into individual variables.
-            let DrawArgs { dim, xy, state, style, theme, .. } = args;
+            let DrawArgs { rect, state, style, theme, .. } = args;
+            let (xy, dim) = rect.xy_dim();
 
             // Retrieve the styling for the Element.
             let color = state.color(style.color(theme));

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -336,8 +336,7 @@ mod circular_button {
             use elmesque::form::{collage, circle, text};
 
             // Unwrap the args and state structs into individual variables.
-            let DrawArgs { state, style, theme, .. } = args;
-            let WidgetState { ref state, dim, xy, .. } = *state;
+            let DrawArgs { dim, xy, state, style, theme, .. } = args;
 
             // Retrieve the styling for the Element.
             let color = state.color(style.color(theme));

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -239,7 +239,7 @@ impl Graph {
                     Visitable::Scrollbar(idx) => {
                         if let Some(&Node::Widget(ref container)) = graph.node_weight(idx) {
                             if let Some(ref scrolling) = container.maybe_scrolling {
-                                if widget::scroll::is_over(scrolling, container.kid_area.rect, xy) {
+                                if scrolling.is_over(xy) {
                                     return true;
                                 }
                             }
@@ -316,7 +316,7 @@ impl Graph {
                 // Check the current widget for any scroll offset.
                 if let Some(&Node::Widget(ref container)) = graph.node_weight(idx) {
                     if let Some(ref scrolling) = container.maybe_scrolling {
-                        let scroll_offset = scrolling.pos_offset();
+                        let scroll_offset = scrolling.kids_pos_offset();
                         offset[0] += scroll_offset[0].round();
                         offset[1] += scroll_offset[1].round();
                     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -615,12 +615,11 @@ impl Graph {
         // `Edge::RelativePosition`.
         if let Some(relative_idx) = maybe_positioned_relatively_to {
             self.set_relative_position_edge(relative_idx, idx);
-        // Otherwise if the widget is not positioned relatively to any other widget, we should
-        // ensure that there are no incoming `RelativePosition` edges.
         } else {
+            // Otherwise if the widget is not positioned relatively to any other widget, we should
+            // ensure that there are no incoming `RelativePosition` edges.
             self.remove_incoming_relative_position_edge(idx);
         }
-
     }
 
 
@@ -804,7 +803,7 @@ fn set_edge(graph: &mut PetGraph, a: NodeIndex, b: NodeIndex, edge: Edge) {
             graph.remove_edge(new_edge);
             writeln!(::std::io::stderr(),
                      "Error: Adding a connection from node {:?} to node {:?} would cause a cycle \
-                     within the Graph.\n{:?}", a, b, graph).unwrap();
+                     within the Graph.", a, b).unwrap();
         }
     }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -316,16 +316,9 @@ impl Graph {
                 // Check the current widget for any scroll offset.
                 if let Some(&Node::Widget(ref container)) = graph.node_weight(idx) {
                     if let Some(ref scrolling) = container.maybe_scrolling {
-
-                        // Vertical offset.
-                        if let Some(ref bar) = scrolling.maybe_vertical {
-                            offset[1] += bar.pos_offset(container.kid_area.rect.h()).round();
-                        }
-
-                        // Horizontal offset.
-                        if let Some(ref bar) = scrolling.maybe_horizontal {
-                            offset[0] += bar.pos_offset(container.kid_area.rect.w()).round();
-                        }
+                        let scroll_offset = scrolling.pos_offset();
+                        offset[0] += scroll_offset[0].round();
+                        offset[1] += scroll_offset[1].round();
                     }
                 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -599,12 +599,9 @@ impl Graph {
     /// The order in which we will draw all widgets will be a akin to a depth-first search, where
     /// the branches with the highest `depth` are drawn first (unless the branch is on a captured
     /// widget, which will always be drawn last).
-    pub fn element<M, K>(&mut self,
-                         maybe_captured_mouse: Option<M>,
-                         maybe_captured_keyboard: Option<K>) -> Element
-        where
-            M: GraphIndex,
-            K: GraphIndex,
+    pub fn element(&mut self,
+                   maybe_captured_mouse: Option<widget::Index>,
+                   maybe_captured_keyboard: Option<widget::Index>) -> Element
     {
         // Convert the GraphIndex for the widget capturing the mouse into a NodeIndex.
         let maybe_captured_mouse = maybe_captured_mouse
@@ -672,13 +669,13 @@ impl Graph {
                             // Now that we've come across a scrollbar, we should pop the group of
                             // elements from the top of our scrollstack for cropping.
                             if let Some(scroll_group) = scroll_stack.pop() {
-                                let (x, y, w, h) = container.kid_area.rect.x_y_w_h();
+                                let (x, y, w, h) = scrolling.visible.x_y_w_h();
                                 let element = layers(scroll_group).crop(x, y, w, h);
                                 elements.push(element);
                             }
 
                             // Construct the element for the scrollbar itself.
-                            let element = widget::scroll::element(container.kid_area.rect, scrolling);
+                            let element = scrolling.element();
                             elements.push(element);
                         }
                     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,7 +3,7 @@
 use elmesque::Element;
 use elmesque::element::layers;
 use petgraph as pg;
-use position::{Depth, Dimensions, is_over_rect, Point, Rect};
+use position::{Depth, Point, Rect};
 use self::index_map::IndexMap;
 use std::any::Any;
 use std::fmt::Debug;

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -706,12 +706,9 @@ impl Graph {
 
     /// Same as `Graph::element`, but only returns a new `Element` if any of the widgets'
     /// `Element`s in the graph have changed.
-    pub fn element_if_changed<M, K>(&mut self,
-                                    maybe_captured_mouse: Option<M>,
-                                    maybe_captured_keyboard: Option<K>) -> Option<Element>
-        where
-            M: GraphIndex,
-            K: GraphIndex,
+    pub fn element_if_changed(&mut self,
+                              maybe_captured_mouse: Option<widget::Index>,
+                              maybe_captured_keyboard: Option<widget::Index>) -> Option<Element>
     {
         // Only return a new element if one or more of the `Widget` `Element`s have changed.
         match self.have_any_elements_changed() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub use position::{middle_of, top_left_of, top_right_of, bottom_left_of, bottom_
 pub use position::{Corner, Depth, Direction, Dimensions, Horizontal, HorizontalAlign, Margin,
                    Padding, Place, Point, Position, Positionable, Range, Rect, Sizeable,
                    Vertical, VerticalAlign};
+pub use position::Matrix as PositionMatrix;
 pub use theme::{Align, Theme};
 pub use ui::{GlyphCache, Ui, UserInput};
 pub use widget::{drag, scroll, CommonBuilder, DrawArgs, UiCell, UpdateArgs, Widget};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ pub use position::{align_left_of, align_right_of, align_bottom_of, align_top_of}
 pub use position::{middle_of, top_left_of, top_right_of, bottom_left_of, bottom_right_of,
                    mid_top_of, mid_bottom_of, mid_left_of, mid_right_of};
 pub use position::{Corner, Depth, Direction, Dimensions, Horizontal, HorizontalAlign, Margin,
-                   Padding, Place, Point, Position, Positionable, Sizeable, Vertical,
-                   VerticalAlign};
+                   Padding, Place, Point, Position, Positionable, Range, Rect, Sizeable,
+                   Vertical, VerticalAlign};
 pub use theme::{Align, Theme};
 pub use ui::{GlyphCache, Ui, UserInput};
 pub use widget::{drag, scroll, CommonBuilder, DrawArgs, UiCell, UpdateArgs, Widget};

--- a/src/position.rs
+++ b/src/position.rs
@@ -666,6 +666,16 @@ impl Range {
         pos >= start && pos <= end
     }
 
+    /// Round the values at both ends of the Range and return the result.
+    pub fn round(self) -> Range {
+        Range::new(self.start.round()..self.end.round())
+    }
+
+    /// Floor the values at both ends of the Range and return the result.
+    pub fn floor(self) -> Range {
+        Range::new(self.start.floor()..self.end.floor())
+    }
+
     /// Shorten the Range from both ends by the given Scalar amount.
     pub fn sub_frame(self, frame: Scalar) -> Range {
         if self.direction() >= 0.0 {
@@ -708,7 +718,6 @@ impl ::std::ops::Sub<Range> for Range {
         Range::new(self.start - rhs.start .. self.end - rhs.end)
     }
 }
-
 
 
 /// Start and end bounds on a single axis.
@@ -884,7 +893,6 @@ impl ::std::ops::Sub<Rect> for Rect {
         }
     }
 }
-
 
 
 /// A function to simplify determining whether or not a point `xy` is over a rectangle.

--- a/src/position.rs
+++ b/src/position.rs
@@ -376,9 +376,9 @@ pub trait Sizeable: Sized {
     }
 
     /// The dimensions for the widget.
-    fn get_dimensions<C: CharacterCache>(&self,
-                                         theme: &Theme,
-                                         glyph_cache: &GlyphCache<C>) -> Dimensions {
+    fn get_dimensions<C: CharacterCache>(&self, theme: &Theme, glyph_cache: &GlyphCache<C>)
+        -> Dimensions
+    {
         [self.get_width(theme, glyph_cache), self.get_height(theme)]
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -694,13 +694,26 @@ impl Range {
         }
     }
 
+    /// The Range with some padding given to the `start` value.
+    pub fn pad_start(mut self, pad: Scalar) -> Range {
+        self.start += if self.start <= self.end { pad } else { -pad };
+        self
+    }
+
+    /// The Range with some padding given to the `end` value.
+    pub fn pad_end(mut self, pad: Scalar) -> Range {
+        self.end += if self.start <= self.end { -pad } else { pad };
+        self
+    }
+
+    /// The Range with some given padding to be applied to each end.
+    pub fn pad(self, pad: Scalar) -> Range {
+        self.pad_start(pad).pad_end(pad)
+    }
+
     /// The Range with some padding given for each end.
-    pub fn padded(self, pad_start: Scalar, pad_end: Scalar) -> Range {
-        if self.start <= self.end {
-            Range::new(self.start + pad_start .. self.end - pad_end)
-        } else {
-            Range::new(self.start - pad_start .. self.end + pad_end)
-        }
+    pub fn padding(self, start: Scalar, end: Scalar) -> Range {
+        self.pad_start(start).pad_end(end)
     }
 
 }
@@ -864,11 +877,37 @@ impl Rect {
         }
     }
 
+    /// The Rect with some padding applied to the left edge.
+    pub fn pad_left(self, pad: Scalar) -> Rect {
+        Rect { x: self.x.pad_start(pad), ..self }
+    }
+
+    /// The Rect with some padding applied to the right edge.
+    pub fn pad_right(self, pad: Scalar) -> Rect {
+        Rect { x: self.x.pad_end(pad), ..self }
+    }
+
+    /// The rect with some padding applied to the bottom edge.
+    pub fn pad_bottom(self, pad: Scalar) -> Rect {
+        Rect { y: self.y.pad_start(pad), ..self }
+    }
+
+    /// The Rect with some padding applied to the top edge.
+    pub fn pad_top(self, pad: Scalar) -> Rect {
+        Rect { y: self.y.pad_end(pad), ..self }
+    }
+
+    /// The Rect with some padding amount applied to each edge.
+    pub fn pad(self, pad: Scalar) -> Rect {
+        let Rect { x, y } = self;
+        Rect { x: x.pad(pad), y: y.pad(pad) }
+    }
+
     /// The Rect with some padding applied.
-    pub fn padded(self, padding: Padding) -> Rect {
+    pub fn padding(self, padding: Padding) -> Rect {
         Rect {
-            x: self.x.padded(padding.left, padding.right),
-            y: self.y.padded(padding.bottom, padding.top),
+            x: self.x.padding(padding.left, padding.right),
+            y: self.y.padding(padding.bottom, padding.top),
         }
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -794,6 +794,11 @@ impl Rect {
         (xy[0], xy[1], dim[0], dim[1])
     }
 
+    /// The length of the longest side of the rectangle.
+    pub fn len(&self) -> Scalar {
+        ::utils::partial_max(self.w(), self.h())
+    }
+
     /// The Rect's lowest y value.
     pub fn bottom(&self) -> Scalar {
         self.y.undirected().start

--- a/src/position.rs
+++ b/src/position.rs
@@ -678,20 +678,12 @@ impl Range {
 
     /// Shorten the Range from both ends by the given Scalar amount.
     pub fn sub_frame(self, frame: Scalar) -> Range {
-        if self.direction() >= 0.0 {
-            Range::new(self.start + frame .. self.end - frame)
-        } else {
-            Range::new(self.start - frame .. self.end + frame)
-        }
+        self.pad(frame)
     }
 
     /// Lengthen the Range from both ends by the given Scalar amount.
     pub fn add_frame(self, frame: Scalar) -> Range {
-        if self.start <= self.end {
-            Range::new(self.start - frame .. self.end + frame)
-        } else {
-            Range::new(self.start + frame .. self.end - frame)
-        }
+        self.pad(-frame)
     }
 
     /// The Range with some padding given to the `start` value.
@@ -939,4 +931,5 @@ impl ::std::ops::Sub<Rect> for Rect {
 pub fn is_over_rect(rect_xy: Point, rect_dim: Dimensions, xy: Point) -> bool {
     Rect::from_xy_dim(rect_xy, rect_dim).is_over(xy)
 }
+
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -48,6 +48,8 @@ pub struct Theme {
     pub maybe_drop_down_list: Option<WidgetDefault<widget::drop_down_list::Style>>,
     /// Optional style defaults for an EnvelopeEditor.
     pub maybe_envelope_editor: Option<WidgetDefault<widget::envelope_editor::Style>>,
+    /// Optional style defaults for a Matrix.
+    pub maybe_matrix: Option<WidgetDefault<widget::matrix::Style>>,
     /// Optional style defaults for a NumberDialer.
     pub maybe_number_dialer: Option<WidgetDefault<widget::number_dialer::Style>>,
     /// Optional style defaults for a Scrollbar.
@@ -130,6 +132,7 @@ impl Theme {
             maybe_canvas: None,
             maybe_drop_down_list: None,
             maybe_envelope_editor: None,
+            maybe_matrix: None,
             maybe_number_dialer: None,
             maybe_slider: None,
             maybe_tabs: None,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -584,12 +584,6 @@ pub fn widget_graph_mut<C>(ui: &mut Ui<C>) -> &mut Graph {
 }
 
 
-/// Set the ID of the current canvas.
-pub fn set_current_parent_idx<C>(ui: &mut Ui<C>, idx: widget::Index) {
-    ui.maybe_current_parent_idx = Some(idx);
-}
-
-
 /// Check the given position for an attached parent widget.
 pub fn parent_from_position<C>(ui: &Ui<C>, position: Position) -> Option<widget::Index> {
     match position {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -604,6 +604,12 @@ pub fn parent_from_position<C>(ui: &Ui<C>, position: Position) -> Option<widget:
 }
 
 
+/// A function to allow the position matrix to set the current parent within the `Ui`.
+pub fn set_current_parent_idx<C>(ui: &mut Ui<C>, idx: widget::Index) {
+    ui.maybe_current_parent_idx = Some(idx);
+}
+
+
 /// Return the user input state available for the widget with the given ID.
 /// Take into consideration whether or not each input type is captured.
 pub fn user_input<'a, C>(ui: &'a Ui<C>, idx: widget::Index) -> UserInput<'a> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -489,8 +489,7 @@ impl<C> Ui<C> {
                     Some(color) => element.clear(color),
                     None => element
                 };
-                // If we have a new `Element` we'll update our stored `Element` and reset the
-                // redraw_count to num_redraw_frames.
+                // If we have a new `Element` we'll update our stored `Element`.
                 *maybe_element = Some(element.clone());
                 maybe_element.as_ref().unwrap()
             })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,7 @@
 
 
 use num::{Float, NumCast, PrimInt, ToPrimitive};
-use position::{Dimensions, Point};
-use vecmath::vec2_sub;
+
 
 /// Compare to PartialOrd values and return the min.
 pub fn partial_min<T: PartialOrd>(a: T, b: T) -> T {
@@ -17,16 +16,13 @@ pub fn partial_max<T: PartialOrd>(a: T, b: T) -> T {
     if a >= b { a } else { b }
 }
 
-/// Clamp a value between a given min and max.
-pub fn clamp<T: PartialOrd>(n: T, min: T, max: T) -> T {
-    if n < min { min } else if n > max { max } else { n }
-}
-
-/// Return whether or not a given point is over a rectangle at a given point on a cartesian plane.
-pub fn is_over_rect(rect_point: Point, mouse_point: Point, rect_dim: Dimensions) -> bool {
-    let point = vec2_sub(rect_point, mouse_point);
-    if point[0].abs() < rect_dim[0] / 2.0 && point[1].abs() < rect_dim[1] / 2.0 { true }
-    else { false }
+/// Clamp a value between some range.
+pub fn clamp<T: PartialOrd>(n: T, start: T, end: T) -> T {
+    if start <= end {
+        if n < start { start } else if n > end { end } else { n }
+    } else {
+        if n < end { end } else if n > start { start } else { n }
+    }
 }
 
 /// Get value percentage between max and min.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,3 +89,45 @@ pub fn val_to_string<T: ToString + NumCast>
     }
 }
 
+
+#[test]
+fn test_map_range() {
+
+    // Normal positive to normal positive.
+    assert_eq!(map_range(0.0, 0.0, 5.0, 0.0, 10.0), 0.0);
+    assert_eq!(map_range(2.5, 0.0, 5.0, 0.0, 10.0), 5.0);
+    assert_eq!(map_range(5.0, 0.0, 5.0, 0.0, 10.0), 10.0);
+
+    // Normal positive to normal negative.
+    assert_eq!(map_range(0.0, 0.0, 5.0, -10.0, 0.0), -10.0);
+    assert_eq!(map_range(2.5, 0.0, 5.0, -10.0, 0.0), -5.0);
+    assert_eq!(map_range(5.0, 0.0, 5.0, -10.0, 0.0), 0.0);
+
+    // Normal positive to inverse positive.
+    assert_eq!(map_range(0.0, 0.0, 5.0, 10.0, 0.0), 10.0);
+    assert_eq!(map_range(2.5, 0.0, 5.0, 10.0, 0.0), 5.0);
+    assert_eq!(map_range(5.0, 0.0, 5.0, 10.0, 0.0), 0.0);
+
+    // Normal positive to inverse negative.
+    assert_eq!(map_range(0.0, 0.0, 5.0, 0.0, -10.0), 0.0);
+    assert_eq!(map_range(2.5, 0.0, 5.0, 0.0, -10.0), -5.0);
+    assert_eq!(map_range(5.0, 0.0, 5.0, 0.0, -10.0), -10.0);
+
+
+    // Normal negative to normal positive.
+    assert_eq!(map_range(-5.0, -5.0, 0.0, 0.0, 10.0), 0.0);
+    assert_eq!(map_range(-2.5, -5.0, 0.0, 0.0, 10.0), 5.0);
+    assert_eq!(map_range(0.0, -5.0, 0.0, 0.0, 10.0), 10.0);
+
+    // Normal negative to normal negative.
+    assert_eq!(map_range(-5.0, -5.0, 0.0, -10.0, 0.0), -10.0);
+    assert_eq!(map_range(-2.5, -5.0, 0.0, -10.0, 0.0), -5.0);
+    assert_eq!(map_range(0.0, -5.0, 0.0, -10.0, 0.0), 0.0);
+
+
+    // Inverse positive to normal positive.
+    assert_eq!(map_range(5.0, 5.0, 0.0, 0.0, 10.0), 0.0);
+    assert_eq!(map_range(2.5, 5.0, 0.0, 0.0, 10.0), 5.0);
+    assert_eq!(map_range(0.0, 5.0, 0.0, 0.0, 10.0), 10.0);
+
+}

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -6,7 +6,7 @@ use frame::Frameable;
 use graphics::character::CharacterCache;
 use label::{FontSize, Labelable};
 use mouse::Mouse;
-use position::{self, Positionable};
+use position::Positionable;
 use theme::Theme;
 use ui::GlyphCache;
 use widget::{self, Widget};

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -108,10 +108,7 @@ impl<'a, F> Button<'a, F> {
 }
 
 
-impl<'a, F> Widget for Button<'a, F>
-    where
-        F: FnMut()
-{
+impl<'a, F> Widget for Button<'a, F> where F: FnMut() {
     type State = State;
     type Style = Style;
 
@@ -153,8 +150,8 @@ impl<'a, F> Widget for Button<'a, F>
     }
 
     /// Update the state of the Button.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
-        where C: CharacterCache,
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State>
+        where C: CharacterCache
     {
         use utils::is_over_rect;
         let widget::UpdateArgs { prev_state, xy, dim, ui, .. } = args;
@@ -193,8 +190,8 @@ impl<'a, F> Widget for Button<'a, F>
     }
 
     /// Construct an Element from the given Button State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
-        where C: CharacterCache,
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
+        where C: CharacterCache
     {
         use elmesque::form::{collage, rect, text};
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -195,8 +195,7 @@ impl<'a, F> Widget for Button<'a, F> where F: FnMut() {
     {
         use elmesque::form::{collage, rect, text};
 
-        let widget::DrawArgs { state, style, theme, .. } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { state, style, theme, dim, xy, .. } = args;
 
         // Retrieve the styling for the Element..
         let color = state.color(style.color(theme));

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -7,7 +7,6 @@ use graphics::character::CharacterCache;
 use label::FontSize;
 use mouse::Mouse;
 use position::{self, Dimensions, Horizontal, Margin, Padding, Place, Point, Position, Rect};
-use super::drag;
 use theme::Theme;
 use widget::{self, Widget};
 use ui::GlyphCache;
@@ -400,7 +399,6 @@ fn title_bar(canvas: Rect, font_size: FontSize) -> Rect {
 
 /// Is the mouse over the canvas, if so which Elem.
 fn is_over(canvas: Rect, maybe_title_bar_rect: Option<Rect>, mouse_xy: Point) -> Option<Elem> {
-    use position::is_over_rect;
     if let Some(rect) = maybe_title_bar_rect {
         if rect.is_over(mouse_xy) {
             return Some(Elem::TitleBar);

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -253,7 +253,7 @@ impl<'a> Widget for Canvas<'a> {
             let font_size = style.title_bar_font_size(theme);
             let title_bar = title_bar(rect, font_size);
             widget::KidArea {
-                rect: rect - title_bar,
+                rect: rect.pad_top(title_bar.h()),
                 pad: style.padding(theme),
             }
         } else {

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -65,7 +65,7 @@ pub struct MarginBuilder {
     pub maybe_bottom: Option<Scalar>,
 }
 
-/// Describes the style of a Canvas Floating.
+/// Describes the style of a Canvas.
 #[allow(missing_copy_implementations)]
 #[derive(Clone, Debug, PartialEq, RustcDecodable, RustcEncodable)]
 pub struct Style {
@@ -87,7 +87,7 @@ pub struct Style {
     pub margin: MarginBuilder,
 }
 
-/// Describes an interaction with the Floating Canvas.
+/// Describes an interaction with the Canvas.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Interaction {
     Normal,
@@ -453,7 +453,7 @@ impl Style {
         }
     }
 
-    /// Get the color for the Floating's Element.
+    /// Get the color for the Canvas' Element.
     pub fn color(&self, theme: &Theme) -> Color {
         self.maybe_color.or(theme.maybe_canvas.as_ref().map(|default| {
             default.style.maybe_color.unwrap_or(theme.background_color)

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -6,7 +6,7 @@ use elmesque::element::Element;
 use graphics::character::CharacterCache;
 use label::FontSize;
 use mouse::Mouse;
-use position::{self, Dimensions, Horizontal, Margin, Padding, Place, Point, Position};
+use position::{self, Dimensions, Horizontal, Margin, Padding, Place, Point, Position, Rect};
 use super::drag;
 use theme::Theme;
 use widget::{self, Widget};
@@ -37,8 +37,7 @@ const TITLE_BAR_LABEL_PADDING: f64 = 4.0;
 #[derive(Clone, Debug, PartialEq)]
 pub struct TitleBar {
     maybe_label: Option<(String, FontSize)>,
-    y: Scalar,
-    h: Scalar,
+    rect: Rect,
 }
 
 /// A builder for the padding of the area where child widgets will be placed.
@@ -238,14 +237,11 @@ impl<'a> Widget for Canvas<'a> {
 
     /// The title bar area at which the Canvas can be clicked and dragged.
     /// The position of the area should be relative to the center of the widget..
-    fn drag_area(&self, dim: Dimensions, style: &Style, theme: &Theme) -> Option<drag::Area> {
+    fn drag_area(&self, dim: Dimensions, style: &Style, theme: &Theme) -> Option<Rect> {
         if self.show_title_bar {
             let font_size = style.title_bar_font_size(theme);
-            let (h, y) = title_bar_h_y(dim, font_size as f64);
-            Some(drag::Area {
-                xy: [0.0, y],
-                dim: [dim[0], h],
-            })
+            let (h, y) = title_bar_h_rel_y(dim[1], font_size);
+            Some(Rect::from_xy_dim([0.0, y], [dim[0], h]))
         } else {
             None
         }
@@ -253,19 +249,17 @@ impl<'a> Widget for Canvas<'a> {
 
     /// The area of the widget below the title bar, upon which child widgets will be placed.
     fn kid_area<C: CharacterCache>(&self, args: widget::KidAreaArgs<Self, C>) -> widget::KidArea {
-        let widget::KidAreaArgs { xy, dim, style, theme, .. } = args;
+        let widget::KidAreaArgs { rect, style, theme, .. } = args;
         if self.show_title_bar {
             let font_size = style.title_bar_font_size(theme);
-            let (title_bar_h, _) = title_bar_h_y(dim, font_size as f64);
+            let title_bar = title_bar(rect, font_size);
             widget::KidArea {
-                xy: [xy[0], xy[1] - (title_bar_h / 2.0)],
-                dim: [dim[0], dim[1] - title_bar_h],
+                rect: rect - title_bar,
                 pad: style.padding(theme),
             }
         } else {
             widget::KidArea {
-                xy: xy,
-                dim: dim,
+                rect: rect,
                 pad: style.padding(theme),
             }
         }
@@ -275,22 +269,20 @@ impl<'a> Widget for Canvas<'a> {
     fn update<C>(self, args: widget::UpdateArgs<Self, C>) -> Option<State>
         where C: CharacterCache,
     {
-        let widget::UpdateArgs { prev_state, xy, dim, ui, .. } = args;
+        let widget::UpdateArgs { prev_state, rect, ui, .. } = args;
         let widget::State { ref state, .. } = *prev_state;
         let State { interaction, time_last_clicked, ref maybe_title_bar } = *state;
-        let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
+        let maybe_mouse = ui.input().maybe_mouse;
         let title_bar_font_size = self.style.title_bar_font_size(ui.theme());
-
-        // Calculate the height and y coord of the title bar.
-        let (title_bar_h, title_bar_y) = if self.show_title_bar {
-            title_bar_h_y(dim, title_bar_font_size as f64)
+        let maybe_title_bar_rect = if self.show_title_bar {
+            Some(title_bar(rect, title_bar_font_size))
         } else {
-            (0.0, 0.0)
+            None
         };
 
         // If there is new mouse state, check for a new interaction.
         let new_interaction = if let Some(mouse) = maybe_mouse {
-            let is_over_elem = is_over(mouse.xy, dim, title_bar_y, title_bar_h);
+            let is_over_elem = is_over(rect, maybe_title_bar_rect, mouse.xy);
             get_new_interaction(is_over_elem, interaction, mouse)
         } else {
             Interaction::Normal
@@ -308,16 +300,11 @@ impl<'a> Widget for Canvas<'a> {
         let new_state = || State {
             interaction: new_interaction,
             time_last_clicked: new_time_last_clicked,
-            maybe_title_bar: if self.show_title_bar {
-                Some(TitleBar {
-                    maybe_label: self.maybe_title_bar_label.as_ref()
-                        .map(|label| (label.to_string(), title_bar_font_size)),
-                    h: title_bar_h,
-                    y: title_bar_y,
-                })
-            } else {
-                None
-            },
+            maybe_title_bar: maybe_title_bar_rect.map(|rect| TitleBar {
+                maybe_label: self.maybe_title_bar_label.as_ref()
+                    .map(|label| (label.to_string(), title_bar_font_size)),
+                rect: rect,
+            }),
         };
 
         // Check whether or not the state has changed since the previous update.
@@ -326,8 +313,7 @@ impl<'a> Widget for Canvas<'a> {
             || match *maybe_title_bar {
                 None => self.show_title_bar,
                 Some(ref title_bar) => {
-                    title_bar.y != title_bar_y
-                    || title_bar.h != title_bar_h
+                    Some(title_bar.rect) != maybe_title_bar_rect
                     || match title_bar.maybe_label {
                         None => false,
                         Some((ref label, font_size)) => {
@@ -346,29 +332,30 @@ impl<'a> Widget for Canvas<'a> {
     fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
-        use elmesque::form::{collage, rect, text};
+        use elmesque::form::{self, collage, text};
 
-        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
+        let widget::DrawArgs { rect, state, style, theme, glyph_cache, .. } = args;
 
         let frame = style.frame(theme);
-        let inner_dim = ::vecmath::vec2_sub(dim, [frame * 2.0; 2]);
+        let inner = rect.sub_frame(frame);
         let color = style.color(theme);
         let frame_color = style.frame_color(theme);
-        let frame_form = rect(dim[0], dim[1]).filled(frame_color);
-        let rect_form = rect(inner_dim[0], inner_dim[1]).filled(color);
+        let frame_form = form::rect(rect.w(), rect.h()).filled(frame_color);
+        let rect_form = form::rect(inner.w(), inner.h()).filled(color);
 
         // Check whether or not to draw the title bar.
         let maybe_title_bar_form = if let Some(ref title_bar) = state.maybe_title_bar {
-            let inner_dim = ::vecmath::vec2_sub([dim[0], title_bar.h], [frame * 2.0; 2]);
-            let title_bar_frame_form = rect(dim[0], title_bar.h).filled(frame_color);
-            let title_bar_rect_form = rect(inner_dim[0], inner_dim[1]).filled(color);
+            let inner = title_bar.rect.sub_frame(frame);
+            let (w, h) = title_bar.rect.w_h();
+            let title_bar_frame_form = form::rect(w, h).filled(frame_color);
+            let title_bar_rect_form = form::rect(inner.w(), inner.h()).filled(color);
             // Check whether or not to draw the title bar's label.
             let maybe_label_form = title_bar.maybe_label.as_ref().map(|&(ref label, font_size)| {
                 use elmesque::text::Text;
                 let label_color = style.title_bar_label_color(theme);
                 let align = style.title_bar_label_align(theme);
                 let label_width = glyph_cache.width(font_size, label);
-                let label_x = align.to(inner_dim[0], label_width) + TITLE_BAR_LABEL_PADDING;
+                let label_x = align.to(inner.w(), label_width) + TITLE_BAR_LABEL_PADDING;
                 text(Text::from_string(label.clone())
                         .color(label_color)
                         .height(font_size as f64)).shift_x(label_x)
@@ -376,7 +363,7 @@ impl<'a> Widget for Canvas<'a> {
             Some(Some(title_bar_frame_form).into_iter()
                 .chain(Some(title_bar_rect_form).into_iter())
                 .chain(maybe_label_form)
-                .map(move |form| form.shift_y(title_bar.y)))
+                .map(move |form| form.shift_y(title_bar.rect.y())))
         } else {
             None
         };
@@ -385,36 +372,42 @@ impl<'a> Widget for Canvas<'a> {
         let form_chain = Some(frame_form).into_iter()
             .chain(Some(rect_form).into_iter())
             .chain(maybe_title_bar_form.into_iter().flat_map(|it| it))
-            .map(|form| form.shift(xy[0], xy[1]));
+            .map(|form| form.shift(rect.x(), rect.y()));
 
         // Construct the renderable element.
-        collage(dim[0] as i32, dim[1] as i32, form_chain.collect())
+        collage(rect.w() as i32, rect.h() as i32, form_chain.collect())
     }
 
 }
 
 
-/// Calculate the height and y position of the Title Bar.
-fn title_bar_h_y(dim: Dimensions, font_size: f64) -> (Scalar, Scalar) {
-    let h = font_size as f64 + TITLE_BAR_LABEL_PADDING * 2.0;
-    let y = position::align_top_of(dim[1], h);
-    (h, y)
+/// The height and relative y coordinate of a Canvas' title bar given some canvas height and font
+/// size for the title bar.
+fn title_bar_h_rel_y(canvas_h: Scalar, font_size: FontSize) -> (Scalar, Scalar) {
+    let h = font_size as Scalar + TITLE_BAR_LABEL_PADDING * 2.0;
+    let rel_y = position::align_top_of(canvas_h, h);
+    (h, rel_y)
+}
+
+/// The Rect for the Canvas' title bar.
+fn title_bar(canvas: Rect, font_size: FontSize) -> Rect {
+    let (h, rel_y) = title_bar_h_rel_y(canvas.h(), font_size);
+    let xy = [canvas.x(), canvas.y() + rel_y];
+    let dim = [canvas.w(), h];
+    Rect::from_xy_dim(xy, dim)
 }
 
 
 /// Is the mouse over the canvas, if so which Elem.
-fn is_over(mouse_xy: Point,
-           dim: Dimensions,
-           title_bar_y: f64,
-           title_bar_h: f64) -> Option<Elem>
-{
-    use utils::is_over_rect;
-    if is_over_rect([0.0, 0.0], mouse_xy, dim) {
-        if is_over_rect([0.0, title_bar_y], mouse_xy, [dim[0], title_bar_h]) {
-            Some(Elem::TitleBar)
-        } else {
-            Some(Elem::WidgetArea)
+fn is_over(canvas: Rect, maybe_title_bar_rect: Option<Rect>, mouse_xy: Point) -> Option<Elem> {
+    use position::is_over_rect;
+    if let Some(rect) = maybe_title_bar_rect {
+        if rect.is_over(mouse_xy) {
+            return Some(Elem::TitleBar);
         }
+    }
+    if canvas.is_over(mouse_xy) {
+        Some(Elem::WidgetArea)
     } else {
         None
     }

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -269,7 +269,7 @@ impl<'a> Widget for Canvas<'a> {
     }
 
     /// Update the state of the Canvas.
-    fn update<'b, C>(self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
+    fn update<C>(self, args: widget::UpdateArgs<Self, C>) -> Option<State>
         where C: CharacterCache,
     {
         let widget::UpdateArgs { prev_state, xy, dim, ui, .. } = args;
@@ -340,8 +340,8 @@ impl<'a> Widget for Canvas<'a> {
     }
 
     /// Draw the canvas.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
-        where C: CharacterCache
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
+        where C: CharacterCache,
     {
         use elmesque::form::{collage, rect, text};
 

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -252,19 +252,22 @@ impl<'a> Widget for Canvas<'a> {
     }
 
     /// The area of the widget below the title bar, upon which child widgets will be placed.
-    fn kid_area(state: &widget::State<State>, style: &Style, theme: &Theme) -> widget::KidArea {
-        let widget::State { ref state, xy, dim, .. } = *state;
-        match state.maybe_title_bar {
-            None => widget::KidArea {
+    fn kid_area<C: CharacterCache>(&self, args: widget::KidAreaArgs<Self, C>) -> widget::KidArea {
+        let widget::KidAreaArgs { xy, dim, style, theme, .. } = args;
+        if self.show_title_bar {
+            let font_size = style.title_bar_font_size(theme);
+            let (title_bar_h, _) = title_bar_h_y(dim, font_size as f64);
+            widget::KidArea {
+                xy: [xy[0], xy[1] - (title_bar_h / 2.0)],
+                dim: [dim[0], dim[1] - title_bar_h],
+                pad: style.padding(theme),
+            }
+        } else {
+            widget::KidArea {
                 xy: xy,
                 dim: dim,
                 pad: style.padding(theme),
-            },
-            Some(ref title_bar) => widget::KidArea {
-                xy: [xy[0], xy[1] - (title_bar.h / 2.0)],
-                dim: [dim[0], dim[1] - title_bar.h],
-                pad: style.padding(theme),
-            },
+            }
         }
     }
 

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -348,8 +348,7 @@ impl<'a> Widget for Canvas<'a> {
     {
         use elmesque::form::{collage, rect, text};
 
-        let widget::DrawArgs { state, style, theme, glyph_cache } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
 
         let frame = style.frame(theme);
         let inner_dim = ::vecmath::vec2_sub(dim, [frame * 2.0; 2]);

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -3,17 +3,9 @@
 //!
 
 use mouse::Mouse;
-use position::{Dimensions, Point};
+use position::{is_over_rect, Dimensions, Point, Rect};
 
 
-/// Represents the draggable area of a widget by its coordinates and dimensions.
-#[derive(Copy, Clone, Debug)]
-pub struct Area {
-    /// The absolute center position of the area.
-    pub xy: Point,
-    /// The dimensions of the area.
-    pub dim: Dimensions,
-}
 
 /// The current drag interaction for the Widget.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -28,20 +20,15 @@ pub enum State {
 
 
 /// Drag the widget from its position `xy` and return the new position.
-pub fn drag_widget(xy: Point,
-                   area: Area,
-                   state: State,
-                   mouse: Mouse) -> (Point, State)
-{
+pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Point, State) {
     use self::State::{Normal, Highlighted, Clicked};
     use mouse::ButtonPosition::{Up, Down};
-    use utils::is_over_rect;
 
     // Find the absolute position of the draggable area.
-    let abs_area_xy = ::vecmath::vec2_add(xy, area.xy);
+    let abs_rect = rel_rect.shift(xy);
 
     // Check whether or not the cursor is over the drag area.
-    let is_over = is_over_rect(abs_area_xy, mouse.xy, area.dim);
+    let is_over = abs_rect.is_over(mouse.xy);
 
     // Determine the new drag state.
     let new_state = match (is_over, state, mouse.left.position) {

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -3,7 +3,7 @@
 //!
 
 use mouse::Mouse;
-use position::{is_over_rect, Dimensions, Point, Rect};
+use position::{Point, Rect};
 
 
 

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -241,6 +241,7 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                     .color(::color::black().alpha(0.0))
                     .frame_color(::color::black().alpha(0.0))
                     .dim([dim[0], max_visible_height])
+                    .parent(Some(idx))
                     .point(canvas_xy)
                     .floating(true)
                     .vertical_scrolling(true)

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -123,9 +123,8 @@ impl<'a, F> DropDownList<'a, F> {
 }
 
 
-impl<'a, F> Widget for DropDownList<'a, F>
-    where
-        F: FnMut(&mut Option<Idx>, Idx, &str),
+impl<'a, F> Widget for DropDownList<'a, F> where
+    F: FnMut(&mut Option<Idx>, Idx, &str),
 {
     type State = State;
     type Style = Style;
@@ -158,8 +157,8 @@ impl<'a, F> Widget for DropDownList<'a, F>
     }
 
     /// Update the state of the DropDownList.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
-        where C: CharacterCache
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State>
+        where C: CharacterCache,
     {
         use std::borrow::Cow;
 
@@ -303,9 +302,8 @@ impl<'a, F> Widget for DropDownList<'a, F>
         if state_has_changed { Some(new_state(buttons)) } else { None }
     }
 
-
     /// Construct an Element from the given DropDownList State.
-    fn draw<'b, C>(_args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(_args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         // We don't need to draw anything, as DropDownList is entirely composed of other widgets.

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -241,8 +241,8 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                     .color(::color::black().alpha(0.0))
                     .frame_color(::color::black().alpha(0.0))
                     .dim([dim[0], max_visible_height])
-                    .parent(Some(idx))
                     .point(canvas_xy)
+                    .parent(Some(idx))
                     .floating(true)
                     .vertical_scrolling(true)
                     .set(canvas_idx, &mut ui);

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -575,8 +575,7 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
         use elmesque::form::{circle, collage, Form, line, rect, solid, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { state, style, theme, glyph_cache } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
         let frame = style.frame(theme);
         let pad_dim = vec2_sub(dim, [frame * 2.0; 2]);
         let (half_pad_w, half_pad_h) = (pad_dim[0] / 2.0, pad_dim[1] / 2.0);

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -150,9 +150,9 @@ fn is_over_elem(mouse_xy: Point,
                 pad_dim: Dimensions,
                 perc_env: &[(f32, f32, f32)],
                 point_radius: Scalar) -> Option<Elem> {
-    use utils::is_over_rect;
-    if is_over_rect([0.0, 0.0], mouse_xy, dim) {
-        if is_over_rect([0.0, 0.0], mouse_xy, pad_dim) {
+    use position::is_over_rect;
+    if is_over_rect([0.0, 0.0], dim, mouse_xy) {
+        if is_over_rect([0.0, 0.0], pad_dim, mouse_xy) {
             for (i, p) in perc_env.iter().enumerate() {
                 let (x, y, _) = *p;
                 let half_pad_w = pad_dim[0] / 2.0;
@@ -368,7 +368,8 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
     fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<E>>
         where C: CharacterCache,
     {
-        let widget::UpdateArgs { prev_state, xy, dim, style, ui, .. } = args;
+        let widget::UpdateArgs { prev_state, rect, style, ui, .. } = args;
+        let (xy, dim) = rect.xy_dim();
         let widget::State { ref state, .. } = *prev_state;
         let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
         let skew = self.skew_y_range;
@@ -572,10 +573,11 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
     fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
-        use elmesque::form::{circle, collage, Form, line, rect, solid, text};
+        use elmesque::form::{self, circle, collage, Form, line, solid, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
+        let widget::DrawArgs { rect, state, style, theme, glyph_cache, .. } = args;
+        let (xy, dim) = rect.xy_dim();
         let frame = style.frame(theme);
         let pad_dim = vec2_sub(dim, [frame * 2.0; 2]);
         let (half_pad_w, half_pad_h) = (pad_dim[0] / 2.0, pad_dim[1] / 2.0);
@@ -585,9 +587,9 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
         // Construct the frame and inner rectangle Forms.
         let value_font_size = style.value_font_size(theme);
         let frame_color = style.frame_color(theme);
-        let frame_form = rect(dim[0], dim[1]).filled(frame_color);
+        let frame_form = form::rect(dim[0], dim[1]).filled(frame_color);
         let color = state.interaction.color(style.color(theme));
-        let pressable_form = rect(pad_dim[0], pad_dim[1]).filled(color);
+        let pressable_form = form::rect(pad_dim[0], pad_dim[1]).filled(color);
 
         // Construct the label Form.
         let maybe_label_form = state.maybe_label.as_ref().map(|l_text| {

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -365,7 +365,7 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
     }
 
     /// Update the state of the EnvelopeEditor's cached state.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State<E>>
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<E>>
         where C: CharacterCache,
     {
         let widget::UpdateArgs { prev_state, xy, dim, style, ui, .. } = args;
@@ -569,7 +569,7 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
     }
 
     /// Construct an Element from the given EnvelopeEditor State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{circle, collage, Form, line, rect, solid, text};

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -83,13 +83,14 @@ impl<'a> Widget for Label<'a> {
     {
         use elmesque::form::{text, collage};
         use elmesque::text::Text;
-        let widget::DrawArgs { dim, xy, state: &State(ref string), style, theme, .. } = args;
+        let widget::DrawArgs { rect, state: &State(ref string), style, theme, .. } = args;
         let size = style.font_size(theme);
         let color = style.color(theme);
+        let (x, y, w, h) = rect.x_y_w_h();
         let form = text(Text::from_string(string.clone())
                             .color(color)
-                            .height(size as f64)).shift(xy[0].floor(), xy[1].floor());
-        collage(dim[0] as i32, dim[1] as i32, vec![form])
+                            .height(size as f64)).shift(x.floor(), y.floor());
+        collage(w as i32, h as i32, vec![form])
     }
     
 }

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -69,7 +69,7 @@ impl<'a> Widget for Label<'a> {
     }
 
     /// Update the state of the Label.
-    fn update<'b, C>(self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
+    fn update<C>(self, args: widget::UpdateArgs<Self, C>) -> Option<State>
         where C: CharacterCache,
     {
         let widget::UpdateArgs { prev_state, .. } = args;
@@ -78,7 +78,7 @@ impl<'a> Widget for Label<'a> {
     }
 
     /// Construct an Element for the Label.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{text, collage};

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -83,8 +83,7 @@ impl<'a> Widget for Label<'a> {
     {
         use elmesque::form::{text, collage};
         use elmesque::text::Text;
-        let widget::DrawArgs { state, style, theme, .. } = args;
-        let widget::State { state: State(ref string), dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state: &State(ref string), style, theme, .. } = args;
         let size = style.font_size(theme);
         let color = style.color(theme);
         let form = text(Text::from_string(string.clone())

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -150,18 +150,19 @@ impl<'a, F, W> Widget for Matrix<F> where
 
         // We only need to worry about element calculations if we actually have rows and columns.
         if rows > 0 && cols > 0 {
-            let cell_pad_w = style.cell_pad_w(ui.theme());
-            let cell_pad_h = style.cell_pad_h(ui.theme());
-            let widget_w = dim[0] / cols as Scalar;
-            let widget_h = dim[1] / rows as Scalar;
-            let (half_w, half_h) = (dim[0] / 2.0, dim[1] / 2.0);
-            let x_min = -half_w + widget_w / 2.0;
-            let x_max = half_w + widget_w / 2.0;
-            let y_min = -half_h - widget_h / 2.0;
-            let y_max = half_h - widget_h / 2.0;
-
-            let mut widget_num = 0;
+            // Likewise, there must also be some function to give us the widgets.
             if let Some(mut each_widget) = maybe_each_widget {
+                let cell_pad_w = style.cell_pad_w(ui.theme());
+                let cell_pad_h = style.cell_pad_h(ui.theme());
+                let widget_w = dim[0] / cols as Scalar;
+                let widget_h = dim[1] / rows as Scalar;
+                let (half_w, half_h) = (dim[0] / 2.0, dim[1] / 2.0);
+                let x_min = -half_w + widget_w / 2.0;
+                let x_max = half_w + widget_w / 2.0;
+                let y_min = -half_h - widget_h / 2.0;
+                let y_max = half_h - widget_h / 2.0;
+
+                let mut widget_num = 0;
                 for col in 0..cols {
                     for row in 0..rows {
                         use position::{Positionable, Sizeable};

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -111,7 +111,7 @@ impl<'a, F, W> Widget for Matrix<F> where
     {
         use std::borrow::Cow;
 
-        let widget::UpdateArgs { idx, prev_state, dim, style, mut ui, .. } = args;
+        let widget::UpdateArgs { idx, prev_state, rect, style, mut ui, .. } = args;
         let widget::State { ref state, .. } = *prev_state;
         let Matrix { cols, rows, maybe_each_widget, .. } = self;
 
@@ -154,9 +154,10 @@ impl<'a, F, W> Widget for Matrix<F> where
             if let Some(mut each_widget) = maybe_each_widget {
                 let cell_pad_w = style.cell_pad_w(ui.theme());
                 let cell_pad_h = style.cell_pad_h(ui.theme());
-                let widget_w = dim[0] / cols as Scalar;
-                let widget_h = dim[1] / rows as Scalar;
-                let (half_w, half_h) = (dim[0] / 2.0, dim[1] / 2.0);
+                let (w, h) = rect.w_h();
+                let widget_w = w / cols as Scalar;
+                let widget_h = h / rows as Scalar;
+                let (half_w, half_h) = (w / 2.0, h / 2.0);
                 let x_min = -half_w + widget_w / 2.0;
                 let x_max = half_w + widget_w / 2.0;
                 let y_min = -half_h - widget_h / 2.0;

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -172,7 +172,6 @@ impl<'a, F, W> Widget for Matrix<F> where
                         let w = widget_w - cell_pad_w * 2.0;
                         let h = widget_h - cell_pad_h * 2.0;
                         let widget_idx = indices[col][row];
-
                         each_widget(widget_num, col, row)
                             .dim([w, h])
                             .relative_to(idx, [rel_x, rel_y])

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -152,6 +152,7 @@ impl<'a, F, W> Widget for Matrix<F> where
         if rows > 0 && cols > 0 {
             // Likewise, there must also be some function to give us the widgets.
             if let Some(mut each_widget) = maybe_each_widget {
+
                 let cell_pad_w = style.cell_pad_w(ui.theme());
                 let cell_pad_h = style.cell_pad_h(ui.theme());
                 let (w, h) = rect.w_h();
@@ -177,7 +178,6 @@ impl<'a, F, W> Widget for Matrix<F> where
                             .dim([w, h])
                             .relative_to(idx, [rel_x, rel_y])
                             .set(widget_idx, &mut ui);
-
                         widget_num += 1;
                     }
                 }

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -1,129 +1,229 @@
 
-use graphics::character::CharacterCache;
-use position::{self, Depth, Dimensions, HorizontalAlign, Point, Position, VerticalAlign};
-use theme::Theme;
-use ui::{self, GlyphCache, Ui};
+use ::{CharacterCache, GlyphCache, NodeIndex, Scalar, Theme};
+use widget::{self, Widget};
+
 
 /// Reaction params.
 pub type WidgetNum = usize;
 pub type ColNum = usize;
 pub type RowNum = usize;
-pub type Width = f64;
-pub type Height = f64;
-pub type PosX = f64;
-pub type PosY = f64;
+pub type Width = Scalar;
+pub type Height = Scalar;
+pub type PosX = Scalar;
+pub type PosY = Scalar;
 
 /// Draw a matrix of any rectangular widget type, where the matrix will provide a function with
 /// the widget number, it's `rows` and `cols` position, the width and height for the widget and
 /// the location at which the widget should be drawn.
 #[derive(Copy, Clone)]
-pub struct Matrix {
+pub struct Matrix<F> {
+    common: widget::CommonBuilder,
+    style: Style,
     cols: usize,
     rows: usize,
-    pos: Position,
-    dim: Dimensions,
-    maybe_h_align: Option<HorizontalAlign>,
-    maybe_v_align: Option<VerticalAlign>,
-    cell_pad_w: f64,
-    cell_pad_h: f64,
+    maybe_each_widget: Option<F>,
 }
 
-// /// A cell to be returned via the cell reaction.
-// pub struct MatrixCell<'a>(&'a mut UiContext, WidgetNum, ColNum, RowNum, PosX, PosY, Width, Height);
+/// The state of the Matrix, to be cached within the `Ui`'s widget `Graph`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct State {
+    /// A `NodeIndex` for every Widget in the Matrix.
+    /// This matrix is column major, meaning the outer-most Vec represents each column, and each
+    /// inner Vec represents a row.
+    indices: Vec<Vec<NodeIndex>>,
+}
 
-impl Matrix {
+/// Unique styling for the `Matrix`.
+#[derive(Copy, Clone, Debug, PartialEq, RustcDecodable, RustcEncodable)]
+pub struct Style {
+    /// The width of the padding for each matrix element's "cell".
+    maybe_cell_pad_w: Option<Scalar>,
+    /// The height of the padding for each matrix element's "cell".
+    maybe_cell_pad_h: Option<Scalar>,
+}
+
+
+impl<F> Matrix<F> {
 
     /// Create a widget matrix context.
-    pub fn new(cols: usize, rows: usize) -> Matrix {
+    pub fn new(cols: usize, rows: usize) -> Matrix<F> {
         Matrix {
+            common: widget::CommonBuilder::new(),
+            style: Style::new(),
             cols: cols,
             rows: rows,
-            pos: Position::default(),
-            dim: [256.0, 256.0],
-            maybe_h_align: None,
-            maybe_v_align: None,
-            cell_pad_w: 0.0,
-            cell_pad_h: 0.0,
+            maybe_each_widget: None,
         }
     }
 
-    /// The reaction called for each widget in the matrix. This should be called following all
-    /// builder methods.
-    pub fn each_widget<C, F>(&mut self, ui: &mut Ui<C>, mut react: F)
-        where
-            F: FnMut(&mut Ui<C>, WidgetNum, ColNum, RowNum, Point, Dimensions)
-    {
-        use utils::map_range;
-        if let Some(id) = ui::parent_from_position(ui, self.pos) {
-            ui::set_current_parent_idx(ui, id);
-        }
-        let dim = self.dim;
-        let h_align = self.maybe_h_align.unwrap_or(ui.theme.align.horizontal);
-        let v_align = self.maybe_v_align.unwrap_or(ui.theme.align.vertical);
-        let xy = ui.get_xy(None, self.pos, dim, h_align, v_align);
-        let (half_w, half_h) = (dim[0] / 2.0, dim[1] / 2.0);
-        let widget_w = dim[0] / self.cols as f64;
-        let widget_h = dim[1] / self.rows as f64;
-        let x_min = -half_w + widget_w / 2.0;
-        let x_max = half_w + widget_w / 2.0;
-        let y_min = -half_h - widget_h / 2.0;
-        let y_max = half_h - widget_h / 2.0;
-        let mut widget_num = 0;
-        for col in 0..self.cols {
-            for row in 0..self.rows {
-                let x = xy[0] + map_range(col as f64, 0.0, self.cols as f64, x_min, x_max);
-                let y = xy[1] + map_range(row as f64, 0.0, self.rows as f64, y_max, y_min);
-                let w = widget_w - self.cell_pad_w * 2.0;
-                let h = widget_h - self.cell_pad_h * 2.0;
-                react(ui, widget_num, col, row, [x, y], [w, h]);
-                widget_num += 1;
-            }
-        }
+    /// The function that will be called for each and every element in the Matrix.
+    /// The function should return the widget that will be displayed in the element associated with
+    /// the given row and column number.
+    /// Note that the returned Widget's position and dimensions will be overridden with the
+    /// dimensions and position of the matrix element's rectangle.
+    pub fn each_widget(mut self, each_widget: F) -> Matrix<F> {
+        self.maybe_each_widget = Some(each_widget);
+        self
     }
 
     /// A builder method for adding padding to the cell.
-    pub fn cell_padding(self, w: f64, h: f64) -> Matrix {
-        Matrix { cell_pad_w: w, cell_pad_h: h, ..self }
-    }
-
-}
-
-impl position::Positionable for Matrix {
-    fn position(mut self, pos: Position) -> Self {
-        self.pos = pos;
+    pub fn cell_padding(mut self, w: Scalar, h: Scalar) -> Matrix<F> {
+        self.style.maybe_cell_pad_w = Some(w);
+        self.style.maybe_cell_pad_h = Some(h);
         self
     }
-    fn get_position(&self, _: &Theme) -> Position { self.pos }
-    #[inline]
-    fn horizontal_align(self, h_align: HorizontalAlign) -> Self {
-        Matrix { maybe_h_align: Some(h_align), ..self }
-    }
-    #[inline]
-    fn vertical_align(self, v_align: VerticalAlign) -> Self {
-        Matrix { maybe_v_align: Some(v_align), ..self }
-    }
-    fn get_horizontal_align(&self, theme: &Theme) -> HorizontalAlign {
-        self.maybe_h_align.unwrap_or(theme.align.horizontal)
-    }
-    fn get_vertical_align(&self, theme: &Theme) -> VerticalAlign {
-        self.maybe_v_align.unwrap_or(theme.align.vertical)
-    }
-    fn depth(self, _depth: Depth) -> Self { self }
-    fn get_depth(&self) -> Depth { 0.0 }
+
 }
 
-impl position::Sizeable for Matrix {
-    #[inline]
-    fn width(self, w: f64) -> Self {
-        let h = self.dim[1];
-        Matrix { dim: [w, h], ..self }
+
+impl<'a, F, W> Widget for Matrix<F> where
+    W: Widget,
+    F: FnMut(WidgetNum, ColNum, RowNum) -> W
+{
+    type State = State;
+    type Style = Style;
+
+    fn common(&self) -> &widget::CommonBuilder { &self.common }
+    fn common_mut(&mut self) -> &mut widget::CommonBuilder { &mut self.common }
+    fn unique_kind(&self) -> &'static str { "Matrix" }
+    fn init_state(&self) -> State {
+        State { indices: Vec::new() }
     }
-    #[inline]
-    fn height(self, h: f64) -> Self {
-        let w = self.dim[0];
-        Matrix { dim: [w, h], ..self }
+    fn style(&self) -> Style { self.style.clone() }
+
+    fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
+        const DEFAULT_WIDTH: Scalar = 128.0;
+        self.common.maybe_width.or(theme.maybe_matrix.as_ref().map(|default| {
+            default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
+        })).unwrap_or(DEFAULT_WIDTH)
     }
-    fn get_width<C: CharacterCache>(&self, _theme: &Theme, _: &GlyphCache<C>) -> f64 { self.dim[0] }
-    fn get_height(&self, _theme: &Theme) -> f64 { self.dim[1] }
+
+    fn default_height(&self, theme: &Theme) -> Scalar {
+        const DEFAULT_HEIGHT: Scalar = 64.0;
+        self.common.maybe_height.or(theme.maybe_matrix.as_ref().map(|default| {
+            default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
+        })).unwrap_or(DEFAULT_HEIGHT)
+    }
+
+    /// Update the state of the Matrix.
+    fn update<C>(self, args: widget::UpdateArgs<Self, C>) -> Option<State>
+        where C: CharacterCache,
+    {
+        use std::borrow::Cow;
+
+        let widget::UpdateArgs { idx, prev_state, dim, style, mut ui, .. } = args;
+        let widget::State { ref state, .. } = *prev_state;
+        let Matrix { cols, rows, maybe_each_widget, .. } = self;
+
+        let mut indices = Cow::Borrowed(&state.indices[..]);
+
+        // Work out whether or not this is the first time the Matrix has been set.
+        let is_first_update = indices.len() == 0;
+
+        // First, check that we have the correct number of columns.
+        if indices.len() < cols {
+            let num_cols = indices.len();
+            indices.to_mut().extend((num_cols..cols).map(|_| Vec::with_capacity(rows)));
+        }
+
+        // Then, check that the number of rows in each column is correct.
+        for i in 0..indices.len() {
+            let num_rows = indices[i].len();
+            if num_rows < rows {
+                indices.to_mut()[i].extend((num_rows..rows).map(|_| ui.new_unique_node_index()));
+            }
+        }
+
+        // Has anything about the Matrix changed since the last update.
+        let state_has_changed = &state.indices[..] != &indices[..];
+
+        // A function for constructing a new new Matrix::State.
+        let new_state = |indices: Cow<[Vec<NodeIndex>]>| State {
+            indices: indices.into_owned(),
+        };
+
+        // If it is the first update, we won't yet call the given `each_widget` function so that we
+        // can ensure that the Matrix exists within the Graph.
+        if is_first_update {
+            return Some(new_state(indices));
+        }
+
+        // We only need to worry about element calculations if we actually have rows and columns.
+        if rows > 0 && cols > 0 {
+            let cell_pad_w = style.cell_pad_w(ui.theme());
+            let cell_pad_h = style.cell_pad_h(ui.theme());
+            let widget_w = dim[0] / cols as Scalar;
+            let widget_h = dim[1] / rows as Scalar;
+            let (half_w, half_h) = (dim[0] / 2.0, dim[1] / 2.0);
+            let x_min = -half_w + widget_w / 2.0;
+            let x_max = half_w + widget_w / 2.0;
+            let y_min = -half_h - widget_h / 2.0;
+            let y_max = half_h - widget_h / 2.0;
+
+            let mut widget_num = 0;
+            if let Some(mut each_widget) = maybe_each_widget {
+                for col in 0..cols {
+                    for row in 0..rows {
+                        use position::{Positionable, Sizeable};
+                        use utils::map_range;
+                        let rel_x = map_range(col as Scalar, 0.0, cols as Scalar, x_min, x_max);
+                        let rel_y = map_range(row as Scalar, 0.0, rows as Scalar, y_max, y_min);
+                        let w = widget_w - cell_pad_w * 2.0;
+                        let h = widget_h - cell_pad_h * 2.0;
+                        let widget_idx = indices[col][row];
+
+                        each_widget(widget_num, col, row)
+                            .dim([w, h])
+                            .relative_to(idx, [rel_x, rel_y])
+                            .set(widget_idx, &mut ui);
+
+                        widget_num += 1;
+                    }
+                }
+            }
+        }
+
+        // Construct the new state if there was a change.
+        if state_has_changed { Some(new_state(indices)) } else { None }
+
+    }
+
+    /// Construct an Element from the given DropDownList State.
+    fn draw<C>(_args: widget::DrawArgs<Self, C>) -> ::Element
+        where C: CharacterCache,
+    {
+        // We don't need to draw anything, as DropDownList is entirely composed of other widgets.
+        ::elmesque::element::empty()
+    }
+
+}
+
+
+impl Style {
+
+    /// Constructor for a new default Matrix Style.
+    pub fn new() -> Style {
+        Style {
+            maybe_cell_pad_w: None,
+            maybe_cell_pad_h: None,
+        }
+    }
+
+    /// Get the width of the padding for each matrix element's cell.
+    pub fn cell_pad_w(&self, theme: &Theme) -> Scalar {
+        const DEFAULT_CELL_PAD_W: Scalar = 0.0;
+        self.maybe_cell_pad_w.or(theme.maybe_matrix.as_ref().map(|default| {
+            default.style.maybe_cell_pad_w.unwrap_or(DEFAULT_CELL_PAD_W)
+        })).unwrap_or(DEFAULT_CELL_PAD_W)
+    }
+
+    /// Get the height of the padding for each matrix element's cell.
+    pub fn cell_pad_h(&self, theme: &Theme) -> Scalar {
+        const DEFAULT_CELL_PAD_H: Scalar = 0.0;
+        self.maybe_cell_pad_h.or(theme.maybe_matrix.as_ref().map(|default| {
+            default.style.maybe_cell_pad_h.unwrap_or(DEFAULT_CELL_PAD_H)
+        })).unwrap_or(DEFAULT_CELL_PAD_H)
+    }
+
 }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -674,11 +674,16 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
         // If we haven't been placed in the graph yet (and bounding_box returns None),
         // we'll just use our current dimensions as the bounding box.
-        let init_bounds = || {
+        let self_bounds = || {
             let half_h = kid_area.dim[1] / 2.0;
             let half_w = kid_area.dim[0] / 2.0;
             (half_h, -half_h, -half_w, half_w)
         };
+
+        // Calculate the scroll bounds for the widget.
+        let bounds = || ui::widget_graph(ui)
+            .bounding_box(false, None, true, idx)
+            .unwrap_or_else(self_bounds);
 
         // If we have neither vertical or horizontal scrolling, return None.
         if !scrolling.horizontal && !scrolling.vertical {
@@ -686,9 +691,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
         // Else if we have some previous scrolling, use it in determining the new scrolling.
         } else if let Some(prev_scrollable) = maybe_scrolling {
-            let (top_y, bottom_y, left_x, right_x) = ui::widget_graph(ui)
-                .bounding_box(false, None, true, idx)
-                .unwrap_or_else(init_bounds);
+            let (top_y, bottom_y, left_x, right_x) = bounds();
 
             // The total length of the area occupied by child widgets that is scrolled.
             let total_v_length = top_y - bottom_y;
@@ -741,9 +744,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
         // Otherwise, we'll make a brand new scrolling.
         } else {
-            let (top_y, bottom_y, left_x, right_x) = ui::widget_graph(ui)
-                .bounding_box(false, None, true, idx)
-                .unwrap_or_else(init_bounds);
+            let (top_y, bottom_y, left_x, right_x) = bounds();
 
             // The total length of the area occupied by child widgets that is scrolled.
             let total_v_length = top_y - bottom_y;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -655,6 +655,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
             let maybe_mouse = ui::get_mouse_state(ui, idx);
             let visible = kid_area.rect;
             let kids = ui::widget_graph(ui).bounding_box(false, None, true, idx)
+                .map(|kids| kids.shift(visible.xy()))
                 .unwrap_or_else(|| kid_area.rect);
             let maybe_prev = maybe_prev_scrolling.as_ref();
             let scroll_state = scroll::State::new(scrolling, visible, kids, &ui.theme, maybe_prev);

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -718,7 +718,7 @@ fn set_widget<'a, W, C>(widget: W, idx: Index, ui: &mut Ui<C>) where
                     None
                 },
 
-                width: scrolling.style.width(&ui.theme),
+                thickness: scrolling.style.thickness(&ui.theme),
                 color: scrolling.style.color(&ui.theme),
             };
 
@@ -761,7 +761,7 @@ fn set_widget<'a, W, C>(widget: W, idx: Index, ui: &mut Ui<C>) where
                     None
                 },
 
-                width: scrolling.style.width(&ui.theme),
+                thickness: scrolling.style.thickness(&ui.theme),
                 color: scrolling.style.color(&ui.theme),
             };
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -749,9 +749,9 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
     // Determine whether or not the `State` has changed.
     let state_has_changed = maybe_new_state.is_some()
-            || rect != prev_state.rect
-            || depth != prev_state.depth
-            || is_first_set;
+        || rect != prev_state.rect
+        || depth != prev_state.depth
+        || is_first_set;
 
     // Determine whether or not the widget's `Style` has changed.
     let style_has_changed = maybe_prev_style.map(|style| style != new_style).unwrap_or(false);

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -177,7 +177,7 @@ fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mou
 }
 
 
-impl<'a, T: Float, F> NumberDialer<'a, T, F> {
+impl<'a, T, F> NumberDialer<'a, T, F> where T: Float {
 
     /// Construct a new NumberDialer widget.
     pub fn new(value: T, min: T, max: T, precision: u8) -> NumberDialer<'a, T, F> {
@@ -209,10 +209,9 @@ impl<'a, T: Float, F> NumberDialer<'a, T, F> {
 
 }
 
-impl<'a, T, F> Widget for NumberDialer<'a, T, F>
-    where
-        F: FnMut(T),
-        T: Any + ::std::fmt::Debug + Float + NumCast + ToString,
+impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
+    F: FnMut(T),
+    T: Any + ::std::fmt::Debug + Float + NumCast + ToString,
 {
     type State = State<T>;
     type Style = Style;
@@ -261,7 +260,7 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F>
     }
 
     /// Update the state of the NumberDialer.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State<T>>
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<T>>
         where C: CharacterCache,
     {
 
@@ -365,7 +364,7 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F>
     }
 
     /// Construct an Element from the given NumberDialer State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{collage, rect, text};

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -370,8 +370,7 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
         use elmesque::form::{collage, rect, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { state, style, theme, glyph_cache } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
 
         // Construct the frame and inner rectangle Forms.
         let frame = style.frame(theme);

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -5,10 +5,9 @@
 use {Element, Scalar};
 use color::Color;
 use mouse::Mouse;
-use position::{Dimensions, Point};
+use position::{Point, Range, Rect};
 use theme::Theme;
-use utils::is_over_rect;
-use widget;
+use utils::map_range;
 
 
 /// A type for building a scrollbar widget.
@@ -30,6 +29,8 @@ pub struct State {
     pub maybe_vertical: Option<Bar>,
     /// Horizontal scrollbar.
     pub maybe_horizontal: Option<Bar>,
+    /// The rectangle representing the Visible area used tot calculate the Bar offsets.
+    pub visible: Rect,
     /// The width for vertical scrollbars, the height for horizontal scrollbars.
     pub thickness: Scalar,
     /// The color of the scrollbar.
@@ -135,204 +136,262 @@ impl Interaction {
 }
 
 
-/// The new state of the given scrollbar if it has changed.
-pub fn update(kid_area: &widget::KidArea,
-              state: &State,
-              maybe_mouse: Option<Mouse>) -> Option<State>
-{
-    use self::Elem::{Handle, Track};
-    use self::Interaction::{Normal, Highlighted, Clicked};
-    use utils::clamp;
+impl State {
 
-    let thickness = state.thickness;
-
-    // Determine the new current `Interaction` for a Scrollbar.
-    // The given mouse_scalar is the position of the mouse to be recorded by the Handle.
-    // For vertical handle this is mouse.y, for horizontal this is mouse.x.
-    let get_new_interaction = |bar: &Bar,
-                               is_over_elem: Option<Elem>,
-                               mouse_scalar: Scalar| -> Interaction
+    /// Construct a new State.
+    /// The `visible` rect corresponds to a Widget's `kid_area` aka the viewable container.
+    /// The `kids` rect is the area *actually occupied* by the children widgets.
+    pub fn new(scrolling: Scrolling, 
+               visible: Rect,
+               kids: Rect,
+               theme: &Theme,
+               maybe_prev: Option<&State>) -> State
     {
-        if let Some(mouse) = maybe_mouse {
-            use mouse::ButtonPosition::{Down, Up};
-            match (is_over_elem, bar.interaction, mouse.left.position) {
-                (Some(_),    Normal,             Down) => Normal,
-                (Some(elem), _,                  Up)   => Highlighted(elem),
-                (Some(_),    Highlighted(_),     Down) |
-                (_,          Clicked(Handle(_)), Down) => Clicked(Handle(mouse_scalar)),
-                (_,          Clicked(elem),      Down) => Clicked(elem),
-                _                                      => Normal,
-            }
-        } else {
-            Normal
-        }
-    };
 
-    // Simplify construction of a new Bar.
-    let maybe_new_bar = |bar: &Bar, new_interaction: Interaction, new_offset: Scalar| {
-        // Has the `Bar` changed at all.
-        let has_changed = bar.interaction != new_interaction || bar.offset != new_offset;
-        // Construct a new `Bar` if it has changed.
-        if has_changed {
-            Some(Bar {
-                interaction: new_interaction,
-                offset: new_offset,
-                max_offset: bar.max_offset,
-                total_length: bar.total_length,
-            })
-        } else {
-            None
-        }
-    };
+        // The amount required to offset the kids_bounds to their non-scrolled position.
+        let x_offset_to_origin = maybe_prev
+            .and_then(|prev| prev.maybe_horizontal.map(|bar| bar.pos_offset(visible.w())))
+            .unwrap_or(0.0);
+        println!("\tx_offset_to_origin: {:?}", x_offset_to_origin);
 
-    // Gives the updated vertical `Bar` if it has changed.
-    let vertical = |bar: &Bar| -> Option<Bar> {
+        // // The non_scrolled start position of the kids bounds.
+        // let kids_origin_x_start = kids_bounds.x.start - x_offset_to_origin;
+        // println!("\tkids_origin_x_start: {:?}", x_offset_to_origin);
 
-        let (track_dim, track_xy) = vertical_track_area(kid_area, thickness);
-        let (handle_dim, handle_xy) =
-            vertical_handle_area(track_dim, track_xy, thickness, bar.offset, bar.max_offset);
+        // // The amount we should use to offset the kids_bounds.
+        // let x_offset = ::utils::partial_max(0.0, kids_origin_x_start - kid_area.rect.x.start);
+        // println!("\tx_offset: {:?}", x_offset);
 
-        // Determine whether or not the mouse is over part of the Scrollbar.
-        let is_over_elem = maybe_mouse.and_then(|mouse| {
-            if is_over_rect(track_xy, mouse.xy, track_dim) {
-                if is_over_rect(handle_xy, mouse.xy, handle_dim) {
-                    Some(Handle(mouse.xy[1]))
-                } else {
-                    Some(Track)
-                }
+        // // The shifted kids bounds.
+        // let kids_bounds = if x_offset_to_origin > 0.0 {
+        //     kids_bounds.shift_x(kids_origin_x_start)
+        // } else {
+        //     kids_bounds
+        // };
+        // println!("\tshifted kids_bounds: {:?}", kids_bounds);
+
+
+
+        State {
+            maybe_vertical: if scrolling.vertical {
+                let maybe_prev = maybe_prev.as_ref()
+                    .and_then(|prev| prev.maybe_vertical.as_ref());
+                // For a vertical scrollbar, we want the range to start at the top and end at
+                // the bottom. To do this, we will use the invert of our visible and kids y ranges.
+                Some(Bar::new(visible.y.invert(), kids.y.invert(), maybe_prev))
             } else {
                 None
-            }
-        });
-
-        // Determine the new current `Interaction`.
-        let new_interaction = match maybe_mouse {
-            Some(mouse) => get_new_interaction(bar, is_over_elem, mouse.xy[1]),
-            None => Normal,
-        };
-
-        // Determine the new offset for the scrollbar.
-        let new_offset = match (bar.interaction, new_interaction, maybe_mouse) {
-
-            // When the track is clicked and the handle snaps to the cursor.
-            (Highlighted(Track), Clicked(Handle(mouse_y)), _) => {
-                // Should try snap the handle so that the mouse is in the middle of it.
-                let track_top = track_xy[1] + track_dim[1] / 2.0;
-                let target_offset = -((mouse_y - track_top) + handle_dim[1] / 2.0);
-                clamp(target_offset, 0.0, bar.max_offset)
             },
-
-            // When the handle is dragged.
-            (Clicked(Handle(prev_mouse_y)), Clicked(Handle(mouse_y)), _) => {
-                let diff = prev_mouse_y - mouse_y;
-                clamp(bar.offset + diff, 0.0, bar.max_offset)
-            },
-
-            // The mouse has been scrolled using a wheel/trackpad/touchpad.
-            (_, _, Some(mouse)) if mouse.scroll.y != 0.0 => {
-                clamp(bar.offset - mouse.scroll.y, 0.0, bar.max_offset)
-            },
-
-            // Otherwise, we'll assume the offset is unchanged.
-            _ => bar.offset,
-
-        };
-
-        // Check to see if the bar has changed and return a new bar if it has.
-        maybe_new_bar(bar, new_interaction, new_offset)
-    };
-
-    // Gives the updated horizontal `Bar` if it has changed.
-    let horizontal = |bar: &Bar| -> Option<Bar> {
-
-        let (track_dim, track_xy) = horizontal_track_area(kid_area, thickness);
-        let (handle_dim, handle_xy) =
-            horizontal_handle_area(track_dim, track_xy, thickness, bar.offset, bar.max_offset);
-
-        // Determine whether or not the mouse is over part of the Scrollbar.
-        let is_over_elem = maybe_mouse.and_then(|mouse| {
-            if is_over_rect(track_xy, mouse.xy, track_dim) {
-                if is_over_rect(handle_xy, mouse.xy, handle_dim) {
-                    Some(Handle(mouse.xy[0]))
-                } else {
-                    Some(Track)
-                }
+            maybe_horizontal: if scrolling.horizontal {
+                let maybe_prev = maybe_prev.as_ref()
+                    .and_then(|prev| prev.maybe_horizontal.as_ref());
+                Some(Bar::new(visible.x, kids.x, maybe_prev))
             } else {
                 None
-            }
-        });
-
-        // Determine the new current `Interaction`.
-        let new_interaction = match maybe_mouse {
-            Some(mouse) => get_new_interaction(bar, is_over_elem, mouse.xy[0]),
-            None => Normal,
-        };
-
-        // Determine the new offset for the scrollbar.
-        let new_offset = match (bar.interaction, new_interaction, maybe_mouse) {
-
-            // When the track is clicked and the handle snaps to the cursor.
-            (Highlighted(Track), Clicked(Handle(mouse_x)), _) => {
-                // Should try snap the handle so that the mouse is in the middle of it.
-                let track_left = track_xy[0] - track_dim[0] / 2.0;
-                let target_offset = (mouse_x - track_left) - handle_dim[0] / 2.0;
-                clamp(target_offset, 0.0, bar.max_offset)
             },
-
-            // When the handle is dragged.
-            (Clicked(Handle(prev_mouse_x)), Clicked(Handle(mouse_x)), _) => {
-                let diff = mouse_x - prev_mouse_x;
-                clamp(bar.offset + diff, 0.0, bar.max_offset)
-            },
-
-            // The mouse has been scrolled using a wheel/trackpad/touchpad.
-            (_, _, Some(mouse)) if mouse.scroll.x != 0.0 => {
-                clamp(bar.offset - mouse.scroll.x, 0.0, bar.max_offset)
-            },
-
-            // Otherwise, we'll assume the offset is unchanged.
-            _ => bar.offset,
-
-        };
-
-        // Check to see if the bar has changed and return a new bar if it has.
-        maybe_new_bar(bar, new_interaction, new_offset)
-    };
-
-    // Produce a new scroll state if there has been any changes in either bar.
-    match (&state.maybe_vertical, &state.maybe_horizontal) {
-
-        // We have both vertical and horizontal bars.
-        (&Some(ref v_bar), &Some(ref h_bar)) => match (vertical(v_bar), horizontal(h_bar)) {
-            (None, None) => None,
-            (Some(new_v_bar), None) => Some(State { maybe_vertical: Some(new_v_bar), ..*state }),
-            (None, Some(new_h_bar)) => Some(State { maybe_horizontal: Some(new_h_bar), ..*state }),
-            (Some(new_v_bar), Some(new_h_bar)) =>
-                Some(State {
-                    maybe_vertical: Some(new_v_bar),
-                    maybe_horizontal: Some(new_h_bar),
-                    ..*state
-                }),
-        },
-
-        // We only have a vertical scrollbar.
-        (&Some(ref v_bar), &None) => vertical(v_bar).map(|new_v_bar| {
-            State { maybe_vertical: Some(new_v_bar), ..*state }
-        }),
-
-        // We only have a horizontal scrollbar.
-        (&None, &Some(ref h_bar)) => horizontal(h_bar).map(|new_h_bar| {
-            State { maybe_horizontal: Some(new_h_bar), ..*state }
-        }),
-
-        // We don't have any scrollbars.
-        (&None, &None) => None,
+            visible: visible,
+            thickness: scrolling.style.thickness(theme),
+            color: scrolling.style.color(theme),
+        }
     }
+
+    /// Given some mouse input, update the State and return the resulting State.
+    pub fn handle_input(self, mouse: Mouse) -> State {
+        use self::Elem::{Handle, Track};
+        use self::Interaction::{Normal, Highlighted, Clicked};
+        use utils::clamp;
+
+        // Whether or not the mouse is currently over the Bar, and if so, which Elem.
+        let is_over_elem = |track: Rect, handle: Rect, mouse_scalar: Scalar| {
+            if handle.is_over(mouse.xy) {
+                Some(Handle(mouse_scalar))
+            } else if track.is_over(mouse.xy) {
+                Some(Track)
+            } else {
+                None
+            }
+        };
+
+        // Determine the new current `Interaction` for a Bar.
+        // The given mouse_scalar is the position of the mouse to be recorded by the Handle.
+        // For vertical handle this is mouse.y, for horizontal this is mouse.x.
+        let new_interaction = |bar: &Bar, is_over_elem: Option<Elem>, mouse_scalar: Scalar| {
+            // If there's no need for a scroll bar, leave the interaction as `Normal`.
+            if bar.max_offset == 0.0 {
+                Normal
+            } else {
+                use mouse::ButtonPosition::{Down, Up};
+                match (is_over_elem, bar.interaction, mouse.left.position) {
+                    (Some(_),    Normal,             Down) => Normal,
+                    (Some(elem), _,                  Up)   => Highlighted(elem),
+                    (Some(_),    Highlighted(_),     Down) |
+                    (_,          Clicked(Handle(_)), Down) => Clicked(Handle(mouse_scalar)),
+                    (_,          Clicked(elem),      Down) => Clicked(elem),
+                    _                                      => Normal,
+                }
+            }
+        };
+
+        // A function for shifting some current offset by some amount while ensuring it remains
+        // within the Bar's Range.
+        fn scroll_offset(offset: Scalar, max_offset: Scalar, amount: Scalar) -> Scalar {
+            let target_offset = offset + amount;
+            // If the offset is before the start, only let it be dragged towards the end.
+            let clamp_current_to_max = || clamp(target_offset, offset, max_offset);
+            // If the offset is past the end, only let it be dragged towards the start.
+            let clamp_zero_to_current = || clamp(target_offset, 0.0, offset);
+            // Otherwise, clamp it between 0.0 and the max.
+            let clamp_zero_to_max = || clamp(target_offset, 0.0, max_offset);
+
+            // For a positive range, check the start and end of the range normally.
+            if max_offset >= 0.0 {
+                if      offset < 0.0        { clamp_current_to_max() }
+                else if offset > max_offset { clamp_zero_to_current() }
+                else                        { clamp_zero_to_max() }
+
+            // Otherwise, check the inverse.
+            } else {
+                if      offset > 0.0        { clamp_current_to_max() }
+                else if offset < max_offset { clamp_zero_to_current() }
+                else                        { clamp_zero_to_max() }
+            }
+        }
+
+
+        State {
+
+            maybe_vertical: self.maybe_vertical.map(|bar| {
+                let track = vertical_track(self.visible, self.thickness);
+                let handle = vertical_handle(track, bar.offset, bar.max_offset);
+
+                // Determine whether or not the mouse is over part of the Scrollbar.
+                let is_over_elem = is_over_elem(track, handle, mouse.xy[1]);
+
+                // Determine the new current `Interaction`.
+                let new_interaction = new_interaction(&bar, is_over_elem, mouse.xy[1]);
+
+                // Determine the new offset for the scrollbar.
+                let new_offset = match (bar.interaction, new_interaction) {
+
+                    // When the track is clicked and the handle snaps to the cursor.
+                    (Highlighted(Track), Clicked(Handle(mouse_y))) => {
+                        // Should try snap the handle so that the mouse is in the middle of it.
+                        let target_offset = -((mouse_y - track.top()) + handle.h() / 2.0);
+                        clamp(target_offset, 0.0, bar.max_offset)
+                    },
+
+                    // When the handle is dragged.
+                    (Clicked(Handle(prev_mouse_y)), Clicked(Handle(mouse_y))) =>
+                        scroll_offset(bar.offset, bar.max_offset, prev_mouse_y - mouse_y),
+
+                    // The mouse has been scrolled using a wheel/trackpad/touchpad.
+                    (_, _) if mouse.scroll.y != 0.0 =>
+                        scroll_offset(bar.offset, bar.max_offset, mouse.scroll.y),
+
+                    // Otherwise, we'll assume the offset is unchanged.
+                    _ => bar.offset,
+                };
+
+                Bar { interaction: new_interaction, offset: new_offset, ..bar }
+            }),
+
+            maybe_horizontal: self.maybe_horizontal.map(|bar| {
+                let track = horizontal_track(self.visible, self.thickness);
+                let handle = horizontal_handle(track, bar.offset, bar.max_offset);
+
+                // Determine whether or not the mouse is over part of the Scrollbar.
+                let is_over_elem = is_over_elem(track, handle, mouse.xy[0]);
+
+                // Determine the new current `Interaction`.
+                let new_interaction = new_interaction(&bar, is_over_elem, mouse.xy[0]);
+
+                // Determine the new offset for the scrollbar.
+                let new_offset = match (bar.interaction, new_interaction) {
+
+                    // When the track is clicked and the handle snaps to the cursor.
+                    (Highlighted(Track), Clicked(Handle(mouse_x))) => {
+                        // Should try snap the handle so that the mouse is in the middle of it.
+                        let target_offset = (mouse_x - track.left()) - handle.w() / 2.0;
+                        clamp(target_offset, 0.0, bar.max_offset)
+                    },
+
+                    // When the handle is dragged.
+                    (Clicked(Handle(prev_mouse_x)), Clicked(Handle(mouse_x))) =>
+                        scroll_offset(bar.offset, bar.max_offset, mouse_x - prev_mouse_x),
+
+                    // The mouse has been scrolled using a wheel/trackpad/touchpad.
+                    (_, _) if mouse.scroll.x != 0.0 => {
+                        println!("Scroll X: {:?}", -mouse.scroll.x);
+                        scroll_offset(bar.offset, bar.max_offset, -mouse.scroll.x)
+                    },
+
+                    // Otherwise, we'll assume the offset is unchanged.
+                    _ => bar.offset,
+                };
+
+                Bar { interaction: new_interaction, offset: new_offset, ..bar }
+            }),
+
+            .. self
+        }
+    }
+
 }
 
 
+// /// The new state of the given scrollbar if it has changed.
+// pub fn update(container: Rect, state: &State, maybe_mouse: Option<Mouse>) -> Option<State> {
+//     use self::Elem::{Handle, Track};
+//     use self::Interaction::{Normal, Highlighted, Clicked};
+//     use utils::clamp;
+// 
+//     // Gives the updated vertical `Bar` if it has changed.
+//     let vertical = |bar: &Bar| -> Option<Bar> {
+//         // Check to see if the bar has changed and return a new bar if it has.
+//         maybe_new_bar(bar, new_interaction, new_offset)
+//     };
+// 
+//     // Gives the updated horizontal `Bar` if it has changed.
+//     let horizontal = |bar: &Bar| -> Option<Bar> {
+// 
+//         // Check to see if the bar has changed and return a new bar if it has.
+//         maybe_new_bar(bar, new_interaction, new_offset)
+//     };
+// 
+//     // Produce a new scroll state if there has been any changes in either bar.
+//     match (&state.maybe_vertical, &state.maybe_horizontal) {
+// 
+//         // We have both vertical and horizontal bars.
+//         (&Some(ref v_bar), &Some(ref h_bar)) => match (vertical(v_bar), horizontal(h_bar)) {
+//             (None, None) => None,
+//             (Some(new_v_bar), None) => Some(State { maybe_vertical: Some(new_v_bar), ..*state }),
+//             (None, Some(new_h_bar)) => Some(State { maybe_horizontal: Some(new_h_bar), ..*state }),
+//             (Some(new_v_bar), Some(new_h_bar)) =>
+//                 Some(State {
+//                     maybe_vertical: Some(new_v_bar),
+//                     maybe_horizontal: Some(new_h_bar),
+//                     ..*state
+//                 }),
+//         },
+// 
+//         // We only have a vertical scrollbar.
+//         (&Some(ref v_bar), &None) => vertical(v_bar).map(|new_v_bar| {
+//             State { maybe_vertical: Some(new_v_bar), ..*state }
+//         }),
+// 
+//         // We only have a horizontal scrollbar.
+//         (&None, &Some(ref h_bar)) => horizontal(h_bar).map(|new_h_bar| {
+//             State { maybe_horizontal: Some(new_h_bar), ..*state }
+//         }),
+// 
+//         // We don't have any scrollbars.
+//         (&None, &None) => None,
+//     }
+// }
+
+
 /// Construct a renderable Element from the state for the given widget's kid area.
-pub fn element(kid_area: &widget::KidArea, state: State) -> Element {
+pub fn element(container: Rect, state: State) -> Element {
     use elmesque::element::{empty, layers};
     use elmesque::form::{collage, rect};
 
@@ -348,14 +407,13 @@ pub fn element(kid_area: &widget::KidArea, state: State) -> Element {
             return empty();
         }
         let color = bar.interaction.color(color);
-        let (track_dim, track_xy) = vertical_track_area(kid_area, thickness);
-        let (handle_dim, handle_xy) =
-            vertical_handle_area(track_dim, track_xy, thickness, bar.offset, bar.max_offset);
-        let track_form = rect(track_dim[0], track_dim[1]).filled(track_color)
-            .shift(track_xy[0], track_xy[1]);
-        let handle_form = rect(handle_dim[0], handle_dim[1]).filled(color)
-            .shift(handle_xy[0], handle_xy[1]);
-        collage(kid_area.dim[0] as i32, kid_area.dim[1] as i32, vec![track_form, handle_form])
+        let track = vertical_track(container, thickness);
+        let handle = vertical_handle(track, bar.offset, bar.max_offset);
+        let track_form = rect(track.w(), track.h()).filled(track_color)
+            .shift(track.x(), track.y());
+        let handle_form = rect(handle.w(), handle.h()).filled(color)
+            .shift(handle.x(), handle.y());
+        collage(container.w() as i32, container.h() as i32, vec![track_form, handle_form])
     };
 
     // An element for a horizontal slider.
@@ -365,14 +423,13 @@ pub fn element(kid_area: &widget::KidArea, state: State) -> Element {
             return empty();
         }
         let color = bar.interaction.color(color);
-        let (track_dim, track_xy) = horizontal_track_area(kid_area, thickness);
-        let (handle_dim, handle_xy) =
-            horizontal_handle_area(track_dim, track_xy, thickness, bar.offset, bar.max_offset);
-        let track_form = rect(track_dim[0], track_dim[1]).filled(track_color)
-            .shift(track_xy[0], track_xy[1]);
-        let handle_form = rect(handle_dim[0], handle_dim[1]).filled(color)
-            .shift(handle_xy[0], handle_xy[1]);
-        collage(kid_area.dim[0] as i32, kid_area.dim[1] as i32, vec![track_form, handle_form])
+        let track = horizontal_track(container, thickness);
+        let handle = horizontal_handle(track, bar.offset, bar.max_offset);
+        let track_form = rect(track.w(), track.h()).filled(track_color)
+            .shift(track.x(), track.y());
+        let handle_form = rect(handle.w(), handle.h()).filled(color)
+            .shift(handle.x(), handle.y());
+        collage(container.w() as i32, container.h() as i32, vec![track_form, handle_form])
     };
 
     // Whether we draw horizontal or vertical or both depends on our state.
@@ -385,67 +442,137 @@ pub fn element(kid_area: &widget::KidArea, state: State) -> Element {
 }
 
 
+impl Bar {
+
+    /// Construct a new Bar with an absolute offset from a visible range and the total range that
+    /// is to be scrolled. If there is some previous Bar state, that is also to be considered.
+    pub fn new(visible: Range, kids: Range, maybe_prev: Option<&Bar>) -> Bar {
+
+        let total = visible.max_directed(kids);
+
+        let visible_len = visible.magnitude();
+        let kids_len = kids.magnitude();
+        let total_len = total.magnitude();
+        //let scrollable_len = total_len - visible_len;
+        let scrollable_len = kids_len - visible_len;
+
+        println!("\tvisible: {:?}", visible);
+        println!("\tkids: {:?}", kids);
+        println!("\ttotal: {:?}", total);
+        println!("\tvisible_len: {:?}", visible_len);
+        println!("\tkids_len: {:?}", kids_len);
+        println!("\ttotal_len: {:?}", total_len);
+        println!("\tscrollable_len: {:?}", scrollable_len);
+
+        // We only need to calculate offsets if we actually have some scrollable area.
+        if scrollable_len.is_normal() && scrollable_len.signum() == kids_len.signum() {
+            // The start and end differences, so that if both visible points are within the kids
+            // range, they will have the same signum as the kids range.
+            let start_diff = visible.start - kids.start;
+            //let end_diff = kids.end - visible.end;
+
+            let bar_len = (visible_len / kids_len) * visible_len;
+            let max_offset = visible_len - bar_len;
+            let offset = maybe_prev.map(|bar| bar.offset)
+                .unwrap_or_else(|| map_range(start_diff, 0.0, scrollable_len, 0.0, max_offset));
+            //let offset = map_range(start_diff, 0.0, scrollable_len, 0.0, max_offset);
+            //let offset = map_range(end_diff, total_len - scrollable_len, total_len, 0.0, max_offset);
+            let interaction = maybe_prev.map(|bar| bar.interaction).unwrap_or(Interaction::Normal);
+
+            println!("\tbar_len: {:?}", bar_len);
+            println!("\tmax_offset: {:?}", max_offset);
+            println!("\toffset: {:?}", offset);
+
+            Bar {
+                interaction: interaction,
+                offset: offset,
+                max_offset: max_offset,
+                total_length: kids_len,
+            }
+        // Otherwise our offsets are zeroed.
+        } else {
+            Bar {
+                interaction: Interaction::Normal,
+                offset: 0.0,
+                max_offset: 0.0,
+                total_length: total_len,
+            }
+        }
+    }
+
+    /// Converts the Bar's current offset to a positional offset given some visible range.
+    pub fn pos_offset(&self, visible_len: Scalar) -> Scalar {
+        if self.max_offset == 0.0
+        || self.max_offset > 0.0 && self.offset <= 0.0
+        || self.max_offset < 0.0 && self.offset >= 0.0 {
+            0.0
+        } else {
+            let scrollable_len = (self.total_length.abs() - visible_len.abs())
+                * self.max_offset.signum();
+            -map_range(self.offset, 0.0, self.max_offset, 0.0, scrollable_len)
+            // let min_offset = ::utils::partial_min(self.offset, 0.0);
+            // let max_offset = ::utils::partial_max(self.offset, self.max_offset);
+            // -map_range(self.offset, min_offset, max_offset, 0.0, scrollable_len)
+        }
+    }
+
+    /// Convert some scalar within the visible_len to a bar offset amount.
+    pub fn pos_offset_to_bar_offset(&self, scalar: Scalar, visible_len: Scalar) -> Scalar {
+        let scrollable_len = (self.total_length.abs() - visible_len.abs())
+            * self.total_length.signum();
+        map_range(scalar, 0.0, scrollable_len, 0.0, self.max_offset)
+    }
+
+}
+
+
 /// The area for a vertical scrollbar track as its dimensions and position.
-fn vertical_track_area(container: &widget::KidArea, thickness: Scalar) -> (Dimensions, Point) {
+fn vertical_track(container: Rect, thickness: Scalar) -> Rect {
     let w = thickness;
-    let h = container.dim[1];
-    let x = container.xy[0] + container.dim[0] / 2.0 - w / 2.0;
-    let y = container.xy[1];
-    ([w, h], [x, y])
+    let x = container.x() + container.w() / 2.0 - w / 2.0;
+    Rect {
+        x: Range::from_pos_and_len(x, w),
+        y: container.y,
+    }
 }
 
 /// The area for a vertical scrollbar handle as its dimensions and position.
-fn vertical_handle_area(track_dim: Dimensions,
-                        track_xy: Point,
-                        thickness: Scalar,
-                        offset: Scalar,
-                        max_offset: Scalar) -> (Dimensions, Point)
-{
-    let w = thickness;
-    let h = track_dim[1] - max_offset;
-    let x = track_xy[0];
-    let top_of_track = track_xy[1] + track_dim[1] / 2.0;
-    let y = top_of_track - offset - (h / 2.0);
-    ([w, h], [x, y])
+fn vertical_handle(track: Rect, offset: Scalar, max_offset: Scalar) -> Rect {
+    let h = track.h() - max_offset;
+    let y = track.top() - offset - (h / 2.0);
+    Rect {
+        x: track.x,
+        y: Range::from_pos_and_len(y, h),
+    }
 }
 
 /// The area for a horizontal scrollbar track as its dimensions and position.
-fn horizontal_track_area(container: &widget::KidArea, thickness: Scalar) -> (Dimensions, Point) {
-    let w = container.dim[0];
+fn horizontal_track(container: Rect, thickness: Scalar) -> Rect {
     let h = thickness;
-    let x = container.xy[0];
-    let y = container.xy[1] - container.dim[1] / 2.0 + h / 2.0;
-    ([w, h], [x, y])
+    let y = container.y() - container.h() / 2.0 + h / 2.0;
+    Rect {
+        x: container.x,
+        y: Range::from_pos_and_len(y, h),
+    }
 }
 
 /// The area for a horizontal scrollbar handle as its dimensions and position.
-fn horizontal_handle_area(track_dim: Dimensions,
-                          track_xy: Point,
-                          thickness: Scalar,
-                          offset: Scalar,
-                          max_offset: Scalar) -> (Dimensions, Point)
-{
-    let w = track_dim[0] - max_offset;
-    let h = thickness;
-    let left_of_track = track_xy[0] - track_dim[0] / 2.0;
-    let x = left_of_track + offset + (w / 2.0);
-    let y = track_xy[1];
-    ([w, h], [x, y])
+fn horizontal_handle(track: Rect, offset: Scalar, max_offset: Scalar) -> Rect {
+    let w = track.w() - max_offset;
+    let x = track.left() + offset + (w / 2.0);
+    Rect {
+        x: Range::from_pos_and_len(x, w),
+        y: track.y,
+    }
 }
 
 
 /// Is the given xy over the area of a scrollbar with the given state.
-pub fn is_over(state: &State, kid_area: &widget::KidArea, target_xy: Point) -> bool {
+pub fn is_over(state: &State, container: Rect, target_xy: Point) -> bool {
     if state.maybe_vertical.is_some() {
-        let (track_dim, track_xy) = vertical_track_area(kid_area, state.thickness);
-        if is_over_rect(track_xy, target_xy, track_dim) {
-            return true;
-        }
+        return vertical_track(container, state.thickness).is_over(target_xy);
     } else if state.maybe_horizontal.is_some() {
-        let (track_dim, track_xy) = horizontal_track_area(kid_area, state.thickness);
-        if is_over_rect(track_xy, target_xy, track_dim) {
-            return true;
-        }
+        return horizontal_track(container, state.thickness).is_over(target_xy);
     }
     false
 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -116,8 +116,8 @@ impl Style {
     /// Get the Color for an Element.
     pub fn color(&self, theme: &Theme) -> Color {
         self.maybe_color.or(theme.maybe_scrollbar.as_ref().map(|style| {
-            style.maybe_color.unwrap_or(theme.shape_color.complement())
-        })).unwrap_or(theme.shape_color.complement())
+            style.maybe_color.unwrap_or(theme.shape_color.plain_contrast())
+        })).unwrap_or(theme.shape_color.plain_contrast())
     }
 
 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -5,7 +5,7 @@
 use {Element, Scalar};
 use color::Color;
 use mouse::Mouse;
-use position::{Point, Range, Rect};
+use position::{Dimensions, Point, Range, Rect};
 use theme::Theme;
 use utils::map_range;
 
@@ -336,58 +336,14 @@ impl State {
         }
     }
 
+    /// Converts the Bars' current offset to a positional offset along its visible area.
+    pub fn pos_offset(&self) -> Dimensions {
+        let maybe_x_offset = self.maybe_horizontal.map(|bar| bar.pos_offset(self.visible.x.len()));
+        let maybe_y_offset = self.maybe_vertical.map(|bar| bar.pos_offset(self.visible.y.len()));
+        [maybe_x_offset.unwrap_or(0.0), maybe_y_offset.unwrap_or(0.0)]
+    }
+
 }
-
-
-// /// The new state of the given scrollbar if it has changed.
-// pub fn update(container: Rect, state: &State, maybe_mouse: Option<Mouse>) -> Option<State> {
-//     use self::Elem::{Handle, Track};
-//     use self::Interaction::{Normal, Highlighted, Clicked};
-//     use utils::clamp;
-// 
-//     // Gives the updated vertical `Bar` if it has changed.
-//     let vertical = |bar: &Bar| -> Option<Bar> {
-//         // Check to see if the bar has changed and return a new bar if it has.
-//         maybe_new_bar(bar, new_interaction, new_offset)
-//     };
-// 
-//     // Gives the updated horizontal `Bar` if it has changed.
-//     let horizontal = |bar: &Bar| -> Option<Bar> {
-// 
-//         // Check to see if the bar has changed and return a new bar if it has.
-//         maybe_new_bar(bar, new_interaction, new_offset)
-//     };
-// 
-//     // Produce a new scroll state if there has been any changes in either bar.
-//     match (&state.maybe_vertical, &state.maybe_horizontal) {
-// 
-//         // We have both vertical and horizontal bars.
-//         (&Some(ref v_bar), &Some(ref h_bar)) => match (vertical(v_bar), horizontal(h_bar)) {
-//             (None, None) => None,
-//             (Some(new_v_bar), None) => Some(State { maybe_vertical: Some(new_v_bar), ..*state }),
-//             (None, Some(new_h_bar)) => Some(State { maybe_horizontal: Some(new_h_bar), ..*state }),
-//             (Some(new_v_bar), Some(new_h_bar)) =>
-//                 Some(State {
-//                     maybe_vertical: Some(new_v_bar),
-//                     maybe_horizontal: Some(new_h_bar),
-//                     ..*state
-//                 }),
-//         },
-// 
-//         // We only have a vertical scrollbar.
-//         (&Some(ref v_bar), &None) => vertical(v_bar).map(|new_v_bar| {
-//             State { maybe_vertical: Some(new_v_bar), ..*state }
-//         }),
-// 
-//         // We only have a horizontal scrollbar.
-//         (&None, &Some(ref h_bar)) => horizontal(h_bar).map(|new_h_bar| {
-//             State { maybe_horizontal: Some(new_h_bar), ..*state }
-//         }),
-// 
-//         // We don't have any scrollbars.
-//         (&None, &None) => None,
-//     }
-// }
 
 
 /// Construct a renderable Element from the state for the given widget's kid area.

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -125,10 +125,9 @@ impl<'a, T, F> Slider<'a, T, F> {
 
 }
 
-impl<'a, T, F> Widget for Slider<'a, T, F>
-    where
-        F: FnMut(T),
-        T: ::std::any::Any + ::std::fmt::Debug + Float + NumCast + ToPrimitive,
+impl<'a, T, F> Widget for Slider<'a, T, F> where
+    F: FnMut(T),
+    T: ::std::any::Any + ::std::fmt::Debug + Float + NumCast + ToPrimitive,
 {
     type State = State<T>;
     type Style = Style;
@@ -177,7 +176,7 @@ impl<'a, T, F> Widget for Slider<'a, T, F>
     }
 
     /// Update the state of the Slider.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State<T>>
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<T>>
         where C: CharacterCache,
     {
         use utils::{is_over_rect, map_range};
@@ -273,7 +272,7 @@ impl<'a, T, F> Widget for Slider<'a, T, F>
     }
 
     /// Construct an Element from the given Slider State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{collage, rect, text};

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -277,8 +277,7 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
     {
         use elmesque::form::{collage, rect, text};
 
-        let widget::DrawArgs { state, style, theme, glyph_cache } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
         let frame = style.frame(theme);
         let (inner_w, inner_h) = (dim[0] - frame * 2.0, dim[1] - frame * 2.0);
         let frame_color = state.color(style.frame_color(theme));

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -179,15 +179,16 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
     fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<T>>
         where C: CharacterCache,
     {
-        use utils::{is_over_rect, map_range};
+        use utils::map_range;
 
-        let widget::UpdateArgs { prev_state, xy, dim, style, ui, .. } = args;
+        let widget::UpdateArgs { prev_state, rect, style, ui, .. } = args;
         let widget::State { ref state, .. } = *prev_state;
+        let (xy, dim) = rect.xy_dim();
         let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
         let new_interaction = match (self.enabled, maybe_mouse) {
             (false, _) | (true, None) => Interaction::Normal,
             (true, Some(mouse)) => {
-                let is_over = is_over_rect([0.0, 0.0], mouse.xy, dim);
+                let is_over = ::position::is_over_rect([0.0, 0.0], dim, mouse.xy);
                 get_new_interaction(is_over, state.interaction, mouse)
             },
         };
@@ -275,9 +276,10 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
     fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
-        use elmesque::form::{collage, rect, text};
+        use elmesque::form::{self, collage, text};
 
-        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
+        let widget::DrawArgs { rect, state, style, theme, glyph_cache, .. } = args;
+        let (xy, dim) = rect.xy_dim();
         let frame = style.frame(theme);
         let (inner_w, inner_h) = (dim[0] - frame * 2.0, dim[1] - frame * 2.0);
         let frame_color = state.color(style.frame_color(theme));
@@ -300,10 +302,10 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
         };
 
         // Rectangle frame / backdrop Form.
-        let frame_form = rect(dim[0], dim[1])
+        let frame_form = form::rect(dim[0], dim[1])
             .filled(frame_color);
         // Slider rectangle Form.
-        let pad_form = rect(pad_dim[0], pad_dim[1])
+        let pad_form = form::rect(pad_dim[0], pad_dim[1])
             .filled(color)
             .shift(pad_rel_xy[0], pad_rel_xy[1]);
 

--- a/src/widget/split.rs
+++ b/src/widget/split.rs
@@ -157,8 +157,7 @@ impl<'a> Split<'a> {
                   xy: Point,
                   maybe_parent: Option<widget::Id>,
                   ui: &mut Ui<C>)
-        where
-            C: CharacterCache,
+        where C: CharacterCache
     {
         use vecmath::{vec2_add, vec2_sub};
 

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -246,7 +246,7 @@ impl<'a> Widget for Tabs<'a> {
     }
 
     /// Update the state of the Tabs.
-    fn update<'b, C>(self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
+    fn update<C>(self, args: widget::UpdateArgs<Self, C>) -> Option<State>
         where C: CharacterCache,
     {
         let widget::UpdateArgs { idx, prev_state, xy, dim, style, mut ui } = args;
@@ -385,7 +385,7 @@ impl<'a> Widget for Tabs<'a> {
 
 
     /// Construct an Element from the given Button State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{collage, rect, text};

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -4,7 +4,7 @@ use color::Color;
 use elmesque::Element;
 use graphics::character::CharacterCache;
 use label::FontSize;
-use position::{Dimensions, Point, Rect};
+use position::{Dimensions, Point};
 use super::canvas::{self, Canvas};
 use theme::Theme;
 use widget::{self, Widget};
@@ -233,24 +233,19 @@ impl<'a> Widget for Tabs<'a> {
     fn kid_area<C: CharacterCache>(&self, args: widget::KidAreaArgs<Self, C>) -> widget::KidArea {
         let widget::KidAreaArgs { rect, style, theme, glyph_cache } = args;
         let font_size = style.font_size(theme);
-        let (x, y, w, h) = rect.x_y_w_h();
         match style.layout(theme) {
             Layout::Horizontal => {
                 let tab_bar_h = horizontal_tab_bar_h(style.maybe_bar_width, font_size as Scalar);
-                let xy = [x, y - tab_bar_h / 2.0];
-                let dim = [w, h - tab_bar_h];
                 widget::KidArea {
-                    rect: Rect::from_xy_dim(xy, dim),
+                    rect: rect.pad_top(tab_bar_h),
                     pad: style.canvas.padding(theme),
                 }
             },
             Layout::Vertical => {
                 let max_text_width = max_text_width(self.tabs.iter(), font_size, glyph_cache);
                 let tab_bar_w = vertical_tab_bar_w(style.maybe_bar_width, max_text_width as Scalar);
-                let xy = [x + tab_bar_w / 2.0, y];
-                let dim = [w - tab_bar_w, h];
                 widget::KidArea {
-                    rect: Rect::from_xy_dim(xy, dim),
+                    rect: rect.pad_left(tab_bar_w),
                     pad: style.canvas.padding(theme),
                 }
             },
@@ -295,7 +290,7 @@ impl<'a> Widget for Tabs<'a> {
                             for i in 0..self.tabs.len() {
                                 let tab_x = start_tab_x + i as f64 * tab_dim[0];
                                 let tab_xy = [tab_x, tab_bar_rel_xy[1]];
-                                if is_over_rect(tab_xy, mouse.xy, tab_dim) {
+                                if is_over_rect(tab_xy, tab_dim, mouse.xy) {
                                     return Some(Elem::Tab(i));
                                 }
                             }
@@ -306,7 +301,7 @@ impl<'a> Widget for Tabs<'a> {
                             for i in 0..self.tabs.len() {
                                 let tab_y = start_tab_y - i as f64 * tab_dim[1];
                                 let tab_xy = [tab_bar_rel_xy[0], tab_y];
-                                if is_over_rect(tab_xy, mouse.xy, tab_dim) {
+                                if is_over_rect(tab_xy, tab_dim, mouse.xy) {
                                     return Some(Elem::Tab(i));
                                 }
                             }

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -397,8 +397,7 @@ impl<'a> Widget for Tabs<'a> {
         use elmesque::form::{collage, rect, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { state, style, theme, .. } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, .. } = args;
         let State {
             ref tabs,
             ref interaction,

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -532,8 +532,7 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
         use elmesque::form::{collage, line, rect, solid, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { state, style, theme, glyph_cache } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
 
         // Construct the frame and inner rectangle Forms.
         let frame = style.frame(theme);

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -185,9 +185,9 @@ fn over_elem<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
                                 text_w: f64,
                                 font_size: FontSize,
                                 text: &str) -> Elem {
-    use utils::is_over_rect;
-    if is_over_rect([0.0, 0.0], mouse_xy, dim) {
-        if is_over_rect([0.0, 0.0], mouse_xy, pad_dim) {
+    use position::is_over_rect;
+    if is_over_rect([0.0, 0.0], dim, mouse_xy) {
+        if is_over_rect([0.0, 0.0], pad_dim, mouse_xy) {
             let (idx, _) = closest_idx(glyph_cache, mouse_xy, text_start_x, text_w, font_size, text);
             Elem::Char(idx)
         } else {
@@ -368,8 +368,9 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
         where C: CharacterCache,
     {
 
-        let widget::UpdateArgs { prev_state, xy, dim, style, ui, .. } = args;
+        let widget::UpdateArgs { prev_state, rect, style, ui, .. } = args;
         let widget::State { ref state, .. } = *prev_state;
+        let (xy, dim) = rect.xy_dim();
         let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
         let frame = style.frame(ui.theme());
         let font_size = style.font_size(ui.theme());
@@ -529,18 +530,19 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
     fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
-        use elmesque::form::{collage, line, rect, solid, text};
+        use elmesque::form::{self, collage, line, solid, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
+        let widget::DrawArgs { rect, state, style, theme, glyph_cache, .. } = args;
 
         // Construct the frame and inner rectangle Forms.
+        let (xy, dim) = rect.xy_dim();
         let frame = style.frame(theme);
         let pad_dim = vec2_sub(dim, [frame * 2.0; 2]);
         let color = state.interaction.color(style.color(theme));
         let frame_color = style.frame_color(theme);
-        let frame_form = rect(dim[0], dim[1]).filled(frame_color);
-        let inner_form = rect(pad_dim[0], pad_dim[1]).filled(color);
+        let frame_form = form::rect(dim[0], dim[1]).filled(frame_color);
+        let inner_form = form::rect(pad_dim[0], pad_dim[1]).filled(color);
         let font_size = style.font_size(theme);
         let text_w = glyph_cache.width(font_size, &state.text[..]);
         let text_x = position::align_left_of(pad_dim[0], text_w) + TEXT_PADDING;
@@ -571,7 +573,7 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
                     let htext_w = glyph_cache.width(font_size, &htext);
                     ([cursor_x + htext_w / 2.0, 0.0], [htext_w, dim[1]])
                 };
-                rect(dim[0], dim[1] - frame * 2.0).filled(color.highlighted())
+                form::rect(dim[0], dim[1] - frame * 2.0).filled(color.highlighted())
                     .shift(block_xy[0], block_xy[1])
             };
 

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -318,10 +318,7 @@ impl<'a, F> TextBox<'a, F> {
 
 }
 
-impl<'a, F> Widget for TextBox<'a, F>
-    where
-        F: FnMut(&mut String)
-{
+impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
     type State = State;
     type Style = Style;
     fn common(&self) -> &widget::CommonBuilder { &self.common }
@@ -367,7 +364,7 @@ impl<'a, F> Widget for TextBox<'a, F>
     }
 
     /// Update the state of the TextBox.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State>
         where C: CharacterCache,
     {
 
@@ -529,7 +526,7 @@ impl<'a, F> Widget for TextBox<'a, F>
     }
 
     /// Construct an Element from the given TextBox State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{collage, line, rect, solid, text};

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -107,10 +107,7 @@ impl<'a, F> Toggle<'a, F> {
 
 }
 
-impl<'a, F> Widget for Toggle<'a, F>
-    where
-        F: FnMut(bool),
-{
+impl<'a, F> Widget for Toggle<'a, F> where F: FnMut(bool), {
     type State = State;
     type Style = Style;
     fn common(&self) -> &widget::CommonBuilder { &self.common }
@@ -155,9 +152,7 @@ impl<'a, F> Widget for Toggle<'a, F>
     }
 
     /// Update the state of the Toggle.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State>
-        where C: CharacterCache,
-    {
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State> {
         use utils::is_over_rect;
 
         let widget::UpdateArgs { prev_state, xy, dim, ui, .. } = args;
@@ -202,7 +197,7 @@ impl<'a, F> Widget for Toggle<'a, F>
     }
 
     /// Construct an Element from the given Toggle State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{collage, rect, text};

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -202,8 +202,7 @@ impl<'a, F> Widget for Toggle<'a, F> where F: FnMut(bool), {
     {
         use elmesque::form::{collage, rect, text};
 
-        let widget::DrawArgs { state, style, theme, .. } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, .. } = args;
 
         // Construct the frame and pressable forms.
         let frame = style.frame(theme);

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -182,7 +182,7 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
     }
 
     /// Update the XYPad's cached state.
-    fn update<'b, C>(mut self, args: widget::UpdateArgs<'b, Self, C>) -> Option<State<X, Y>>
+    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<X, Y>>
         where C: CharacterCache,
     {
         use utils::is_over_rect;
@@ -246,7 +246,7 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
     }
 
     /// Construct an Element from the given XYPad State.
-    fn draw<'b, C>(args: widget::DrawArgs<'b, Self, C>) -> Element
+    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
         where C: CharacterCache,
     {
         use elmesque::form::{collage, line, rect, solid, text};

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -252,8 +252,7 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
         use elmesque::form::{collage, line, rect, solid, text};
         use elmesque::text::Text;
 
-        let widget::DrawArgs { state, style, theme, glyph_cache } = args;
-        let widget::State { ref state, dim, xy, .. } = *state;
+        let widget::DrawArgs { dim, xy, state, style, theme, glyph_cache, .. } = args;
         let frame = style.frame(theme);
         let pad_dim = vec2_sub(dim, [frame * 2.0; 2]);
         let (half_pad_w, half_pad_h) = (pad_dim[0] / 2.0, pad_dim[1] / 2.0);


### PR DESCRIPTION
**WIP** (don't merge just yet)

- [x] Consider relative positioning properly in scroll_offset calculation.
- [x] Fix horizontal scrolling.
- [x] Make `WidgetMatrix` an actual `Widget` (which will fix its scroll behaviour). Closes #578.
    ~~- Turns out `impl`ing `Widget` for `WidgetMatrix` requires moving the `<C>` generic from the `update` method to the `Widget` trait itself. This is because `WidgetMatrix` holds some closure that has a `UiCell<C>` as an arg, and the C must match the same C given by the `UiCell<C>` passed to the update. I've been hoping to avoid this (mainly just because `Widget` trait looked so pretty without generic params) but it does make logical sense to make the change... so I might as well make the change along with this PR also.~~
- [x] In `set_widget`, update the widget's cached xy coords and dimensions before `Widget::update` is called, so that child widgets can correctly calculate scroll offset when set within `Widget::update`.
    - [x] Calculate `kid_area` prior to calling `Widget::update`
    - [x] Calculate the scrolling prior to calling `Widget::update`
    - [x] Split the `Graph::update_widget` method into `Graph::pre_update_cache` and `Graph::post_update_cache`. This will allow us to cache information about a widget necessary for the child widgets *prior* to calling `Widget::update` (in which child widgets are `set`).
~~- [ ] Move `CharacterCache` generic from `Widget::update` method to the `Widget` trait itself.~~
- [x] Fix issue where the scroll Bar's max_offset is slightly short when visible area is initially outside of the kids' bounding box.
- [x] Fix scrolling behaviour for floating widgets' children.
- [x] Fix bug causing canvas.rs initial scroll offset to be out of bounds.
- [x] Fix issue introduced in prev commit where Tabs kid area seems to be incorrect.