### PR TITLE
Fix Graph::pick_widget/bounding_box so that they properly consider widgets' cropped scroll area.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.20.1"
+version = "0.20.2"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -229,8 +229,8 @@ impl Graph {
             .find(|&&visitable| {
                 match visitable {
                     Visitable::Widget(idx) => {
-                        if let Some(&Node::Widget(ref container)) = dag.node_weight(idx) {
-                            if container.rect.is_over(xy) {
+                        if let Some(visible_rect) = self.visible_area(idx) {
+                            if visible_rect.is_over(xy) {
                                 return true
                             }
                         }
@@ -456,12 +456,10 @@ impl Graph {
         let mut current = idx.to_node_index(&self.index_map).expect(NO_MATCHING_NODE_INDEX);
         let mut overlapping_rect = self[current].rect;
         loop {
-            println!("\toverlapping_rect: {:?}", overlapping_rect);
             match maybe_parent_depth_edge(&self.dag, current) {
                 Some((_, parent)) => match self.get_widget(parent) {
                     Some(parent_widget) => match parent_widget.maybe_scrolling {
                         Some(_) => {
-                            println!("\tparent.kid_area.rect: {:?}", parent_widget.kid_area.rect);
                             match overlapping_rect.overlap(parent_widget.kid_area.rect) {
                                 Some(overlap) => {
                                     overlapping_rect = overlap;

--- a/src/position.rs
+++ b/src/position.rs
@@ -655,6 +655,21 @@ impl Range {
         Range::new(start..end)
     }
 
+    /// The Range that represents the range of the overlap between two Ranges if there is some.
+    /// The returned Range's `start` will always be <= its `end`.
+    pub fn overlap(mut self, mut other: Range) -> Option<Range> {
+        self = self.undirected();
+        other = other.undirected();
+        let start = ::utils::partial_max(self.start, other.start);
+        let end = ::utils::partial_min(self.end, other.end);
+        let magnitude = end - start;
+        if magnitude > 0.0 {
+            Some(Range::new(start..end))
+        } else {
+            None
+        }
+    }
+
     /// The Range that encompasses both self and the given Range.
     /// The returned Range will retain `self`'s original direction.
     pub fn max_directed(self, other: Range) -> Range {
@@ -749,6 +764,11 @@ impl Rect {
             x: Range::from_pos_and_len(xy[0], dim[0]),
             y: Range::from_pos_and_len(xy[1], dim[1]),
         }
+    }
+
+    /// The Rect representing the area in which two Rects overlap.
+    pub fn overlap(self, other: Rect) -> Option<Rect> {
+        self.x.overlap(other.x).and_then(|x| self.y.overlap(other.y).map(|y| Rect { x: x, y: y }))
     }
 
     /// The Rect that encompass the two given sets of Rect.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -567,10 +567,18 @@ impl<C> Ui<C> {
         }
     }
 
-    /// The rectangle that represents the maximum fully visible area for the widget with the given
-    /// index, including considering cropped scroll area.
+
+    /// The **Rect** that bounds the kids of the widget with the given index.
+    pub fn kids_bounding_box<I: Into<widget::Index>>(&self, idx: I) -> Option<Rect> {
+        let idx: widget::Index = idx.into();
+        self.widget_graph.kids_bounding_box(idx)
+    }
+
+
+    /// The **Rect** that represents the maximum fully visible area for the widget with the given
+    /// index, including consideration of cropped scroll area.
     ///
-    /// Otherwise, return None if the widget is hidden.
+    /// Otherwise, return None if the widget is not visible.
     pub fn visible_area<I: Into<widget::Index>>(&self, idx: I) -> Option<Rect> {
         let idx: widget::Index = idx.into();
         self.widget_graph.visible_area(idx)
@@ -578,11 +586,6 @@ impl<C> Ui<C> {
 
 }
 
-
-/// Return an immutable reference to the given `Ui`'s `Graph`.
-pub fn widget_graph<C>(ui: &Ui<C>) -> &Graph {
-    &ui.widget_graph
-}
 
 /// A mutable reference to the given `Ui`'s widget `Graph`.
 pub fn widget_graph_mut<C>(ui: &mut Ui<C>) -> &mut Graph {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,7 +16,7 @@ use input::{
     RenderEvent,
     TextEvent,
 };
-use position::{Dimensions, HorizontalAlign, Padding, Point, Position, VerticalAlign};
+use position::{Dimensions, HorizontalAlign, Padding, Point, Position, Rect, VerticalAlign};
 use std::cell::RefCell;
 use std::io::Write;
 use theme::Theme;
@@ -565,6 +565,15 @@ impl<C> Ui<C> {
         if self.redraw_count > 0 {
             self.draw(context, graphics);
         }
+    }
+
+    /// The rectangle that represents the maximum fully visible area for the widget with the given
+    /// index, including considering cropped scroll area.
+    ///
+    /// Otherwise, return None if the widget is hidden.
+    pub fn visible_area<I: Into<widget::Index>>(&self, idx: I) -> Option<Rect> {
+        let idx: widget::Index = idx.into();
+        self.widget_graph.visible_area(idx)
     }
 
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -654,7 +654,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
         } else {
             let maybe_mouse = ui::get_mouse_state(ui, idx);
             let visible = kid_area.rect;
-            let kids = ui::widget_graph(ui).bounding_box(false, None, true, idx)
+            let kids = ui.kids_bounding_box(idx)
                 .map(|kids| kids.shift(visible.xy()))
                 .unwrap_or_else(|| kid_area.rect);
             let maybe_prev = maybe_prev_scrolling.as_ref();


### PR DESCRIPTION
Fixes #589 
Fixes #572 
Fixes #446 