### PR TITLE
Change Widget::update to mutate the Widget::State rather than return a new one. Move input capturing methods from Widget trait to UiCell.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.20.3"
+version = "0.21.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -42,7 +42,6 @@ mod circular_button {
         Theme,
         UpdateArgs,
         Widget,
-        WidgetState,
     };
 
 
@@ -204,30 +203,6 @@ mod circular_button {
         }
         fn style(&self) -> Style { self.style.clone() }
 
-        /// Whether the button should capture the mouse. Widgets can "capture" user input.
-        /// If the button captures the mouse, then mouse events will only be seen by the
-        /// button. Other widgets will not see mouse events until the button uncaptures
-        /// the mouse.
-        fn capture_mouse(prev: &State, new: &State) -> bool {
-            match (prev.interaction, new.interaction) {
-                // If the user has pressed the button since the last update, then the
-                // button captures the mouse.
-                (Interaction::Highlighted, Interaction::Clicked) => true,
-                _ => false,
-            }
-        }
-
-        /// Whether the button should uncapture the mouse.
-        fn uncapture_mouse(prev: &State, new: &State) -> bool {
-            match (prev.interaction, new.interaction) {
-                // If the user has released the button since the last update, then the
-                // button uncaptures the mouse.
-                (Interaction::Clicked, Interaction::Highlighted) => true,
-                (Interaction::Clicked, Interaction::Normal) => true,
-                _ => false,
-            }
-        }
-
         /// Default width of the widget. This method is optional. The Widget trait
         /// provides a default implementation that always returns zero.
         fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
@@ -254,11 +229,8 @@ mod circular_button {
         /// Update the state of the button. The state may or may not have changed since
         /// the last update. (E.g. it may have changed because the user moused over the
         /// button.) If the state has changed, return the new state. Else, return None.
-        fn update<'b, C>(mut self, args: UpdateArgs<'b, Self, C>) -> Option<State>
-            where C: CharacterCache,
-        {
-            let UpdateArgs { prev_state, rect, ui, .. } = args;
-            let WidgetState { ref state, .. } = *prev_state;
+        fn update<C: CharacterCache>(mut self, args: UpdateArgs<Self, C>) {
+            let UpdateArgs { state, rect, mut ui, .. } = args;
             let (xy, dim) = rect.xy_dim();
             let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
 
@@ -275,7 +247,7 @@ mod circular_button {
                     let is_over = is_over_circ([0.0, 0.0], mouse.xy, dim);
 
                     // See above where we define get_new_interaction.
-                    get_new_interaction(is_over, state.interaction, mouse)
+                    get_new_interaction(is_over, state.view().interaction, mouse)
                 },
             };
 
@@ -284,7 +256,7 @@ mod circular_button {
             // of right now. So this if statement is saying: If the button was clicked a
             // moment ago, and it's now highlighted, then the button has been activated.
             if let (Interaction::Clicked, Interaction::Highlighted) =
-                (state.interaction, new_interaction)
+                (state.view().interaction, new_interaction)
             {
                 // Recall that our CircularButton struct includes maybe_react, which
                 // stores either a reaction function or None. If maybe_react is Some, call
@@ -292,41 +264,48 @@ mod circular_button {
                 if let Some(ref mut react) = self.maybe_react { react() }
             }
 
-            // A function for constructing a new state. We'll call this function below
-            // if we determine that the state has changed.
-            let new_state = || State {
-                // Recall that our CircularButton struct includes maybe_label, which
-                // stores either an &str or None. If there's something there, we
-                // copy the &str into an owned String for the State object.
-                maybe_label: self.maybe_label.as_ref().map(|label| label.to_string()),
+            // Here we check to see whether or not our button should capture the mouse.
+            //
+            // Widgets can "capture" user input. If the button captures the mouse, then mouse
+            // events will only be seen by the button. Other widgets will not see mouse events
+            // until the button uncaptures the mouse.
+            match (state.view().interaction, new_interaction) {
+                // If the user has pressed the button we capture the mouse.
+                (Interaction::Highlighted, Interaction::Clicked) => {
+                    ui.capture_mouse();
+                },
+                // If the user releases the button, we uncapture the mouse.
+                (Interaction::Clicked, Interaction::Highlighted) |
+                (Interaction::Clicked, Interaction::Normal)      => {
+                    ui.uncapture_mouse();
+                },
+                _ => (),
+            }
 
-                // We constructed new_interaction above. This is the interaction state
-                // as of this update.
-                interaction: new_interaction,
-            };
+            // Whenever we call `state.update` (as below), a flag is set within our `State`
+            // indicating that there has been some mutation and that our widget requires a
+            // new `Element` (meaning that `Widget::draw` will be called again). Thus, we only want
+            // to call `state.update` if there has been some change in order to only redraw our
+            // `Element` when absolutely required.
+            //
+            // You can see how we do this below - we check if the state has changed before calling
+            // `state.update`.
 
-            // Check whether or not the state has changed since the previous update. The
-            // state has changed if (1) the interaction state has changed, or (2) the
-            // label string has changed.
-            let state_has_changed =
-                state.interaction != new_interaction
-                || state.maybe_label
-                    // Convert the Option<String> to an Option<&String>.
-                    .as_ref()
-                    // Convert the Option<&String> to an Option<&str>.
-                    .map(|string| &string[..])
-                    // Compare the current Option<&str> to the previous one.
-                    != self.maybe_label;
+            // If the interaction has changed, set the new interaction.
+            if state.view().interaction != new_interaction {
+                state.update(|state| state.interaction = new_interaction);
+            }
 
-            // Construct and return the new state if there was a change. Recall that we
-            // defined new_state above.
-            if state_has_changed { Some(new_state()) } else { None }
+            // If the label has changed, set the new label.
+            if state.view().maybe_label.as_ref().map(|label| &label[..]) != self.maybe_label {
+                state.update(|state| {
+                    state.maybe_label = self.maybe_label.as_ref().map(|label| label.to_string());
+                })
+            }
         }
 
         /// Construct and return a renderable `Element` for the given button state.
-        fn draw<'b, C>(args: DrawArgs<'b, Self, C>) -> Element
-            where C: CharacterCache,
-        {
+        fn draw<C: CharacterCache>(args: DrawArgs<Self, C>) -> Element {
             use elmesque;
             use elmesque::form::{collage, circle, text};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub use position::Matrix as PositionMatrix;
 pub use theme::{Align, Theme};
 pub use ui::{GlyphCache, Ui, UserInput};
 pub use widget::{drag, scroll, CommonBuilder, DrawArgs, UiCell, UpdateArgs, Widget};
+pub use widget::CommonState as WidgetCommonState;
 pub use widget::Id as WidgetId;
 pub use widget::Index as WidgetIndex;
 pub use widget::State as WidgetState;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -678,24 +678,40 @@ pub fn get_mouse_state<C>(ui: &Ui<C>, idx: widget::Index) -> Option<Mouse> {
 
 
 /// Indicate that the widget with the given widget::Index has captured the mouse.
-pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
+///
+/// Returns true if the mouse was successfully captured.
+/// 
+/// Returns false if the mouse was already captured.
+pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) -> bool {
     // If the mouse isn't already captured, set idx as the capturing widget.
     if let None = ui.maybe_captured_mouse {
         ui.maybe_captured_mouse = Some(Capturing::Captured(idx));
+        return true;
     }
+    false
 }
 
 
 /// Indicate that the widget is no longer capturing the mouse.
-pub fn mouse_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
+///
+/// Returns true if the mouse was sucessfully released.
+///
+/// Returns false if the mouse wasn't captured by the widget in the first place.
+pub fn mouse_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) -> bool {
     // Check that we are indeed the widget that is currently capturing the Mouse before releasing.
     if ui.maybe_captured_mouse == Some(Capturing::Captured(idx)) {
-        ui.maybe_captured_mouse = Some(Capturing::JustReleased)
+        ui.maybe_captured_mouse = Some(Capturing::JustReleased);
+        return true;
     }
+    false
 }
 
 /// Indicate that the widget with the given widget::Index has captured the keyboard.
-pub fn keyboard_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
+///
+/// Returns true if the keyboard was successfully captured.
+///
+/// Returns false if the keyboard was already captured by another widget.
+pub fn keyboard_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) -> bool {
     match ui.maybe_captured_keyboard {
         Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
             writeln!(::std::io::stderr(),
@@ -707,13 +723,21 @@ pub fn keyboard_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
                     "Warning: {:?} tried to capture the keyboard, however it was \
                      already captured.", idx).unwrap();
         },
-        None => ui.maybe_captured_keyboard = Some(Capturing::Captured(idx)),
+        None => {
+            ui.maybe_captured_keyboard = Some(Capturing::Captured(idx));
+            return true;
+        },
     }
+    false
 }
 
 
 /// Indicate that the widget is no longer capturing the keyboard.
-pub fn keyboard_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
+///
+/// Returns true if the keyboard was successfully released.
+///
+/// Returns false if the keyboard wasn't captured by the given widget in the first place.
+pub fn keyboard_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) -> bool {
     match ui.maybe_captured_keyboard {
         Some(Capturing::Captured(captured_idx)) => if idx != captured_idx {
             writeln!(::std::io::stderr(),
@@ -721,6 +745,7 @@ pub fn keyboard_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
                      actually captured by {:?}.", idx, captured_idx).unwrap();
         } else {
             ui.maybe_captured_keyboard = Some(Capturing::JustReleased);
+            return true;
         },
         Some(Capturing::JustReleased) => {
             writeln!(::std::io::stderr(),
@@ -733,6 +758,7 @@ pub fn keyboard_uncaptured_by<C>(ui: &mut Ui<C>, idx: widget::Index) {
                      was not captured", idx).unwrap();
         },
     }
+    false
 }
 
 

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -69,18 +69,15 @@ impl<'a> Widget for Label<'a> {
     }
 
     /// Update the state of the Label.
-    fn update<C>(self, args: widget::UpdateArgs<Self, C>) -> Option<State>
-        where C: CharacterCache,
-    {
-        let widget::UpdateArgs { prev_state, .. } = args;
-        let widget::State { state: State(ref string), .. } = *prev_state;
-        if &string[..] != self.text { Some(State(self.text.to_string())) } else { None }
+    fn update<C: CharacterCache>(self, args: widget::UpdateArgs<Self, C>) {
+        let widget::UpdateArgs { state, .. } = args;
+        if &state.view().0[..] != self.text {
+            state.update(|state| *state = State(self.text.to_owned()));
+        }
     }
 
     /// Construct an Element for the Label.
-    fn draw<C>(args: widget::DrawArgs<Self, C>) -> Element
-        where C: CharacterCache,
-    {
+    fn draw<C: CharacterCache>(args: widget::DrawArgs<Self, C>) -> Element {
         use elmesque::form::{text, collage};
         use elmesque::text::Text;
         let widget::DrawArgs { rect, state: &State(ref string), style, theme, .. } = args;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -33,89 +33,99 @@ pub mod toggle;
 pub mod xy_pad;
 
 
-/// Arguments for the `Widget::update` method in a struct to simplify the method signature.
+/// Arguments for the [**Widget::update**](./trait.Widget#method.update) method in a struct to
+/// simplify the method signature.
 pub struct UpdateArgs<'a, W, C: 'a> where W: Widget {
-    /// The Widget's unique index.
+    /// The **Widget**'s unique index.
     pub idx: Index,
-    /// The Widget's previous state. Specifically, the state that is common between all widgets.
+    /// The **Widget**'s previous state. Specifically, the state that is common between all widgets,
+    /// such as positioning, floatability, draggability, etc.
     pub prev: &'a CommonState,
-    /// A wrapper around the Widget's unique state, providing methods for both immutably viewing
+    /// A wrapper around the **Widget**'s unique state, providing methods for both immutably viewing
     /// and mutably updating the state.
     ///
     /// We wrap mutation in a method so that we can keep track of whether or not the unique state
-    /// has been updated. If `State::update` is called, we assume that there has been some mutation
-    /// and in turn will produce a new `Element` for the `Widget`. Thus, it is recommended that you
-    /// *only* call `State::update` if you need to update the unique state in some way.
+    /// has been updated.
+    ///
+    /// If **State::update** is called, we assume that there has been some mutation and in turn will
+    /// produce a new **Element** for the **Widget**. Thus, it is recommended that you *only* call
+    /// **State::update** if you need to update the unique state in some way.
     pub state: &'a mut State<'a, W::State>,
-    /// The rectangle describing the `Widget`'s area.
+    /// The rectangle describing the **Widget**'s area.
     pub rect: Rect,
-    /// The Widget's current Style.
+    /// The **Widget**'s current **Widget::Style**.
     pub style: &'a W::Style,
     /// Restricted access to the `Ui`.
+    ///
     /// Provides methods for immutably accessing the `Ui`'s `Theme` and `GlyphCache`.
     /// Also allows calling `Widget::set` within the `Widget::update` method.
     pub ui: UiCell<'a, C>,
 }
 
-/// A wrapper around a `Ui` that only exposes the functionality necessary for the `Widget::update`
-/// method. Its primary role is to allow for widget designers to compose their own unique `Widget`s
-/// from other `Widget`s by calling the `Widget::set` method within their own `Widget`'s
-/// update method. It also provides methods for accessing the `Ui`'s `Theme`, `GlyphCache` and
-/// `UserInput` via immutable reference.
+/// A wrapper around a `Ui` that only exposes the functionality necessary for the
+/// **Widget::update** method.
+///
+/// Its primary role is to allow for widget designers to compose their own unique **Widget**s from
+/// other **Widget**s by calling the **Widget::set** method within their own **Widget**'s
+/// update method.
+///
+/// It also provides methods for accessing the **Ui**'s **Theme**, **GlyphCache** and **UserInput**
+/// via immutable reference.
 ///
 /// BTW - if you have a better name for this type, please post an issue or PR! "Cell" was the best
-/// I could come up with as it's kind of like a jail cell for the `Ui` - restricting a user's
+/// I could come up with as it's kind of like a jail cell for the **Ui** - restricting a user's
 /// access to it.
 pub struct UiCell<'a, C: 'a> {
-    /// A mutable reference to a `Ui`.
+    /// A mutable reference to a **Ui**.
     ui: &'a mut Ui<C>,
-    /// The index of the Widget that "owns" the `UiCell`. The index is needed so that we can
+    /// The index of the Widget that "owns" the **UiCell**. The index is needed so that we can
     /// correctly retrieve user input information for the specific widget.
     idx: Index,
 }
 
-/// Arguments for the `Widget::draw` method in a struct to simplify the method signature.
+/// Arguments for the **Widget::draw** method in a struct to simplify the method signature.
 pub struct DrawArgs<'a, W, C: 'a> where W: Widget {
     /// The current state of the Widget.
     pub state: &'a W::State,
     /// The current style of the Widget.
     pub style: &'a W::Style,
-    /// The active `Theme` within the `Ui`.
+    /// The active **Theme** within the **Ui**.
     pub theme: &'a Theme,
-    /// The `Ui`'s GlyphCache (for determining text width, etc).
+    /// The **Ui**'s **GlyphCache** (for determining text width).
     pub glyph_cache: &'a GlyphCache<C>,
-    /// The widget's z-axis position relative to its sibling widgets.
+    /// The **Widget**'s z-axis position relative to its sibling widgets.
     pub depth: Depth,
-    /// The rectangle describing the `Widget`'s area.
+    /// The rectangle describing the **Widget**'s area.
     pub rect: Rect,
-    /// The current state of the dragged widget, if it is draggable.
+    /// The current state of the dragged **Widget**, if it is draggable.
     pub drag_state: drag::State,
     /// Floating state for the widget if it is floating.
     pub maybe_floating: Option<Floating>,
 }
 
-/// Arguments to the `Widget::kid_area` method in a struct to simplify the method signature.
+/// Arguments to the [**Widget::kid_area**](./trait.Widget#method.kid_area) method in a struct to
+/// simplify the method signature.
 pub struct KidAreaArgs<'a, W, C: 'a> where W: Widget {
-    /// The rectangle describing the `Widget`'s area.
+    /// The **Rect** describing the **Widget**'s position and dimensions.
     pub rect: Rect,
-    /// Current Style of the Widget.
+    /// Current **Widget::Style** of the **Widget**.
     pub style: &'a W::Style,
-    /// The active `Theme` within the `Ui`.
+    /// The active **Theme** within the **Ui**.
     pub theme: &'a Theme,
-    /// The `Ui`'s GlyphCache (for determining text width, etc).
+    /// The **Ui**'s **GlyphCache** (for determining text width).
     pub glyph_cache: &'a GlyphCache<C>,
 }
 
-/// The area upon which a Widget's child widgets will be placed.
+/// The area upon which a **Widget**'s child widgets will be placed.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct KidArea {
-    /// The Rectangle bounds describing the area.
+    /// The **Rect** bounds describing the position and area.
     pub rect: Rect,
     /// The distance between the edge of the area and where the widgets will be placed.
     pub pad: Padding,
 }
 
-/// The builder argument for the widget's Parent.
+/// The builder argument for the **Widget**'s parent.
 #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum MaybeParent {
     /// The user specified the widget should not have any parents, so the Root will be used.
@@ -126,15 +136,15 @@ pub enum MaybeParent {
     Unspecified,
 }
 
-/// State necessary for Floating widgets.
+/// State necessary for "floating" (pop-up style) widgets.
 #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Floating {
-    /// The time the canvas was last clicked (used for depth sorting in graph).
+    /// The time the **Widget** was last clicked (used for depth sorting in the widget **Graph**).
     pub time_last_clicked: u64,
 }
 
-/// A struct containing builder data common to all Widget types.
-/// This type allows us to do a blanket impl of Positionable and Sizeable for T: Widget.
+/// A struct containing builder data common to all **Widget** types.
+/// This type allows us to do a blanket impl of **Positionable** and **Sizeable** for `T: Widget`.
 #[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable)]
 pub struct CommonBuilder {
     /// The width of a Widget.
@@ -157,16 +167,18 @@ pub struct CommonBuilder {
     pub scrolling: scroll::Scrolling,
 }
 
-/// A wrapper around a `Widget`'s unique `Widget::State`.
+/// A wrapper around a **Widget**'s unique **Widget::State**.
 ///
-/// This type is used to provide limited access to the `Widget::State` within the `Widget::update`
-/// method (to which it is passed via the `UpdateArgs`).
+/// This type is used to provide limited access to the **Widget::State** within the
+/// [**Widget::update**](./trait.Widget#method.update) method (to which it is passed via the
+/// [**UpdateArgs**](./struct.UpdateArgs)).
 ///
-/// The type provides only two methods. One for viewing the state, and one for mutating the state.
+/// The type provides only two methods. One for viewing the state, the other for mutating it.
 ///
-/// We do this so that we can keep track of whether or not the `Widget::State` has been mutated
+/// We do this so that we can keep track of whether or not the **Widget::State** has been mutated
 /// (using an internal `has_updated` flag). This allows us to know whether or not we need to
-/// produce a new `Element` for the widget, without having to compare previous and new states.
+/// produce a new **Element** for the **Widget**, without having to compare the previous and
+/// new **Widget::State**s.
 #[derive(Debug)]
 pub struct State<'a, T: 'a> {
     state: &'a mut T,
@@ -174,8 +186,7 @@ pub struct State<'a, T: 'a> {
     has_updated: bool,
 }
 
-/// A wrapper around a Widget's common state. Particularly, that state which was produced via the
-/// previous time that the Widget was set.
+/// A wrapper around state that is common to all **Widget** types.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct CommonState {
     /// The rectangle describing the `Widget`'s area.
@@ -188,7 +199,7 @@ pub struct CommonState {
     pub maybe_floating: Option<Floating>,
 }
 
-/// The previous widget state to be returned by the Ui prior to a widget updating it's new state.
+/// A **Widget**'s state in a form that is retrievable from the **Ui**'s widget cache.
 pub struct Cached<W> where W: Widget {
     /// State that is unique to the Widget.
     pub state: W::State,
@@ -208,46 +219,52 @@ pub struct Cached<W> where W: Widget {
     pub maybe_scrolling: Option<scroll::State>,
 }
 
-/// Widget data to be cached prior to the `Widget::update` call in the `set_widget` function.
-/// We do this so that if this Widget were to internally `set` some other `Widget`s, this
-/// `Widget`s positioning and dimension data already exists within the `Graph` for reference.
+/// **Widget** data to be cached prior to the **Widget::update** call in the **set_widget**
+/// function.
+///
+/// We do this so that if this **Widget** were to internally `set` some other **Widget**s, this
+/// **Widget**'s positioning and dimension data already exists within the widget **Graph** for
+/// reference.
 pub struct PreUpdateCache {
-    /// The `Widget`'s unique kind.
+    /// The **Widget**'s unique kind.
     pub kind: &'static str,
-    /// The `Widget`'s unique Index.
+    /// The **Widget**'s unique Index.
     pub idx: Index,
-    /// The widget's parent's unique index (if it has a parent).
+    /// The **Widget**'s parent's unique index (if it has a parent).
     pub maybe_parent_idx: Option<Index>,
-    /// If this widget is relatively positioned to another `Widget`, this will be the index of
-    /// the `Widget` to which this `Widget` is relatively positioned
+    /// If this **Widget** is relatively positioned to another **Widget**, this will be the index
+    /// of the **Widget** to which this **Widget** is relatively positioned
     pub maybe_positioned_relatively_idx: Option<Index>,
-    /// The rectangle describing the Widget's area.
+    /// The **Rect** describing the **Widget**'s position and dimensions.
     pub rect: Rect,
     /// The z-axis depth - affects the render order of sibling widgets.
     pub depth: Depth,
-    /// The new KidArea for the Widget.
+    /// The area upon which the **Widget**'s children widgets will be placed.
     pub kid_area: KidArea,
-    /// The current state of the dragged widget, if it is draggable.
+    /// The current state of the dragged **Widget**, if it is draggable.
     pub drag_state: drag::State,
-    /// Scrolling data for the Widget if there is some.
+    /// Floating data for the **Widget** if there is some.
     pub maybe_floating: Option<Floating>,
-    /// Scrolling data for the Widget if there is some.
+    /// Scrolling data for the **Widget** if there is some.
     pub maybe_scrolling: Option<scroll::State>,
 }
 
-/// Widget data to be cached after the `Widget::update` call in the `set_widget` function.
-/// We do this so that if this Widget were to internally `set` some other `Widget`s, this
-/// `Widget`s positioning and dimension data already exists within the `Graph` for reference.
+/// **Widget** data to be cached after the **Widget::update** call in the **set_widget**
+/// function.
+///
+/// We do this so that if this **Widget** were to internally **Widget::set** some other
+/// **Widget**s, this **Widget**'s positioning and dimension data will already exist within the
+/// widget **Graph** for reference.
 pub struct PostUpdateCache<W> where W: Widget {
-    /// The `Widget`'s unique Index.
+    /// The **Widget**'s unique **Index**.
     pub idx: Index,
-    /// The widget's parent's unique index (if it has a parent).
+    /// The **Widget**'s parent's unique **Index** (if it has a parent).
     pub maybe_parent_idx: Option<Index>,
-    /// The newly produced unique `State` associated with the `Widget`.
+    /// The newly produced unique **Widget::State** associated with the **Widget**.
     pub state: W::State,
-    /// The newly produced unique `Style` associated with the `Widget`.
+    /// The newly produced unique **Widget::Style** associated with the **Widget**.
     pub style: W::Style,
-    /// A new `Element` to use for the `Widget` if a new one has been produced.
+    /// A new **Element** to use for the **Widget** if a new one has been produced.
     pub maybe_element: Option<Element>,
 }
 
@@ -270,11 +287,11 @@ impl<'a, C> UiRefMut for UiCell<'a, C> where C: CharacterCache {
 }
 
 
-/// A trait to be implemented by all Widget types.
+/// A trait to be implemented by all **Widget** types.
 ///
 /// Methods that *must* be overridden:
-/// - common_mut
 /// - common
+/// - common_mut
 /// - unique_kind
 /// - init_state
 /// - style
@@ -282,7 +299,6 @@ impl<'a, C> UiRefMut for UiCell<'a, C> where C: CharacterCache {
 /// - draw
 ///
 /// Methods that can be optionally overridden:
-/// - parent_id
 /// - default_position
 /// - default_width
 /// - default_height
@@ -303,20 +319,32 @@ pub trait Widget: Sized {
     /// serializing non-internal widget styling with the `Theme` type, but we hope to soon.
     type Style: Any + PartialEq + ::std::fmt::Debug;
 
-    /// Return a reference to a CommonBuilder struct owned by the Widget.
+    /// Return a reference to a **CommonBuilder** struct owned by the Widget.
     /// This method allows us to do a blanket impl of Positionable and Sizeable for T: Widget.
+    ///
+    /// Note: When rust introduces field inheritance, we will move the **CommonBuilder**
+    /// accordingly (perhaps under a different name).
     fn common(&self) -> &CommonBuilder;
 
     /// Return a mutable reference to a CommonBuilder struct owned by the Widget.
     /// This method allows us to do a blanket impl of Positionable and Sizeable for T: Widget.
+    ///
+    /// Note: When rust introduces field inheritance, we will move the **CommonBuilder**
+    /// accordingly (perhaps under a different name).
     fn common_mut(&mut self) -> &mut CommonBuilder;
 
-    /// Return the kind of the widget as a &'static str. Note that this must be unique from all
-    /// other widgets' "unique kinds". This is used by conrod to help avoid WidgetId errors and to
-    /// provide better messages for those that do occur.
+    /// Return the kind of the widget as a &'static str.
+    ///
+    /// Note that this must be unique from all other widgets' "unique kinds".
+    ///
+    /// This is used by conrod to help avoid WidgetId errors and to provide better messages for
+    /// those that do occur.
     fn unique_kind(&self) -> &'static str;
 
-    /// Return the initial `State` of the Widget. The `Ui` will only call this once.
+    /// Return the initial **State** of the Widget.
+    ///
+    /// The `Ui` will only call this once, shortly prior to the first time that **Widget::update**
+    /// is first called.
     fn init_state(&self) -> Self::State;
 
     /// Return the styling of the widget. The `Ui` will call this once prior to each `update`. It
@@ -324,18 +352,24 @@ pub trait Widget: Sized {
     /// be constructed.
     fn style(&self) -> Self::Style;
 
-    /// Your widget's previous state is given to you as a parameter and it is your job to
-    /// construct and return an Update that will be used to update the widget's cached state.
-    /// You only have to return `Some` state if the resulting state would be different to `prev`.
-    /// If `Some` new state was returned, `Widget::draw` will be called in order to construct an
-    /// up to date `Element`.
+    /// Update our **Widget**'s unique **Widget::State** via the **State** wrapper type (the
+    /// `state` field within the [**UpdateArgs**](./struct.UpdateArgs)).
+    ///
+    /// Whenever [**State::update**](./struct.State.html#method.update) is called, a `has_updated`
+    /// flag is set within the **State**, indicating that there has been some change to the unique
+    /// **Widget::State** and that we require re-drawing the **Widget**'s **Element** (i.e. calling
+    /// [**Widget::draw**](./trait.Widget#method.draw). As a result, widget designers should only
+    /// call **State::update** when necessary, checking whether or not the state has changed before
+    /// invoking the the method. See the custom_widget.rs example for a demonstration
+    /// of this.
     ///
     /// # Arguments
     /// * idx - The `Widget`'s unique index (whether `Public` or `Internal`).
-    /// * prev - The previous state of the Widget. If none existed, `Widget::init_state` will be
-    /// used to pass the initial state instead.
-    /// * xy - The coordinates representing the middle of the widget.
-    /// * dim - The dimensions of the widget.
+    /// * prev - The previous common state of the Widget. If this is the first time **update** is
+    /// called, `Widget::init_state` will be used to produce some intial state instead.
+    /// * state - A wrapper around the `Widget::State`. See the [**State** docs](./struct.State)
+    /// for more details.
+    /// * rect - The position (centered) and dimensions of the widget.
     /// * style - The style produced by the `Widget::style` method.
     /// * ui - A wrapper around the `Ui`, offering restricted access to its functionality. See the
     /// docs for `UiCell` for more details.
@@ -346,10 +380,10 @@ pub trait Widget: Sized {
     /// when designing your widget's `Style` and `State` types.
     ///
     /// # Arguments
-    /// * new_state - The freshly produced State which contains the unique widget info necessary
-    /// for rendering.
-    /// * current_style - The freshly produced `Style` of the widget.
-    /// * theme - The currently active `Theme` within the `Ui`.
+    /// * state - The current **Widget::State** which should contain all unique state necessary for
+    /// rendering the **Widget**.
+    /// * style - The current **Widget::Style** of the **Widget**.
+    /// * theme - The currently active **Theme** within the `Ui`.
     /// * glyph_cache - Used for determining the size of rendered text if necessary.
     fn draw<C: CharacterCache>(args: DrawArgs<Self, C>) -> Element;
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -289,6 +289,10 @@ impl<'a, C> UiRefMut for UiCell<'a, C> where C: CharacterCache {
 
 /// A trait to be implemented by all **Widget** types.
 ///
+/// A type that implements **Widget** can be thought of as a collection of arguments to the
+/// **Widget**'s **Widget::update** method. They type itself is not stored between updates, but
+/// rather is used to update an instance of the **Widget**'s **Widget::State**, which *is* stored.
+///
 /// Methods that *must* be overridden:
 /// - common
 /// - common_mut

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -146,21 +146,6 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
     }
     fn style(&self) -> Style { self.style.clone() }
 
-    fn capture_mouse(prev: &State<T>, new: &State<T>) -> bool {
-        match (prev.interaction, new.interaction) {
-            (Interaction::Highlighted, Interaction::Clicked) => true,
-            _ => false,
-        }
-    }
-
-    fn uncapture_mouse(prev: &State<T>, new: &State<T>) -> bool {
-        match (prev.interaction, new.interaction) {
-            (Interaction::Clicked, Interaction::Highlighted) => true,
-            (Interaction::Clicked, Interaction::Normal) => true,
-            _ => false,
-        }
-    }
-
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 192.0;
         self.common.maybe_width.or(theme.maybe_slider.as_ref().map(|default| {
@@ -176,22 +161,26 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
     }
 
     /// Update the state of the Slider.
-    fn update<C>(mut self, args: widget::UpdateArgs<Self, C>) -> Option<State<T>>
-        where C: CharacterCache,
-    {
+    fn update<C: CharacterCache>(mut self, args: widget::UpdateArgs<Self, C>) {
         use utils::map_range;
 
-        let widget::UpdateArgs { prev_state, rect, style, ui, .. } = args;
-        let widget::State { ref state, .. } = *prev_state;
+        let widget::UpdateArgs { state, rect, style, mut ui, .. } = args;
         let (xy, dim) = rect.xy_dim();
         let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
         let new_interaction = match (self.enabled, maybe_mouse) {
             (false, _) | (true, None) => Interaction::Normal,
             (true, Some(mouse)) => {
                 let is_over = ::position::is_over_rect([0.0, 0.0], dim, mouse.xy);
-                get_new_interaction(is_over, state.interaction, mouse)
+                get_new_interaction(is_over, state.view().interaction, mouse)
             },
         };
+
+        match (state.view().interaction, new_interaction) {
+            (Interaction::Highlighted, Interaction::Clicked) => { ui.capture_mouse(); },
+            (Interaction::Clicked, Interaction::Highlighted) |
+            (Interaction::Clicked, Interaction::Normal)      => { ui.uncapture_mouse(); },
+            _ => (),
+        }
 
         let new_value = if let Some(mouse) = maybe_mouse {
             let Slider { value, min, max, skew, .. } = self;
@@ -203,7 +192,7 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
 
             if is_horizontal {
                 // Horizontal.
-                let w_perc = match (state.interaction, new_interaction) {
+                let w_perc = match (state.view().interaction, new_interaction) {
                     (Interaction::Highlighted, Interaction::Clicked) |
                     (Interaction::Clicked, Interaction::Clicked) => {
                         let w = map_range(mouse.xy[0], -half_inner_w, half_inner_w, 0.0, inner_w);
@@ -219,7 +208,7 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
                 value_from_perc(w_perc as f32, min, max)
             } else {
                 // Vertical.
-                let h_perc = match (state.interaction, new_interaction) {
+                let h_perc = match (state.view().interaction, new_interaction) {
                     (Interaction::Highlighted, Interaction::Clicked) |
                     (Interaction::Clicked, Interaction::Clicked) => {
                         let h = map_range(mouse.xy[1], -half_inner_h, half_inner_h, 0.0, inner_h);
@@ -241,7 +230,7 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
         // React.
         match self.maybe_react {
             Some(ref mut react) => {
-                if self.value != new_value || match (state.interaction, new_interaction) {
+                if self.value != new_value || match (state.view().interaction, new_interaction) {
                     (Interaction::Highlighted, Interaction::Clicked) |
                     (Interaction::Clicked, Interaction::Highlighted) => true,
                     _ => false,
@@ -249,27 +238,31 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
             }, None => (),
         }
 
-        // A function for constructing a new state.
-        let new_state = || {
-            State {
-                interaction: new_interaction,
-                value: self.value,
-                min: self.min,
-                max: self.max,
-                skew: self.skew,
-                maybe_label: self.maybe_label.as_ref().map(|label| label.to_string()),
-            }
-        };
+        if state.view().interaction != new_interaction {
+            state.update(|state| state.interaction = new_interaction);
+        }
 
-        // Check whether or not the state has changed since the previous update.
-        let state_has_changed = state.interaction != new_interaction
-            || state.value != self.value
-            || state.min != self.min || state.max != self.max
-            || state.skew != self.skew
-            || state.maybe_label.as_ref().map(|string| &string[..]) != self.maybe_label;
+        if state.view().value != new_value {
+            state.update(|state| state.value = self.value);
+        }
 
-        // Construct the new state if there was a change.
-        if state_has_changed { Some(new_state()) } else { None }
+        if state.view().min != self.min {
+            state.update(|state| state.min = self.min);
+        }
+
+        if state.view().max != self.max {
+            state.update(|state| state.max = self.max);
+        }
+
+        if state.view().skew != self.skew {
+            state.update(|state| state.skew = self.skew);
+        }
+
+        if state.view().maybe_label.as_ref().map(|label| &label[..]) != self.maybe_label {
+            state.update(|state| {
+                state.maybe_label = self.maybe_label.as_ref().map(|label| label.to_string());
+            })
+        }
     }
 
     /// Construct an Element from the given Slider State.


### PR DESCRIPTION
This change addresses the problem highlighted in #554 where large widgets would be required to allocate an entire new `Widget::State` even for the slightest of changes. This is because the only way of updating the state was to return an entirely new state from the `Widget::update` method.

This PR changes the `Widget::update` method so that it no longer returns an `Option<Widget::State>` but instead provides a way of mutating the state via the `State` wrapper which is given via the `UpdateArgs`. All fields not relating to the unique widget state have been moved out of the `State` type and into a `CommonState` type. This allows us to use the `State` type purely as a "cell"-like wrapper around the `WidgetState`.

`State::view` provides immutable access to the `Widget::State`.
`State::update` allows for mutation of the `Widget::State`. When called, it sets a `has_updated` flag, allowing us to check whether or not the `Widget::State` was updated at all following the call of `Widget::update` and in turn allowing us to know whether or not we need to produce a new `Element` for the `Widget`.

This change also required moving the input capturing methods from the `Widget` trait to the `UiCell`, to be called within the `Widget::update` if necessary.