### PR TITLE
Remove unnecessary code from default_width/height. Clarify comment in custom_widget example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.21.4"
+version = "0.21.5"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -208,11 +208,17 @@ mod circular_button {
         fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
             const DEFAULT_WIDTH: Scalar = 64.0;
 
-            // Defaults can come from several places. Here, we define how certain defaults
-            // take precedence over others.
-            self.common.maybe_width.or(theme.maybe_button.as_ref().map(|default| {
+            // If no width was given via the `Sizeable` (a trait implemented for all widgets)
+            // methods, some default width must be chosen.
+            //
+            // Defaults can come from several places. Here, we define how certain defaults take
+            // precedence over others.
+            //
+            // Most commonly, defaults are to be retrieved from the `Theme`, however in some cases
+            // some other logic may need to be considered.
+            theme.maybe_button.as_ref().map(|default| {
                 default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-            })).unwrap_or(DEFAULT_WIDTH)
+            }).unwrap_or(DEFAULT_WIDTH)
         }
 
         /// Default width of the widget. This method is optional. The Widget trait
@@ -221,9 +227,9 @@ mod circular_button {
             const DEFAULT_HEIGHT: Scalar = 64.0;
 
             // See default_width for comments on this logic.
-            self.common.maybe_height.or(theme.maybe_button.as_ref().map(|default| {
+            theme.maybe_button.as_ref().map(|default| {
                 default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-            })).unwrap_or(DEFAULT_HEIGHT)
+            }).unwrap_or(DEFAULT_HEIGHT)
         }
 
         /// Update the state of the button. The state may or may not have changed since

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -122,16 +122,16 @@ impl<'a, F> Widget for Button<'a, F> where F: FnMut() {
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 64.0;
-        self.common.maybe_width.or(theme.maybe_button.as_ref().map(|default| {
+        theme.maybe_button.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 64.0;
-        self.common.maybe_height.or(theme.maybe_button.as_ref().map(|default| {
+        theme.maybe_button.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the Button.

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -223,16 +223,16 @@ impl<'a> Widget for Canvas<'a> {
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 160.0;
-        self.common.maybe_width.or(theme.maybe_button.as_ref().map(|default| {
+        theme.maybe_button.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 80.0;
-        self.common.maybe_height.or(theme.maybe_button.as_ref().map(|default| {
+        theme.maybe_button.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// The title bar area at which the Canvas can be clicked and dragged.

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -145,16 +145,16 @@ impl<'a, F> Widget for DropDownList<'a, F> where
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 128.0;
-        self.common.maybe_width.or(theme.maybe_drop_down_list.as_ref().map(|default| {
+        theme.maybe_drop_down_list.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 32.0;
-        self.common.maybe_height.or(theme.maybe_drop_down_list.as_ref().map(|default| {
+        theme.maybe_drop_down_list.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the DropDownList.

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -337,16 +337,16 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 256.0;
-        self.common.maybe_width.or(theme.maybe_envelope_editor.as_ref().map(|default| {
+        theme.maybe_envelope_editor.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 128.0;
-        self.common.maybe_height.or(theme.maybe_envelope_editor.as_ref().map(|default| {
+        theme.maybe_envelope_editor.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the EnvelopeEditor's cached state.

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -93,16 +93,16 @@ impl<'a, F, W> Widget for Matrix<F> where
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 128.0;
-        self.common.maybe_width.or(theme.maybe_matrix.as_ref().map(|default| {
+        theme.maybe_matrix.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 64.0;
-        self.common.maybe_height.or(theme.maybe_matrix.as_ref().map(|default| {
+        theme.maybe_matrix.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the Matrix.

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -232,16 +232,16 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 128.0;
-        self.common.maybe_width.or(theme.maybe_number_dialer.as_ref().map(|default| {
+        theme.maybe_number_dialer.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 48.0;
-        self.common.maybe_height.or(theme.maybe_number_dialer.as_ref().map(|default| {
+        theme.maybe_number_dialer.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the NumberDialer.

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -148,16 +148,16 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 192.0;
-        self.common.maybe_width.or(theme.maybe_slider.as_ref().map(|default| {
+        theme.maybe_slider.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 48.0;
-        self.common.maybe_height.or(theme.maybe_slider.as_ref().map(|default| {
+        theme.maybe_slider.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the Slider.

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -335,16 +335,16 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 192.0;
-        self.common.maybe_width.or(theme.maybe_text_box.as_ref().map(|default| {
+        theme.maybe_text_box.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 48.0;
-        self.common.maybe_height.or(theme.maybe_text_box.as_ref().map(|default| {
+        theme.maybe_text_box.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the TextBox.

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -124,16 +124,16 @@ impl<'a, F> Widget for Toggle<'a, F> where F: FnMut(bool), {
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 64.0;
-        self.common.maybe_width.or(theme.maybe_toggle.as_ref().map(|default| {
+        theme.maybe_toggle.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 64.0;
-        self.common.maybe_height.or(theme.maybe_toggle.as_ref().map(|default| {
+        theme.maybe_toggle.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the state of the Toggle.

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -154,16 +154,16 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
 
     fn default_width<C: CharacterCache>(&self, theme: &Theme, _: &GlyphCache<C>) -> Scalar {
         const DEFAULT_WIDTH: Scalar = 128.0;
-        self.common.maybe_width.or(theme.maybe_xy_pad.as_ref().map(|default| {
+        theme.maybe_xy_pad.as_ref().map(|default| {
             default.common.maybe_width.unwrap_or(DEFAULT_WIDTH)
-        })).unwrap_or(DEFAULT_WIDTH)
+        }).unwrap_or(DEFAULT_WIDTH)
     }
 
     fn default_height(&self, theme: &Theme) -> Scalar {
         const DEFAULT_HEIGHT: Scalar = 128.0;
-        self.common.maybe_height.or(theme.maybe_xy_pad.as_ref().map(|default| {
+        theme.maybe_xy_pad.as_ref().map(|default| {
             default.common.maybe_height.unwrap_or(DEFAULT_HEIGHT)
-        })).unwrap_or(DEFAULT_HEIGHT)
+        }).unwrap_or(DEFAULT_HEIGHT)
     }
 
     /// Update the XYPad's cached state.


### PR DESCRIPTION
The common builder is already checked, no need to check it there too. 