### PR TITLE
First pass at allowing user to move between TextBoxes with keyboard - Don't Merge

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -183,7 +183,7 @@ impl Graph {
             floating_deque: Vec::with_capacity(capacity),
         }
     }
-    
+
     /// Add a new placeholder node and return it's `NodeIndex` into the `Graph`.
     ///
     /// This method is used by the `widget::set_widget` function when some internal widget does not
@@ -1039,4 +1039,3 @@ impl<I: GraphIndex> ::std::ops::IndexMut<I> for Graph {
         self.get_widget_mut(idx).expect("No Widget matching the given ID")
     }
 }
-

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -521,7 +521,7 @@ pub trait Widget: Sized {
 /// For all following occasions, the pre-existing cached state will be compared and updated.
 ///
 /// Note that this is a very imperative, mutation oriented segment of code. We try to move as much
-/// imperativeness and mutation out of the users hands and into this function as possible, so that 
+/// imperativeness and mutation out of the users hands and into this function as possible, so that
 /// users have a clear, consise, purely functional `Widget` API. As a result, we try to keep this
 /// as verbosely annotated as possible. If anything is unclear, feel free to post an issue or PR
 /// with concerns/improvements to the github repo.
@@ -1014,4 +1014,3 @@ impl<W> Sizeable for W where W: Widget {
         self.common().maybe_height.unwrap_or(self.default_height(theme))
     }
 }
-


### PR DESCRIPTION
This is just a first pass at getting this to work. This PR is just to provide a place for people to comment and give feedback on the approach. Do not merge this! 

This allows users to move between TextBox widgets by hitting enter. One problem I see with this approach is that whatever TextBox had previously captured input will try to un-capture after the next TextBox has started capturing. This results in a bunch of warnings printed to stdout.