### PR TITLE
modified Cargo.toml to use the "time" crate instead of the deprecated "clock_ticks" module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "./src/lib.rs"
 
 [dependencies]
 bitflags = "0.3.3"
-clock_ticks = "0.1.0"
 elmesque = "0.10.2"
 json_io = "0.1.2"
 daggy = "0.3.0"
@@ -32,6 +31,7 @@ piston2d-graphics = "0.12.0"
 num = "0.1.28"
 rand = "0.3.12"
 rustc-serialize = "0.3.16"
+time = "0.1.34"
 vecmath = "0.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
"clock_ticks" is deprecated and broken, the git repo says to use "time" instead.