### PR TITLE
Fix Panic When TextBox is Empty

### DIFF
--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -1,4 +1,4 @@
-
+use std::cmp;
 use {
     Align,
     CharacterCache,
@@ -257,7 +257,7 @@ impl<'a> Widget for Text<'a> {
             },
         };
         let line_spacing = self.style.line_spacing(&ui.theme);
-        let height = total_height(num_lines, font_size, line_spacing);
+        let height = total_height(cmp::max(num_lines, 1), font_size, line_spacing);
         Dimension::Absolute(height)
     }
 


### PR DESCRIPTION
Previously if all the characters were deleted from a text box then we
would try to calculate the height based on 0 lines of text. This causes
the thread to panic with an arithmetic overflow on OS X.

This commit fixes things by rendering a text box with 0 characters in it
as the height of a single line.