### PR TITLE
Renamed some methods on `Sizeable` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.24.1"
+version = "0.25.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -39,4 +39,3 @@ piston2d-gfx_graphics = "0.16.0"
 piston2d-opengl_graphics = "0.21.0"
 pistoncore-glutin_window = "0.20.0"
 piston = "0.16.0"
-

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -194,7 +194,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
         // Button widget example button.
         Button::new()
-            .dimensions(200.0, 50.0)
+            .w_h(200.0, 50.0)
             .x_y(140.0 - (ui.win_w / 2.0), title_y - 70.0)
             .rgb(0.4, 0.75, 0.6)
             .frame(app.frame_width)
@@ -218,7 +218,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
         // Slider widget example slider(value, min, max).
         Slider::new(pad as f32, 30.0, 700.0)
-            .dimensions(200.0, 50.0)
+            .w_h(200.0, 50.0)
             .x_y(140.0 - (ui.win_w / 2.0), title_y - 70.0)
             .rgb(0.5, 0.3, 0.6)
             .frame(app.frame_width)
@@ -237,7 +237,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
     // Toggle widget example toggle(value).
     Toggle::new(app.show_button)
-        .dimensions(75.0, 75.0)
+        .w_h(75.0, 75.0)
         .down(20.0)
         .rgb(0.6, 0.25, 0.75)
         .frame(app.frame_width)
@@ -276,7 +276,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
         // Slider widget examples. slider(value, min, max)
         if i == 0 { Slider::new(value, 0.0, 1.0).down(25.0) }
         else      { Slider::new(value, 0.0, 1.0).right(20.0) }
-            .dimensions(40.0, app.v_slider_height)
+            .w_h(40.0, app.v_slider_height)
             .color(color)
             .frame(app.frame_width)
             .label(&label)
@@ -292,7 +292,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
     // Number Dialer widget example. (value, min, max, precision)
     NumberDialer::new(app.v_slider_height, 25.0, 250.0, 1)
-        .dimensions(260.0, 60.0)
+        .w_h(260.0, 60.0)
         .right_from(shown_widget, 30.0)
         .color(app.bg_color.invert())
         .frame(app.frame_width)
@@ -303,7 +303,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
     // Number Dialer widget example. (value, min, max, precision)
     NumberDialer::new(app.frame_width, 0.0, 15.0, 2)
-        .dimensions(260.0, 60.0)
+        .w_h(260.0, 60.0)
         .down(20.0)
         .color(app.bg_color.invert().plain_contrast())
         .frame(app.frame_width)
@@ -318,7 +318,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
     let (cols, rows) = (8, 8);
     WidgetMatrix::new(cols, rows)
         .down(20.0)
-        .dimensions(260.0, 260.0) // matrix width and height.
+        .w_h(260.0, 260.0) // matrix width and height.
         .each_widget(|_n, col: usize, row: usize| { // called for every matrix elem.
 
             // Color effect for fun.
@@ -344,7 +344,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
     // A demonstration using a DropDownList to select its own color.
     let mut ddl_color = app.ddl_color;
     DropDownList::new(&mut app.ddl_colors, &mut app.selected_idx)
-        .dimensions(150.0, 40.0)
+        .w_h(150.0, 40.0)
         .right_from(SLIDER_HEIGHT, 30.0) // Position right from widget 6 by 50 pixels.
         .max_visible_items(3)
         .color(ddl_color)
@@ -369,7 +369,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
     // Draw an xy_pad.
     XYPad::new(app.circle_pos[0], -75.0, 75.0, // x range.
                app.circle_pos[1], 95.0, 245.0) // y range.
-        .dimensions(150.0, 150.0)
+        .w_h(150.0, 150.0)
         .right_from(TOGGLE_MATRIX, 30.0)
         .align_bottom_of(TOGGLE_MATRIX) // Align to the bottom of the last TOGGLE_MATRIX element.
         .color(ddl_color)
@@ -399,7 +399,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
         if i == 0 { TextBox::new(text).right_from(COLOR_SELECT, 30.0) }
         else      { TextBox::new(text) }
             .font_size(20)
-            .dimensions(320.0, 40.0)
+            .w_h(320.0, 40.0)
             .frame(app.frame_width)
             .frame_color(app.bg_color.invert().plain_contrast())
             .color(app.bg_color.invert())
@@ -412,7 +412,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
         // Draw an EnvelopeEditor. (Vec<Point>, x_min, x_max, y_min, y_max).
         EnvelopeEditor::new(env, 0.0, 1.0, 0.0, env_y_max)
             .down(10.0)
-            .dimensions(320.0, 150.0)
+            .w_h(320.0, 150.0)
             .skew_y(env_skew_y)
             .color(app.bg_color.invert())
             .frame(app.frame_width)

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! A simple demonstration of how to construct and use Canvasses by splitting up the window.
 //!
 
@@ -60,7 +60,7 @@ fn set_widgets(ui: &mut Ui) {
     Canvas::new()
         .title_bar("Blue")
         .floating(true)
-        .dimensions(110.0, 150.0)
+        .w_h(110.0, 150.0)
         .middle_of(LEFT_COLUMN)
         .color(blue())
         .label_color(white())
@@ -69,7 +69,7 @@ fn set_widgets(ui: &mut Ui) {
     Canvas::new()
         .title_bar("Orange")
         .floating(true)
-        .dimensions(110.0, 150.0)
+        .w_h(110.0, 150.0)
         .middle_of(RIGHT_COLUMN)
         .color(light_orange())
         .label_color(white())
@@ -103,7 +103,7 @@ fn set_widgets(ui: &mut Ui) {
 
     let footer_dim = ui.dim_of(FOOTER).unwrap();
     WidgetMatrix::new(COLS, ROWS)
-        .dimensions(footer_dim[0], footer_dim[1] * 2.0)
+        .w_h(footer_dim[0], footer_dim[1] * 2.0)
         .mid_top_of(FOOTER)
         .each_widget(|n, _col, _row| {
             Button::new()
@@ -112,10 +112,10 @@ fn set_widgets(ui: &mut Ui) {
         })
         .set(BUTTON_MATRIX, ui);
 
-    Button::new().color(red()).dimensions(30.0, 30.0).middle_of(FLOATING_A)
+    Button::new().color(red()).w_h(30.0, 30.0).middle_of(FLOATING_A)
         .react(|| println!("Bing!"))
         .set(BING, ui);
-    Button::new().color(red()).dimensions(30.0, 30.0).middle_of(FLOATING_B)
+    Button::new().color(red()).w_h(30.0, 30.0).middle_of(FLOATING_B)
         .react(|| println!("Bong!"))
         .set(BONG, ui);
 }
@@ -157,4 +157,3 @@ widget_ids! {
     BONG,
 
 }
-

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -37,7 +37,7 @@ fn main() {
             // Draw the button and increment `count` if pressed.
             conrod::Button::new()
                 .middle_of(CANVAS)
-                .dimensions(80.0, 80.0)
+                .w_h(80.0, 80.0)
                 .label(&count.to_string())
                 .react(|| count += 1)
                 .set(COUNTER, ui);

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -1,5 +1,5 @@
 //!
-//! 
+//!
 //! A demonstration of designing a custom, third-party widget.
 //!
 //! In this case, we'll design a simple circular button.
@@ -465,7 +465,7 @@ fn main() {
             CircularButton::new()
                 .color(conrod::color::rgb(0.0, 0.3, 0.1))
                 .middle_of(BACKGROUND)
-                .dimensions(256.0, 256.0)
+                .w_h(256.0, 256.0)
                 .label_color(conrod::color::white())
                 .label("Circular Button")
                 // This is called when the user clicks the button.

--- a/src/position/mod.rs
+++ b/src/position/mod.rs
@@ -492,14 +492,14 @@ pub trait Sizeable: Sized {
 
     /// Set the dimensions for the widget.
     #[inline]
-    fn dim(self, dim: Dimensions) -> Self {
+    fn wh(self, dim: Dimensions) -> Self {
         self.width(dim[0]).height(dim[1])
     }
 
     /// Set the width and height for the widget.
     #[inline]
-    fn dimensions(self, width: Scalar, height: Scalar) -> Self {
-        self.dim([width, height])
+    fn w_h(self, width: Scalar, height: Scalar) -> Self {
+        self.wh([width, height])
     }
 
     /// Set the width as the width of the widget at the given index.
@@ -609,4 +609,3 @@ impl Margin {
         Margin { top: 0.0, bottom: 0.0, left: 0.0, right: 0.0 }
     }
 }
-

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -221,7 +221,7 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                 {
                     let mut button = Button::new()
                         .xy(rect.xy())
-                        .dim(rect.dim())
+                        .wh(rect.dim())
                         .label(label)
                         .parent(idx)
                         .react(|| was_clicked = true);
@@ -270,7 +270,7 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                 let mut was_clicked = None;
                 for (i, ((label, button_node_idx), button_xy)) in iter {
                     let mut button = Button::new()
-                        .dim(dim)
+                        .wh(dim)
                         .label(label)
                         .parent(canvas_idx)
                         .xy(button_xy)
@@ -426,4 +426,3 @@ impl<'a, F> Labelable<'a> for DropDownList<'a, F> {
         self
     }
 }
-

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -259,7 +259,7 @@ impl<'a, E, F> EnvelopeEditor<'a, E, F> where E: EnvelopePoint {
         }
     }
 
-    /// Set the reaction for the EnvelopeEditor. 
+    /// Set the reaction for the EnvelopeEditor.
     pub fn react(mut self, reaction: F) -> EnvelopeEditor<'a, E, F> {
         self.maybe_react = Some(reaction);
         self
@@ -636,7 +636,7 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
                 [x, y]
             });
             PointPath::new(points)
-                .dim(inner_rect.dim())
+                .wh(inner_rect.dim())
                 .xy(inner_rect.xy())
                 .graphics_for(idx)
                 .parent(idx)
@@ -827,4 +827,3 @@ impl<'a, E, F> Labelable<'a> for EnvelopeEditor<'a, E, F>
         self
     }
 }
-

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -171,7 +171,7 @@ impl<'a, F, W> Widget for Matrix<F> where
                         let h = widget_h - cell_pad_h * 2.0;
                         let widget_idx = indices[col][row];
                         each_widget(widget_num, col, row)
-                            .dim([w, h])
+                            .wh([w, h])
                             .x_y_relative_to(idx, rel_x, rel_y)
                             .set(widget_idx, &mut ui);
                         widget_num += 1;
@@ -215,4 +215,3 @@ impl Style {
     }
 
 }
-

--- a/src/widget/primitive/line.rs
+++ b/src/widget/primitive/line.rs
@@ -102,7 +102,7 @@ impl Line {
     /// The same as [**Line::abs**](./struct.Line#method.abs) but with the given style.
     pub fn abs_styled(start: Point, end: Point, style: Style) -> Self {
         let (xy, dim) = Rect::from_corners(start, end).xy_dim();
-        Line::styled(start, end, style).dim(dim).xy(xy)
+        Line::styled(start, end, style).wh(dim).xy(xy)
     }
 
     /// Build a new **Line** and shift the location of the start and end points so that the centre
@@ -121,7 +121,7 @@ impl Line {
     /// The same as [**Line::centred**](./struct.Line#method.centred) but with the given style.
     pub fn centred_styled(start: Point, end: Point, style: Style) -> Self {
         let dim = Rect::from_corners(start, end).dim();
-        let mut line = Line::styled(start, end, style).dim(dim);
+        let mut line = Line::styled(start, end, style).wh(dim);
         line.should_centre_points = true;
         line
     }
@@ -320,5 +320,3 @@ impl Colorable for Line {
         self
     }
 }
-
-

--- a/src/widget/primitive/point_path.rs
+++ b/src/widget/primitive/point_path.rs
@@ -95,7 +95,7 @@ impl<I> PointPath<I> {
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
-        PointPath::styled(points, style).dim(dim).xy(xy)
+        PointPath::styled(points, style).wh(dim).xy(xy)
     }
 
     /// Build a new **PointPath** and shift the location of the points so that the centre of their
@@ -119,7 +119,7 @@ impl<I> PointPath<I> {
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
-        let mut point_path = PointPath::styled(points, style).dim(dim);
+        let mut point_path = PointPath::styled(points, style).wh(dim);
         point_path.maybe_shift_to_centre_from = Some(xy);
         point_path
     }
@@ -224,4 +224,3 @@ impl<I> Colorable for PointPath<I> {
         self
     }
 }
-

--- a/src/widget/primitive/shape/framed_rectangle.rs
+++ b/src/widget/primitive/shape/framed_rectangle.rs
@@ -43,7 +43,7 @@ impl FramedRectangle {
         FramedRectangle {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
-        }.dim(dim)
+        }.wh(dim)
     }
 
     /// Build the **FramedRectangle** with the given styling.
@@ -136,4 +136,3 @@ impl Frameable for FramedRectangle {
         self
     }
 }
-

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -47,7 +47,7 @@ impl Oval {
         Oval {
             common: widget::CommonBuilder::new(),
             style: style,
-        }.dim(dim)
+        }.wh(dim)
     }
 
     /// Build a new **Fill**ed **Oval**.
@@ -122,4 +122,3 @@ impl Colorable for Oval {
         self
     }
 }
-

--- a/src/widget/primitive/shape/polygon.rs
+++ b/src/widget/primitive/shape/polygon.rs
@@ -100,7 +100,7 @@ impl<I> Polygon<I> {
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
-        Polygon::styled(points, style).dim(dim).xy(xy)
+        Polygon::styled(points, style).wh(dim).xy(xy)
     }
 
     /// The same as [**Polygon::abs_styled**](./struct.Polygon#method.abs_styled) but builds the
@@ -148,7 +148,7 @@ impl<I> Polygon<I> {
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
-        let mut polygon = Polygon::styled(points, style).dim(dim);
+        let mut polygon = Polygon::styled(points, style).wh(dim);
         polygon.maybe_shift_to_centre_from = Some(xy);
         polygon
     }
@@ -270,4 +270,3 @@ impl<I> Colorable for Polygon<I> {
         self
     }
 }
-

--- a/src/widget/primitive/shape/rectangle.rs
+++ b/src/widget/primitive/shape/rectangle.rs
@@ -46,7 +46,7 @@ impl Rectangle {
         Rectangle {
             common: widget::CommonBuilder::new(),
             style: style,
-        }.dim(dim)
+        }.wh(dim)
     }
 
     /// Build a new filled rectangle.
@@ -121,4 +121,3 @@ impl Colorable for Rectangle {
         self
     }
 }
-

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -16,7 +16,6 @@ use {
     Rect,
     Rectangle,
     Scalar,
-    Sizeable,
     Text,
     Theme,
     Ui,
@@ -448,4 +447,3 @@ impl<'a, T, F> Labelable<'a> for Slider<'a, T, F> {
         self
     }
 }
-

--- a/src/widget/split.rs
+++ b/src/widget/split.rs
@@ -200,7 +200,7 @@ impl<'a> Split<'a> {
                 Some(parent_id) => canvas.parent(parent_id),
                 None            => canvas.no_parent(),
             }.xy(xy)
-                .dim(dim)
+                .wh(dim)
                 .vertical_scrolling(is_v_scrollable)
                 .horizontal_scrolling(is_h_scrollable)
                 .set(id, ui);
@@ -310,5 +310,3 @@ impl<'a> ::frame::Frameable for Split<'a> {
         self
     }
 }
-
-

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -317,7 +317,7 @@ impl<'a> Widget for Tabs<'a> {
 
                 // We'll instantiate each selectable **Tab** as a **Button** widget.
                 Button::new()
-                    .dim(dim)
+                    .wh(dim)
                     .xy_relative_to(idx, xy)
                     .color(color)
                     .frame(frame)


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/conrod/issues/644

- Renamed `dim` to `xy`
- Renamed `dimensions` to `x_y`
- Bumped to 0.25.0