### PR TITLE
Scrolling refactoring and Bug fixes. Add `Axis` enum arg to `Edge::Position` in graph.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.28.0"
+version = "0.29.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -173,7 +173,7 @@ fn main() {
 fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
     // We can use this `Canvas` as a parent Widget upon which we can place other widgets.
-    Canvas::new().frame(app.frame_width).color(app.bg_color).scrolling(true).set(CANVAS, ui);
+    Canvas::new().frame(app.frame_width).color(app.bg_color).scroll_kids().set(CANVAS, ui);
 
     // Text example.
     Text::new("Widget Demonstration")

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -180,11 +180,16 @@ fn main() {
 fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
 
     // We can use this `Canvas` as a parent Widget upon which we can place other widgets.
-    Canvas::new().frame(app.frame_width).color(app.bg_color).scroll_kids().set(CANVAS, ui);
+    Canvas::new()
+        .frame(app.frame_width)
+        .pad(30.0)
+        .color(app.bg_color)
+        .scroll_kids()
+        .set(CANVAS, ui);
 
     // Text example.
     Text::new("Widget Demonstration")
-        .top_left_with_margins_on(CANVAS, 25.0, app.title_pad)
+        .top_left_with_margins_on(CANVAS, 0.0, app.title_pad)
         .font_size(32)
         .color(app.bg_color.plain_contrast())
         .set(TITLE, ui);
@@ -194,7 +199,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
         // Button widget example button.
         Button::new()
             .w_h(200.0, 50.0)
-            .mid_left_with_margin_on(CANVAS, 30.0)
+            .mid_left_of(CANVAS)
             .down_from(TITLE, 45.0)
             .rgb(0.4, 0.75, 0.6)
             .frame(app.frame_width)
@@ -219,7 +224,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
         // Slider widget example slider(value, min, max).
         Slider::new(pad as f32, 30.0, 700.0)
             .w_h(200.0, 50.0)
-            .mid_left_with_margin_on(CANVAS, 30.0)
+            .mid_left_of(CANVAS)
             .down_from(TITLE, 45.0)
             .rgb(0.5, 0.3, 0.6)
             .frame(app.frame_width)

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -52,7 +52,7 @@ fn set_widgets(ui: &mut Ui) {
             (MIDDLE_COLUMN, Canvas::new().color(color::ORANGE)),
             (RIGHT_COLUMN, Canvas::new().color(color::DARK_ORANGE).pad(20.0)),
         ])),
-        (FOOTER, Canvas::new().color(color::BLUE).vertical_scrolling(true)),
+        (FOOTER, Canvas::new().color(color::BLUE).scroll_kids_vertically()),
     ]).set(MASTER, ui);
 
     // Now we'll make a couple floating `Canvas`ses.

--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -368,7 +368,7 @@ pub fn draw_scrolling<G>(context: &Context,
               A: scroll::Axis,
     {
         use widget::scroll::Elem::{Handle, Track};
-        use widget::scroll::Interaction::{Normal, Highlighted, Clicked};
+        use widget::scroll::Interaction::{Highlighted, Clicked};
 
         let color = scroll_state.color;
         let track_color = match scroll_state.interaction {

--- a/src/graph/depth_order.rs
+++ b/src/graph/depth_order.rs
@@ -181,8 +181,11 @@ fn visit_by_depth(graph: &Graph,
     }
 
     // If the widget is scrollable, we should add its scrollbar to the visit order also.
-    if graph.widget_scroll_state(idx).is_some() {
-        depth_order.push(Visitable::Scrollbar(idx));
+    if let Some(widget) = graph.widget(idx) {
+        if widget.maybe_x_scroll_state.is_some()
+        || widget.maybe_y_scroll_state.is_some() {
+            depth_order.push(Visitable::Scrollbar(idx));
+        }
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -4,11 +4,13 @@
 //! The primary type of interest in this module is the [**Graph**](./struct.Graph) type.
 
 use daggy;
-use position::{Depth, Rect};
+use position::{Axis, Depth, Rect};
 use self::index_map::IndexMap;
 use std::any::Any;
 use std::fmt::Debug;
+use std::iter;
 use std::ops::{Index, IndexMut};
+use std::option;
 use widget::{self, Widget};
 
 pub use daggy::Walker;
@@ -34,13 +36,20 @@ pub type Parents = daggy::Parents<Node, Edge, u32>;
 /// A **Walker** over some node's child nodes.
 pub type Children = daggy::Children<Node, Edge, u32>;
 
+/// An alias for the iterator yielding both **X** and **Y** **Position** parents.
+pub type PositionParents<I> = iter::Chain<option::IntoIter<I>, option::IntoIter<I>>;
+
 /// An alias for some filtered children walker.
 pub type FilteredChildren =
     daggy::walker::Filter<Children, fn(&Graph, EdgeIndex, NodeIndex) -> bool>;
 /// An alias for a **Walker** over a node's **Depth** children.
 pub type DepthChildren = FilteredChildren;
-/// An alias for a **Walker** over a node's **Position** children.
-pub type PositionChildren = FilteredChildren;
+/// An alias for a **Walker** over a node's **X Position** children.
+pub type XPositionChildren = FilteredChildren;
+/// An alias for a **Walker** over a node's **Y Position** children.
+pub type YPositionChildren = FilteredChildren;
+/// An alias for a **Walker** over a node's **X** and **Y** **Position** children respectively.
+pub type PositionChildren = daggy::walker::Chain<Graph, u32, XPositionChildren, YPositionChildren>;
 /// An alias for a **Walker** over a node's **Graphic** children.
 pub type GraphicChildren = FilteredChildren;
 
@@ -81,8 +90,10 @@ pub struct Container {
     ///
     /// See the `Widget::float` docs for an explanation of what this means.
     pub maybe_floating: Option<widget::Floating>,
-    /// Scroll related state (is only `Some` if the widget is scrollable).
-    pub maybe_scrolling: Option<widget::scroll::State>,
+    /// Scroll related state (is only `Some` if this axis is scrollable).
+    pub maybe_x_scroll_state: Option<widget::scroll::State>,
+    /// Scroll related state (is only `Some` if this axis is scrollable).
+    pub maybe_y_scroll_state: Option<widget::scroll::State>,
     /// Represents the Widget's position within the overall instantiation ordering of the widgets.
     ///
     /// i.e. if foo's `instantiation_order_idx` is lower than bar's, it means that foo was
@@ -108,7 +119,7 @@ pub enum Edge {
     /// Describes the relative positioning of widgets.
     ///
     /// When adding an edge *a -> b*, *b* is positioned relatively to *a*.
-    Position,
+    Position(Axis),
     /// Describes the rendering order of the widgets.
     ///
     /// When adding an edge *a -> b*, *a* is the parent of (and will be rendered before) *b*.
@@ -198,7 +209,8 @@ impl Container {
                 drag_state: self.drag_state,
                 kid_area: self.kid_area,
                 maybe_floating: self.maybe_floating,
-                maybe_scrolling: self.maybe_scrolling,
+                maybe_x_scroll_state: self.maybe_x_scroll_state,
+                maybe_y_scroll_state: self.maybe_y_scroll_state,
             })
         } else {
             None
@@ -430,12 +442,6 @@ impl Graph {
         })
     }
 
-    /// If there is a scrollable widget at the given index, return a reference to the widget's
-    /// scroll state.
-    pub fn widget_scroll_state<I: GraphIndex>(&self, idx: I) -> Option<&widget::scroll::State> {
-        self.widget(idx).and_then(|widget| widget.maybe_scrolling.as_ref())
-    }
-
     /// A **Walker** type that may be used to step through the parents of the given child node.
     pub fn parents<I: GraphIndex>(&self, child: I) -> Parents {
         let idx = self.node_index(child).unwrap_or(NodeIndex::end());
@@ -471,11 +477,28 @@ impl Graph {
     }
 
     /// Return the index of the parent along the given widget's **Position** **Edge**.
-    pub fn position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn x_position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
               J: GraphIndex,
     {
-        self.edge_parent(idx, Edge::Position)
+        self.edge_parent(idx, Edge::Position(Axis::X))
+    }
+
+    /// Return the index of the parent along the given widget's **Position** **Edge**.
+    pub fn y_position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+        where I: GraphIndex,
+              J: GraphIndex,
+    {
+        self.edge_parent(idx, Edge::Position(Axis::Y))
+    }
+
+    /// Produces an iterator yielding the parents along both the **X** and **Y** **Position**
+    /// **Edge**s respectively.
+    pub fn position_parents<I, J=NodeIndex>(&self, idx: I) -> PositionParents<J>
+        where I: GraphIndex,
+              J: GraphIndex,
+    {
+        self.x_position_parent(idx).into_iter().chain(self.y_position_parent(idx))
     }
 
     /// Return the index of the parent along the given widget's **Graphic** **Edge**.
@@ -496,14 +519,26 @@ impl Graph {
         self.recursive_walk(idx, depth_edge_parent)
     }
 
-    /// A **Walker** type that recursively walks **Position** parents starting from the given node.
-    pub fn position_parent_recursion<I: GraphIndex>(&self, idx: I)
+    /// A **Walker** type that recursively walks **X** **Position** parents starting from the given
+    /// node.
+    pub fn x_position_parent_recursion<I: GraphIndex>(&self, idx: I)
         -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>>
     {
-        fn position_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
-            graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Position)
+        fn x_position_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
+            graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Position(Axis::X))
         }
-        self.recursive_walk(idx, position_edge_parent)
+        self.recursive_walk(idx, x_position_edge_parent)
+    }
+
+    /// A **Walker** type that recursively walks **Y** **Position** parents starting from the given
+    /// node.
+    pub fn y_position_parent_recursion<I: GraphIndex>(&self, idx: I)
+        -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>>
+    {
+        fn y_position_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
+            graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Position(Axis::Y))
+        }
+        self.recursive_walk(idx, y_position_edge_parent)
     }
 
     /// A **Walker** type that recursively walks **Graphic** parents starting from the given node.
@@ -527,9 +562,21 @@ impl Graph {
         self.children(idx).filter(is_depth_edge)
     }
 
+    /// For walking the **Position(X)** children of the given parent node.
+    pub fn x_position_children<I: GraphIndex>(&self, idx: I) -> XPositionChildren {
+        self.children(idx).filter(is_x_position_edge)
+    }
+
+    /// For walking the **Position(Y)** children of the given parent node.
+    pub fn y_position_children<I: GraphIndex>(&self, idx: I) -> YPositionChildren {
+        self.children(idx).filter(is_y_position_edge)
+    }
+
     /// For walking the **Position** children of the given parent node.
+    ///
+    /// This first walks the **Axis::X** children, before walking the **Axis::Y** children.
     pub fn position_children<I: GraphIndex>(&self, idx: I) -> PositionChildren {
-        self.children(idx).filter(is_position_edge)
+        self.x_position_children(idx).chain(self.y_position_children(idx))
     }
 
     /// For walking the **Graphic** children of the given parent node.
@@ -540,12 +587,13 @@ impl Graph {
     /// Does the given edge type exist between the nodes `parent` -> `child`.
     ///
     /// Returns `false` if either of the given node indices do not exist.
-    pub fn does_edge_exist<P, C>(&self, parent: P, child: C, edge: Edge) -> bool
+    pub fn does_edge_exist<P, C, F>(&self, parent: P, child: C, is_edge: F) -> bool
         where P: GraphIndex,
               C: GraphIndex,
+              F: Fn(Edge) -> bool,
     {
         self.node_index(parent).map(|parent| {
-            self.parents(child).any(self, |g, e, n| n == parent && g[e] == edge)
+            self.parents(child).any(self, |g, e, n| n == parent && is_edge(g[e]))
         }).unwrap_or(false)
     }
 
@@ -556,7 +604,7 @@ impl Graph {
         where P: GraphIndex,
               C: GraphIndex,
     {
-        self.does_edge_exist(parent, child, Edge::Depth)
+        self.does_edge_exist(parent, child, |e| e == Edge::Depth)
     }
 
     /// Does a **Edge::Position** exist between the nodes `parent` -> `child`.
@@ -566,7 +614,8 @@ impl Graph {
         where P: GraphIndex,
               C: GraphIndex,
     {
-        self.does_edge_exist(parent, child, Edge::Position)
+        let is_edge = |e| e == Edge::Position(Axis::X) || e == Edge::Position(Axis::Y);
+        self.does_edge_exist(parent, child, is_edge)
     }
 
     /// Does a **Edge::Graphic** exist between the nodes `parent` -> `child`.
@@ -576,7 +625,7 @@ impl Graph {
         where P: GraphIndex,
               C: GraphIndex,
     {
-        self.does_edge_exist(parent, child, Edge::Graphic)
+        self.does_edge_exist(parent, child, |e| e == Edge::Graphic)
     }
 
     /// Are the given `parent` and `child` nodes connected by a single chain of edges of the given
@@ -585,12 +634,13 @@ impl Graph {
     /// i.e. `parent` -> x -> y -> `child`.
     ///
     /// Returns `false` if either of the given node indices do not exist.
-    pub fn does_recursive_edge_exist<P, C>(&self, parent: P, child: C, edge: Edge) -> bool
+    pub fn does_recursive_edge_exist<P, C, F>(&self, parent: P, child: C, is_edge: F) -> bool
         where P: GraphIndex,
               C: GraphIndex,
+              F: Fn(Edge) -> bool,
     {
         self.node_index(parent).map(|parent| {
-            self.recursive_walk(child, |g, n| g.parents(n).find(g, |g, e, _| g[e] == edge))
+            self.recursive_walk(child, |g, n| g.parents(n).find(g, |g, e, _| is_edge(g[e])))
                 .any(self, |_, _, n| n == parent)
         }).unwrap_or(false)
     }
@@ -604,7 +654,7 @@ impl Graph {
         where P: GraphIndex,
               C: GraphIndex,
     {
-        self.does_recursive_edge_exist(parent, child, Edge::Depth)
+        self.does_recursive_edge_exist(parent, child, |e| e == Edge::Depth)
     }
 
     /// Are the given `parent` and `child` nodes connected by a single chain of **Position** edges?
@@ -616,7 +666,8 @@ impl Graph {
         where P: GraphIndex,
               C: GraphIndex,
     {
-        self.does_recursive_edge_exist(parent, child, Edge::Position)
+        let is_edge = |e| e == Edge::Position(Axis::X) || e == Edge::Position(Axis::Y);
+        self.does_recursive_edge_exist(parent, child, is_edge)
     }
 
     /// Are the given `parent` and `child` nodes connected by a single chain of **Graphic** edges?
@@ -628,7 +679,7 @@ impl Graph {
         where P: GraphIndex,
               C: GraphIndex,
     {
-        self.does_recursive_edge_exist(parent, child, Edge::Graphic)
+        self.does_recursive_edge_exist(parent, child, |e| e == Edge::Graphic)
     }
 
 
@@ -646,8 +697,9 @@ impl Graph {
                             instantiation_order_idx: usize)
     {
         let widget::PreUpdateCache {
-            kind, idx, maybe_parent_idx, maybe_positioned_relatively_idx, rect, depth, kid_area,
-            drag_state, maybe_floating, maybe_scrolling, maybe_graphics_for,
+            kind, idx, maybe_parent_idx, maybe_x_positioned_relatively_idx,
+            maybe_y_positioned_relatively_idx, rect, depth, kid_area, drag_state, maybe_floating,
+            maybe_x_scroll_state, maybe_y_scroll_state, maybe_graphics_for,
         } = widget;
 
         // Construct a new `Container` to place in the `Graph`.
@@ -659,7 +711,8 @@ impl Graph {
             drag_state: drag_state,
             kid_area: kid_area,
             maybe_floating: maybe_floating,
-            maybe_scrolling: maybe_scrolling,
+            maybe_x_scroll_state: maybe_x_scroll_state,
+            maybe_y_scroll_state: maybe_y_scroll_state,
             instantiation_order_idx: instantiation_order_idx,
         };
 
@@ -724,7 +777,8 @@ impl Graph {
                     container.drag_state = drag_state;
                     container.kid_area = kid_area;
                     container.maybe_floating = maybe_floating;
-                    container.maybe_scrolling = maybe_scrolling;
+                    container.maybe_x_scroll_state = maybe_x_scroll_state;
+                    container.maybe_y_scroll_state = maybe_y_scroll_state;
                     container.instantiation_order_idx = instantiation_order_idx;
                 },
 
@@ -743,14 +797,24 @@ impl Graph {
             }
         }
 
-        // Now that we've updated the widget's cached data, we need to check if we should add an
-        // `Edge::Position`.
-        if let Some(relative_idx) = maybe_positioned_relatively_idx {
-            self.set_edge(relative_idx, idx, Edge::Position).unwrap();
-        // Otherwise if the widget is not positioned relatively to any other widget, we should
-        // ensure that there are no incoming `Position` edges.
+        // Now that we've updated the widget's cached data, we need to check if we should add any
+        // `Edge::Position`s.
+        //
+        // If the widget is *not* positioned relatively to any other widget, we should ensure that
+        // there are no incoming `Position` edges.
+
+        // X
+        if let Some(relative_idx) = maybe_x_positioned_relatively_idx {
+            self.set_edge(relative_idx, idx, Edge::Position(Axis::X)).unwrap();
         } else {
-            self.remove_parent_edge(idx, Edge::Position);
+            self.remove_parent_edge(idx, Edge::Position(Axis::X));
+        }
+
+        // Y
+        if let Some(relative_idx) = maybe_y_positioned_relatively_idx {
+            self.set_edge(relative_idx, idx, Edge::Position(Axis::Y)).unwrap();
+        } else {
+            self.remove_parent_edge(idx, Edge::Position(Axis::Y));
         }
 
         // Check whether or not the widget is a graphics element for some other widget.
@@ -795,8 +859,12 @@ fn is_depth_edge(g: &Graph, e: EdgeIndex, _: NodeIndex) -> bool {
     g[e] == Edge::Depth
 }
 
-fn is_position_edge(g: &Graph, e: EdgeIndex, _: NodeIndex) -> bool {
-    g[e] == Edge::Position
+fn is_x_position_edge(g: &Graph, e: EdgeIndex, _: NodeIndex) -> bool {
+    g[e] == Edge::Position(Axis::X)
+}
+
+fn is_y_position_edge(g: &Graph, e: EdgeIndex, _: NodeIndex) -> bool {
+    g[e] == Edge::Position(Axis::Y)
 }
 
 fn is_graphic_edge(g: &Graph, e: EdgeIndex, _: NodeIndex) -> bool {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -91,9 +91,9 @@ pub struct Container {
     /// See the `Widget::float` docs for an explanation of what this means.
     pub maybe_floating: Option<widget::Floating>,
     /// Scroll related state (is only `Some` if this axis is scrollable).
-    pub maybe_x_scroll_state: Option<widget::scroll::State>,
+    pub maybe_x_scroll_state: Option<widget::scroll::StateX>,
     /// Scroll related state (is only `Some` if this axis is scrollable).
-    pub maybe_y_scroll_state: Option<widget::scroll::State>,
+    pub maybe_y_scroll_state: Option<widget::scroll::StateY>,
     /// Represents the Widget's position within the overall instantiation ordering of the widgets.
     ///
     /// i.e. if foo's `instantiation_order_idx` is lower than bar's, it means that foo was
@@ -657,18 +657,22 @@ impl Graph {
         self.does_recursive_edge_exist(parent, child, |e| e == Edge::Depth)
     }
 
-    /// Are the given `parent` and `child` nodes connected by a single chain of **Position** edges?
-    ///
-    /// i.e. `parent` -> x -> y -> `child`.
-    ///
-    /// Returns `false` if either of the given node indices do not exist.
-    pub fn does_recursive_position_edge_exist<P, C>(&self, parent: P, child: C) -> bool
-        where P: GraphIndex,
-              C: GraphIndex,
-    {
-        let is_edge = |e| e == Edge::Position(Axis::X) || e == Edge::Position(Axis::Y);
-        self.does_recursive_edge_exist(parent, child, is_edge)
-    }
+    // FIXME: This only recurses down the *first* edge that satisfies the predicate, whereas we
+    // want to check *every* position parent edge. This means we need to do a DFS or BFS over
+    // position edges from the parent node until we find the child node.
+    // ///
+    // /// Are the given `parent` and `child` nodes connected by a single chain of **Position** edges?
+    // ///
+    // /// i.e. `parent` -> x -> y -> `child`.
+    // ///
+    // /// Returns `false` if either of the given node indices do not exist.
+    // pub fn does_recursive_position_edge_exist<P, C>(&self, parent: P, child: C) -> bool
+    //     where P: GraphIndex,
+    //           C: GraphIndex,
+    // {
+    //     let is_edge = |e| e == Edge::Position(Axis::X) || e == Edge::Position(Axis::Y);
+    //     self.does_recursive_edge_exist(parent, child, is_edge)
+    // }
 
     /// Are the given `parent` and `child` nodes connected by a single chain of **Graphic** edges?
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,8 @@ pub use mouse::Mouse;
 pub use mouse::ButtonState as MouseButtonState;
 pub use mouse::ButtonPosition as MouseButtonPosition;
 pub use mouse::Scroll as MouseScroll;
-pub use position::{Align, Corner, Depth, Direction, Dimension, Dimensions, Edge, Margin, Padding,
-                   Place, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};
+pub use position::{Align, Axis, Corner, Depth, Direction, Dimension, Dimensions, Edge, Margin,
+                   Padding, Place, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};
 pub use position::Matrix as PositionMatrix;
 pub use theme::Theme;
 pub use ui::{Ui, UserInput};

--- a/src/position/mod.rs
+++ b/src/position/mod.rs
@@ -35,6 +35,15 @@ pub type Point = [Scalar; 2];
 /// The margin for some `Place`ment on either end of an axis.
 pub type Margin = Scalar;
 
+/// Represents either **Axis** in the 2-dimensional plane.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Axis {
+    /// The horizontal plane's Axis.
+    X,
+    /// The vertical plane's Axis.
+    Y,
+}
+
 /// Some **Position** of some **Widget** along a single axis.
 ///
 /// **Position**s for both the *x* and *y* axes are stored internally within the

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -596,15 +596,7 @@ impl<C> Ui<C> {
     /// The **Rect** that bounds the kids of the widget with the given index.
     pub fn kids_bounding_box<I: Into<widget::Index>>(&self, idx: I) -> Option<Rect> {
         let idx: widget::Index = idx.into();
-        const INCLUDE_SELF: bool = false;
-        const USE_KID_AREA: bool = true;
-        graph::algo::bounding_box(&self.widget_graph,
-                                  &self.prev_updated_widgets,
-                                  INCLUDE_SELF,
-                                  None,
-                                  USE_KID_AREA,
-                                  idx,
-                                  None)
+        graph::algo::kids_bounding_box(&self.widget_graph, &self.prev_updated_widgets, idx)
     }
 
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -224,6 +224,22 @@ impl<C> Ui<C> {
         &self.widget_graph
     }
 
+    /// Borrow the **Ui**'s set of updated widgets.
+    ///
+    /// This set indicates which widgets have been instantiated since the beginning of the most
+    /// recent `Ui::set_widgets` call.
+    pub fn updated_widgets(&self) -> &HashSet<NodeIndex> {
+        &self.updated_widgets
+    }
+
+    /// Borrow the **Ui**'s set of updated widgets.
+    ///
+    /// This set indicates which widgets have were instantiated during the previous call to
+    /// `Ui::set_widgets`.
+    pub fn prev_updated_widgets(&self) -> &HashSet<NodeIndex> {
+        &self.prev_updated_widgets
+    }
+
     /// Handle game events and update the state.
     pub fn handle_event<E: GenericEvent>(&mut self, event: &E) {
 
@@ -580,7 +596,15 @@ impl<C> Ui<C> {
     /// The **Rect** that bounds the kids of the widget with the given index.
     pub fn kids_bounding_box<I: Into<widget::Index>>(&self, idx: I) -> Option<Rect> {
         let idx: widget::Index = idx.into();
-        graph::algo::bounding_box(&self.widget_graph, false, None, true, idx, None)
+        const INCLUDE_SELF: bool = false;
+        const USE_KID_AREA: bool = true;
+        graph::algo::bounding_box(&self.widget_graph,
+                                  &self.prev_updated_widgets,
+                                  INCLUDE_SELF,
+                                  None,
+                                  USE_KID_AREA,
+                                  idx,
+                                  None)
     }
 
 

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -250,7 +250,7 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                     .xy(canvas_xy)
                     .parent(idx)
                     .floating(true)
-                    .vertical_scrolling(true)
+                    .scroll_kids_vertically()
                     .set(canvas_idx, &mut ui);
 
                 let labels = self.strings.iter();

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -272,9 +272,9 @@ pub struct Cached<W> where W: Widget {
     /// Whether or not the Widget is a "floating" Widget.
     pub maybe_floating: Option<Floating>,
     /// The state for a widget's scrollable *x* axis.
-    pub maybe_x_scroll_state: Option<scroll::State>,
+    pub maybe_x_scroll_state: Option<scroll::StateX>,
     /// The state for a widget's scrollable *y* axis.
-    pub maybe_y_scroll_state: Option<scroll::State>,
+    pub maybe_y_scroll_state: Option<scroll::StateY>,
 }
 
 /// A unique identifier for a **Widget** type.
@@ -312,9 +312,9 @@ pub struct PreUpdateCache {
     /// Floating data for the **Widget** if there is some.
     pub maybe_floating: Option<Floating>,
     /// Scrolling data for the **Widget**'s *x* axis if there is some.
-    pub maybe_x_scroll_state: Option<scroll::State>,
+    pub maybe_x_scroll_state: Option<scroll::StateX>,
     /// Scrolling data for the **Widget**'s *y* axis if there is some.
-    pub maybe_y_scroll_state: Option<scroll::State>,
+    pub maybe_y_scroll_state: Option<scroll::StateY>,
     /// Whether or not the **Widget** has been instantiated as a graphical element for some other
     /// widget.
     pub maybe_graphics_for: Option<Index>,
@@ -880,24 +880,13 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
         widget.kid_area(args)
     };
 
-    // If the `y` range is scrollable, retrieve the up-to-date scroll_offset.
-    let maybe_y_scroll_state = widget.common().maybe_y_scroll.map(|scroll_args| {
-        let kid_area_range = kid_area.rect.y;
-        scroll::State::update(ui, idx, scroll_args, kid_area_range, maybe_prev_y_scroll_state)
+    // If either axis is scrollable, retrieve the up-to-date scroll_offset for that axis.
+    let maybe_x_scroll_state = widget.common().maybe_x_scroll.map(|scroll_args| {
+        scroll::State::update(ui, idx, scroll_args, kid_area.rect, maybe_prev_x_scroll_state)
     });
-
-    let maybe_x_scroll_state = None;
-
-    // TODO
-    // // Check whether or not our new scrolling state should capture or uncapture the mouse.
-    // if let (Some(ref prev), Some(ref new)) = (maybe_prev_scrolling, maybe_new_scrolling) {
-    //     if scroll::capture_mouse(prev, new) {
-    //         ui::mouse_captured_by(ui, idx);
-    //     }
-    //     if scroll::uncapture_mouse(prev, new) {
-    //         ui::mouse_uncaptured_by(ui, idx);
-    //     }
-    // }
+    let maybe_y_scroll_state = widget.common().maybe_y_scroll.map(|scroll_args| {
+        scroll::State::update(ui, idx, scroll_args, kid_area.rect, maybe_prev_y_scroll_state)
+    });
 
     // Determine whether or not this is the first time set has been called.
     // We'll use this to determine whether or not we need to draw for the first time.

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -888,13 +888,13 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
     //
     // We must step the scrolling using the previous `kid_area` state so that the bounding box
     // around our kid widgets is in sync with the position of the `kid_area`.
-    let kid_area_rect = maybe_prev_common.map(|common| common.kid_area.rect)
-        .unwrap_or_else(|| kid_area.rect);
+    let prev_kid_area = maybe_prev_common.map(|common| common.kid_area)
+        .unwrap_or_else(|| kid_area);
     let maybe_x_scroll_state = widget.common().maybe_x_scroll.map(|scroll_args| {
-        scroll::State::update(ui, idx, scroll_args, kid_area_rect, maybe_prev_x_scroll_state)
+        scroll::State::update(ui, idx, scroll_args, &prev_kid_area, maybe_prev_x_scroll_state)
     });
     let maybe_y_scroll_state = widget.common().maybe_y_scroll.map(|scroll_args| {
-        scroll::State::update(ui, idx, scroll_args, kid_area_rect, maybe_prev_y_scroll_state)
+        scroll::State::update(ui, idx, scroll_args, &prev_kid_area, maybe_prev_y_scroll_state)
     });
 
     // Determine whether or not this is the first time set has been called.

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -4,6 +4,7 @@ use {
     Align,
     Color,
     Mouse,
+    MouseScroll,
     Point,
     Range,
     Rect,
@@ -11,6 +12,7 @@ use {
     Theme,
     Ui,
 };
+use std::marker::PhantomData;
 use ui;
 
 
@@ -24,7 +26,7 @@ pub struct Scroll {
 
 /// Scroll state calculated for a single axis.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct State {
+pub struct State<A> {
     /// The distance that has been scrolled from the origin.
     ///
     /// A positive offset pushes the scrollable range that is under the kid_area upwards.
@@ -42,6 +44,12 @@ pub struct State {
     pub thickness: Scalar,
     /// The color of the scrollbar.
     pub color: Color,
+    /// The current state of interaction between the mouse and the scrollbar.
+    pub interaction: Interaction,
+    /// The axis type used to instantiate this state.
+    axis: PhantomData<A>,
+    /// Whether or not the this axis is currently scrolling.
+    pub is_scrolling: bool,
 }
 
 /// Style for the Scrolling.
@@ -52,6 +60,51 @@ pub struct Style {
     /// The color of the scrollbar.
     pub maybe_color: Option<Color>,
 }
+
+/// Represents an interaction between the mouse cursor and the scroll bar.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Interaction {
+    /// There are currently no interactions.
+    Normal,
+    /// The mouse is over either the track or the handle of the scroll bar.
+    Highlighted(Elem),
+    /// The scrollbar handle is currently clicked by the mouse.
+    Clicked(Elem),
+}
+
+/// The elements that make up the scrollbar.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Elem {
+    /// The draggable part of the scrollbar and the mouse's position.
+    Handle(Scalar),
+    /// The track along which the `Handle` can be dragged.
+    Track,
+}
+
+/// Methods for distinguishing behaviour between both scroll axes at compile-time.
+pub trait Axis {
+    fn parallel_range(Rect) -> Range;
+    fn perpendicular_range(Rect) -> Range;
+    fn track(container: Rect, thickness: Scalar) -> Rect;
+    fn mouse_scalar(mouse_xy: Point) -> Scalar;
+    fn mouse_scroll_axis(MouseScroll) -> Scalar;
+    fn handle_rect(perpendicular_track_range: Range, handle_range: Range) -> Rect;
+    fn offset_direction() -> Scalar;
+}
+
+/// Behaviour for scrolling across the `X` axis.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum X {}
+
+/// Behaviour for scrolling across the `Y` axis.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Y {}
+
+/// State for scrolling along the **X** axis.
+pub type StateX = State<X>;
+
+/// State for scrolling along the **Y** axis.
+pub type StateY = State<Y>;
 
 
 impl Scroll {
@@ -65,20 +118,74 @@ impl Scroll {
 }
 
 
-impl State {
+impl<A> State<A>
+    where A: Axis
+{
 
     /// Calculate the new scroll state for the single axis of a `Widget`.
-    pub fn update<C>(ui: &Ui<C>,
+    ///
+    /// ```
+    ///           >     +---+
+    ///           |     |   |
+    ///           |   =========================
+    ///           |   | | a | scroll root     |
+    ///           |   | +---+ aka `kid_area`  |
+    ///           |   |            +--------+ |
+    ///           |   |            |        | |
+    ///           |   =========================
+    ///           |                |   b    |
+    ///           |                +--------+
+    /// scrollable|    +--------+
+    ///    range y|    |        |
+    ///           |    |        | +------+
+    ///           |    |    c   | |      |
+    ///           |    +--------+ |  d   |
+    ///           |               |      |
+    ///           >               +------+
+    ///
+    ///                ^--------------------^
+    ///                     scrollable
+    ///                      range x
+    /// ```
+    ///
+    /// - `kid_area` is the cropped area of the container widget in which kid widgets may be
+    /// viewed.
+    /// - `a`, `b`, `c` and `d` are widgets that are kids of the "scroll root" widget in their
+    /// original, un-scrolled positions.
+    /// - `scrollable_range` is the total range occuppied by all children widgets in their
+    /// original, un-scrolled positions.
+    ///
+    /// Everything above and below the set of ==== bars of the parent widget is hidden, i.e:
+    ///
+    /// ```
+    /// =========================
+    /// | | a | scroll root     |
+    /// | +---+ aka `kid_area`  |
+    /// |            +--------+ |
+    /// |            |   b    | |
+    /// =========================
+    /// ```
+    ///
+    /// The `scrollable_range` on each axis only becomes scrollable if its length exceeds the
+    /// length of the `kid_area` on the same axis. Thus, in the above example, only the *y*
+    /// scrollable_range is scrollable.
+    pub fn update<C>(ui: &mut Ui<C>,
                      idx: super::Index,
                      scroll_args: Scroll,
-                     kid_area_range: Range,
-                     maybe_prev_scroll_state: Option<State>) -> Self
+                     kid_area_rect: Rect,
+                     maybe_prev_scroll_state: Option<Self>) -> Self
     {
 
         // Retrieve the *current* scroll offset.
-        let current_offset = maybe_prev_scroll_state
+        let current_offset = maybe_prev_scroll_state.as_ref()
             .map(|state| state.offset)
             .unwrap_or(0.0);
+
+        // Get the range for the Axis that concerns this particular scroll `State`.
+        let kid_area_range = A::parallel_range(kid_area_rect);
+
+        // The mouse state for the widget whose scroll state we're calculating.
+        let maybe_mouse = ui::get_mouse_state(ui, idx);
 
         // Retrieve the entire scrollable_range. This is the total range which may be "offset" from
         // the "root" range (aka the `kid_area`). The scrollable_range is determined as the
@@ -91,33 +198,122 @@ impl State {
         // `scrollable_range` relative to the `kid_area_range`.
         let scrollable_range = {
             let kids_bounding_range = ui.kids_bounding_box(idx)
-                .map(|kids| kids.y.shift(-current_offset).shift(kid_area_range.middle()))
+                .map(|kids| {
+                    A::parallel_range(kids)
+                        .shift(-current_offset)
+                        .shift(kid_area_range.middle())
+                })
                 .unwrap_or_else(|| kid_area_range);
             kid_area_range.max(kids_bounding_range)
         };
 
-        // Determine the min and max scroll bounds.
+        // Determine the min and max offst bounds. These bounds are the limits to which the
+        // scrollable_range may be shifted in either direction across the range.
         let offset_bounds = {
-            let max_offset = scrollable_range.end - kid_area_range.end;
             let min_offset = kid_area_range.start - scrollable_range.start;
+            let max_offset = scrollable_range.end - kid_area_range.end;
+            let max_offset = min_offset - (max_offset - min_offset) * A::offset_direction();
             Range { start: min_offset, end: max_offset }
         };
 
         // Determine the total `additional_scroll_offset` that we want to add to the
         // `current_offset`.
-        let additional_offset = {
+        let (additional_offset, new_interaction) = {
 
-            let scroll_bar_offset = {
-                0.0
+            let (scroll_bar_drag_offset, new_interaction) = match maybe_prev_scroll_state {
+                Some(prev_scroll_state) => {
+                    use self::Elem::{Track, Handle};
+                    use self::Interaction::{Normal, Highlighted, Clicked};
+                    use utils::map_range;
+
+                    let track = track::<A>(kid_area_rect, prev_scroll_state.thickness);
+                    let handle = handle::<A>(track, &prev_scroll_state);
+                    let handle_range = A::parallel_range(handle);
+                    let handle_pos_range_len = || {
+                        let track_range = A::parallel_range(track);
+                        let handle_pos_at_start = handle_range.align_start_of(track_range).middle();
+                        let handle_pos_at_end = handle_range.align_end_of(track_range).middle();
+                        let handle_pos_range = Range::new(handle_pos_at_start, handle_pos_at_end);
+                        handle_pos_range.len()
+                    };
+                    let prev_interaction = prev_scroll_state.interaction;
+                    let is_scrollable = offset_bounds.len() > 0.0;
+                    let new_interaction = match (maybe_mouse, is_scrollable) {
+                        (Some(mouse), true) => {
+                            use mouse::ButtonPosition::{Down, Up};
+                            let mouse_scalar = A::mouse_scalar(mouse.xy);
+
+                            // Check if the mouse is currently over part of the scroll bar.
+                            let is_over_elem = if handle.is_over(mouse.xy) {
+                                Some(Handle(mouse_scalar))
+                            } else if track.is_over(mouse.xy) {
+                                Some(Track)
+                            } else {
+                                None
+                            };
+
+                            // Determine the new `Interaction` between the mouse and scrollbar.
+                            match (is_over_elem, prev_interaction, mouse.left.position) {
+                                (Some(_),    Normal,             Down) => Normal,
+                                (Some(elem), _,                  Up)   => Highlighted(elem),
+                                (Some(_),    Highlighted(_),     Down) |
+                                (_,          Clicked(Handle(_)), Down) => Clicked(Handle(mouse_scalar)),
+                                (_,          Clicked(elem),      Down) => Clicked(elem),
+                                _                                      => Normal,
+                            }
+                        },
+                        _ => Normal,
+                    };
+
+                    // Check whether or not the mouse interactions require (un)capturing of mouse.
+                    match (prev_interaction, new_interaction) {
+                        (Highlighted(_), Clicked(_)) => { ui::mouse_captured_by(ui, idx); }
+                        (Clicked(_), Highlighted(_)) |
+                        (Clicked(_), Normal) => { ui::mouse_uncaptured_by(ui, idx); }
+                        _ => (),
+                    }
+
+                    let scroll_bar_drag_offset = match (prev_interaction, new_interaction) {
+
+                        // When the track is clicked and the handle snaps to the cursor.
+                        (Highlighted(Track), Clicked(Handle(mouse_scalar))) => {
+                            let handle_pos_range_len = handle_pos_range_len();
+                            let offset_range_len = offset_bounds.len();
+                            let pos_offset = mouse_scalar - handle_range.middle();
+                            let offset = map_range(pos_offset,
+                                                   0.0, handle_pos_range_len,
+                                                   0.0, offset_range_len);
+                            -offset
+                        },
+
+                        // When the handle is dragged.
+                        (Clicked(Handle(prev_mouse_scalar)), Clicked(Handle(new_mouse_scalar))) => {
+                            let handle_pos_range_len = handle_pos_range_len();
+                            let offset_range_len = offset_bounds.len();
+                            let pos_offset = new_mouse_scalar - prev_mouse_scalar;
+                            let offset = map_range(pos_offset,
+                                                   0.0, handle_pos_range_len,
+                                                   0.0, offset_range_len);
+                            -offset
+                        },
+
+                        _ => 0.0,
+                    };
+
+                    (scroll_bar_drag_offset, new_interaction)
+                },
+                None => (0.0, Interaction::Normal),
             };
 
             let scroll_wheel_offset = {
-                ui::get_mouse_state(ui, idx)
-                    .map(|mouse| -mouse.scroll.y)
+                maybe_mouse
+                    .map(|mouse| A::mouse_scroll_axis(mouse.scroll) * A::offset_direction())
                     .unwrap_or(0.0)
             };
 
-            scroll_bar_offset + scroll_wheel_offset
+            let additional_offset = scroll_bar_drag_offset + scroll_wheel_offset;
+
+            (additional_offset, new_interaction)
         };
 
         let new_offset = offset_bounds.clamp_value(current_offset + additional_offset);
@@ -128,12 +324,15 @@ impl State {
             scrollable_range_len: scrollable_range.len(),
             thickness: scroll_args.style.thickness(&ui.theme),
             color: scroll_args.style.color(&ui.theme),
+            interaction: new_interaction,
+            axis: PhantomData,
+            is_scrolling: additional_offset != 0.0,
         }
     }
 
     /// Whether or not the given `xy` point is over the scroll track.
     pub fn is_over(&self, xy: Point, kid_area_rect: Rect) -> bool {
-        track(kid_area_rect, self.thickness).is_over(xy)
+        A::track(kid_area_rect, self.thickness).is_over(xy)
     }
 
 }
@@ -167,25 +366,100 @@ impl Style {
 }
 
 
-pub fn track(container: Rect, thickness: Scalar) -> Rect {
-    let w = thickness;
-    let h = container.h();
-    let y = container.y();
-    Rect::from_xy_dim([0.0, y], [w, h]).align_right_of(container)
-}
-
-pub fn handle(track: Rect, state: &State) -> Rect {
-    let track_len = track.h();
+pub fn handle<A: Axis>(track: Rect, state: &State<A>) -> Rect {
+    let track_range = A::parallel_range(track);
+    let track_len = track_range.len();
     let len = track_len * (track_len / state.scrollable_range_len);
     let handle_range = Range::from_pos_and_len(0.0, len);
     let pos = {
-        let pos_min = handle_range.align_start_of(track.y).middle();
-        let pos_max = handle_range.align_end_of(track.y).middle();
+        let pos_min = handle_range.align_start_of(track_range).middle();
+        let pos_max = handle_range.align_end_of(track_range).middle();
         let pos_bounds = Range::new(pos_min, pos_max);
         state.offset_bounds.map_value_to(state.offset, &pos_bounds)
     };
-    Rect {
-        x: track.x,
-        y: Range::from_pos_and_len(pos, len),
+    let perpendicular_track_range = A::perpendicular_range(track);
+    let range = Range::from_pos_and_len(pos, len);
+    A::handle_rect(perpendicular_track_range, range)
+}
+
+pub fn track<A: Axis>(container: Rect, thickness: Scalar) -> Rect {
+    A::track(container, thickness)
+}
+
+
+impl Axis for X {
+
+    fn parallel_range(rect: Rect) -> Range {
+        rect.x
     }
+
+    fn perpendicular_range(rect: Rect) -> Range {
+        rect.y
+    }
+
+    fn track(container: Rect, thickness: Scalar) -> Rect {
+        let h = thickness;
+        let w = container.w();
+        let x = container.x();
+        Rect::from_xy_dim([x, 0.0], [w, h]).align_bottom_of(container)
+    }
+
+    fn mouse_scalar(mouse_xy: Point) -> Scalar {
+        mouse_xy[0]
+    }
+
+    fn mouse_scroll_axis(scroll: MouseScroll) -> Scalar {
+        scroll.x
+    }
+
+    fn handle_rect(perpendicular_track_range: Range, handle_range: Range) -> Rect {
+        Rect {
+            x: handle_range,
+            y: perpendicular_track_range,
+        }
+    }
+
+    fn offset_direction() -> Scalar {
+        1.0
+    }
+
+}
+
+
+impl Axis for Y {
+
+    fn parallel_range(rect: Rect) -> Range {
+        rect.y
+    }
+
+    fn perpendicular_range(rect: Rect) -> Range {
+        rect.x
+    }
+
+    fn track(container: Rect, thickness: Scalar) -> Rect {
+        let w = thickness;
+        let h = container.h();
+        let y = container.y();
+        Rect::from_xy_dim([0.0, y], [w, h]).align_right_of(container)
+    }
+
+    fn mouse_scalar(mouse_xy: Point) -> Scalar {
+        mouse_xy[1]
+    }
+
+    fn mouse_scroll_axis(scroll: MouseScroll) -> Scalar {
+        scroll.y
+    }
+
+    fn handle_rect(perpendicular_track_range: Range, handle_range: Range) -> Rect {
+        Rect {
+            x: perpendicular_track_range,
+            y: handle_range,
+        }
+    }
+
+    fn offset_direction() -> Scalar {
+        -1.0
+    }
+
 }

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -124,7 +124,8 @@ impl<A> State<A>
 
     /// Calculate the new scroll state for the single axis of a `Widget`.
     ///
-    /// ```
+    /// ```txt
+    ///
     ///           >     +---+
     ///           |     |   |
     ///           |   =========================
@@ -146,6 +147,7 @@ impl<A> State<A>
     ///                ^--------------------^
     ///                     scrollable
     ///                      range x
+    ///
     /// ```
     ///
     /// - `kid_area` is the cropped area of the container widget in which kid widgets may be
@@ -157,13 +159,15 @@ impl<A> State<A>
     ///
     /// Everything above and below the set of ==== bars of the parent widget is hidden, i.e:
     ///
-    /// ```
+    /// ```txt
+    ///
     /// =========================
     /// | | a | scroll root     |
     /// | +---+ aka `kid_area`  |
     /// |            +--------+ |
     /// |            |   b    | |
     /// =========================
+    ///
     /// ```
     ///
     /// The `scrollable_range` on each axis only becomes scrollable if its length exceeds the

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -1,49 +1,48 @@
-//! 
-//! Types and functionality related to the scrolling behaviour of widgets.
-//!
+//! Scroll related types and logic.
 
 use {
+    Align,
     Color,
-    Dimensions,
     Mouse,
     Point,
     Range,
     Rect,
     Scalar,
     Theme,
+    Ui,
 };
-use utils::{map_range, partial_max};
+use ui;
 
 
-/// A type for building a scrollbar widget.
+/// Arguments given via a scrollable `Widget`'s builder methods for the scrolling along a single
+/// axis.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Scrolling {
-    /// Is there horizontal scrolling.
-    pub horizontal: bool,
-    /// Is there vertical scrolling.
-    pub vertical: bool,
-    /// Styling for the Scrolling.
-    pub style: Style,
+pub struct Scroll {
+    maybe_initial_alignment: Option<Align>,
+    style: Style,
 }
 
-
-/// State related to scrolling.
+/// Scroll state calculated for a single axis.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct State {
-    /// vertical scrollbar.
-    pub maybe_vertical: Option<Bar>,
-    /// Horizontal scrollbar.
-    pub maybe_horizontal: Option<Bar>,
-    /// The rectangle representing the Visible area used tot calculate the Bar offsets.
-    pub visible: Rect,
-    /// The dimensions of the maximum bounding box around both the visible and kids Rects.
-    pub total_dim: Dimensions,
+    /// The distance that has been scrolled from the origin.
+    ///
+    /// A positive offset pushes the scrollable range that is under the kid_area upwards.
+    ///
+    /// A negative offset pushes the scrollable range that is under the kid_area downwards.
+    pub offset: Scalar,
+    /// The start and end bounds for the offset along the axis.
+    offset_bounds: Range,
+    /// The total range which may be "offset" from the "root" range (aka the `kid_area`).
+    ///
+    /// The `scrollable_range` is determined as the bounding range around both the `kid_area` and
+    /// all **un-scrolled** **visible** children widgets.
+    scrollable_range_len: Scalar,
     /// The width for vertical scrollbars, the height for horizontal scrollbars.
     pub thickness: Scalar,
     /// The color of the scrollbar.
     pub color: Color,
 }
-
 
 /// Style for the Scrolling.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -55,58 +54,88 @@ pub struct Style {
 }
 
 
-/// The state of a single scrollbar.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Bar {
-    /// The current interaction with the Scrollbar.
-    pub interaction: Interaction,
-    /// The range to which the start of the visible range is bounded.
-    pub scrollable: Range,
-    /// The distance from the start of the scrollable range and the start of the visible range.
-    /// i.e. visible.start - scrollable.start
-    pub offset: Scalar,
-    /// If the start of the visible range would start before the range of the widget's kids'
-    /// bounding box, this amount will represent the difference as a positive scalar value.
-    ///
-    /// Otherwise, it will remain 0.0.
-    ///
-    /// We need to keep track of this as we should never let the offset become before the start
-    /// overlap when being scrolled.
-    pub start_overlap: Scalar,
-}
-
-
-/// The current interaction with the 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum Interaction {
-    /// No interaction with the Scrollbar.
-    Normal,
-    /// Part of the scrollbar is highlighted.
-    Highlighted(Elem),
-    /// Part of the scrollbar is clicked.
-    Clicked(Elem),
-}
-
-
-/// The elements that make up a ScrollBar.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum Elem {
-    /// The draggable part of the bar and the mouse's position.
-    Handle(Scalar),
-    /// The track along which the bar can be dragged.
-    Track,
-}
-
-
-impl Scrolling {
-    /// Constructs the default Scrolling.
-    pub fn new() -> Scrolling {
-        Scrolling {
-            vertical: false,
-            horizontal: false,
+impl Scroll {
+    /// The default `Scroll` args.
+    pub fn new() -> Self {
+        Scroll {
+            maybe_initial_alignment: None,
             style: Style::new(),
         }
     }
+}
+
+
+impl State {
+
+    /// Calculate the new scroll state for the single axis of a `Widget`.
+    pub fn update<C>(ui: &Ui<C>,
+                     idx: super::Index,
+                     scroll_args: Scroll,
+                     kid_area_range: Range,
+                     maybe_prev_scroll_state: Option<State>) -> Self
+    {
+
+        // Retrieve the *current* scroll offset.
+        let current_offset = maybe_prev_scroll_state
+            .map(|state| state.offset)
+            .unwrap_or(0.0);
+
+        // Retrieve the entire scrollable_range. This is the total range which may be "offset" from
+        // the "root" range (aka the `kid_area`). The scrollable_range is determined as the
+        // bounding range around both the kid_area and all **un-scrolled** **visible** children
+        // widgets. Note that this means when reading all children widget's `Range`s to construct
+        // the bounding `Range`, we must first subtract the `current_scroll_offset` in order to get
+        // the *original* aka *un-scrolled* position. Thus, the calculated `scrollable_range`
+        // should be entirely unaffected by the `scroll_offset`. Notice also that we add the
+        // position of the `kid_area` to the `kids_bounding_range`. This allows us to create the
+        // `scrollable_range` relative to the `kid_area_range`.
+        let scrollable_range = {
+            let kids_bounding_range = ui.kids_bounding_box(idx)
+                .map(|kids| kids.y.shift(-current_offset).shift(kid_area_range.middle()))
+                .unwrap_or_else(|| kid_area_range);
+            kid_area_range.max(kids_bounding_range)
+        };
+
+        // Determine the min and max scroll bounds.
+        let offset_bounds = {
+            let max_offset = scrollable_range.end - kid_area_range.end;
+            let min_offset = kid_area_range.start - scrollable_range.start;
+            Range { start: min_offset, end: max_offset }
+        };
+
+        // Determine the total `additional_scroll_offset` that we want to add to the
+        // `current_offset`.
+        let additional_offset = {
+
+            let scroll_bar_offset = {
+                0.0
+            };
+
+            let scroll_wheel_offset = {
+                ui::get_mouse_state(ui, idx)
+                    .map(|mouse| -mouse.scroll.y)
+                    .unwrap_or(0.0)
+            };
+
+            scroll_bar_offset + scroll_wheel_offset
+        };
+
+        let new_offset = offset_bounds.clamp_value(current_offset + additional_offset);
+
+        State {
+            offset: new_offset,
+            offset_bounds: offset_bounds,
+            scrollable_range_len: scrollable_range.len(),
+            thickness: scroll_args.style.thickness(&ui.theme),
+            color: scroll_args.style.color(&ui.theme),
+        }
+    }
+
+    /// Whether or not the given `xy` point is over the scroll track.
+    pub fn is_over(&self, xy: Point, kid_area_rect: Rect) -> bool {
+        track(kid_area_rect, self.thickness).is_over(xy)
+    }
+
 }
 
 
@@ -138,417 +167,25 @@ impl Style {
 }
 
 
-impl Interaction {
-    /// The stateful version of the given color.
-    pub fn color(&self, color: Color) -> Color {
-        match *self {
-            Interaction::Normal => color,
-            Interaction::Highlighted(_) => color.highlighted(),
-            Interaction::Clicked(_) => color.clicked(),
-        }
-    }
-}
-
-
-impl State {
-
-    /// Construct a new State.
-    /// The `visible` rect corresponds to a Widget's `kid_area` aka the viewable container.
-    /// The `kids` rect is the area *actually occupied* by the children widgets.
-    pub fn new(scrolling: Scrolling, 
-               visible: Rect,
-               kids: Rect,
-               theme: &Theme,
-               maybe_prev: Option<&State>) -> State
-    {
-        State {
-
-            maybe_vertical: if scrolling.vertical {
-                let maybe_prev = maybe_prev.as_ref()
-                    .and_then(|prev| prev.maybe_vertical.as_ref());
-                // For a vertical scrollbar, we want the range to start at the top and end at
-                // the bottom. To do this, we will use the invert of our visible and kids y ranges.
-                Bar::new_if_scrollable(visible.y.invert(), kids.y.invert(), maybe_prev)
-            } else {
-                None
-            },
-
-            maybe_horizontal: if scrolling.horizontal {
-                let maybe_prev = maybe_prev.as_ref()
-                    .and_then(|prev| prev.maybe_horizontal.as_ref());
-                Bar::new_if_scrollable(visible.x, kids.x, maybe_prev)
-            } else {
-                None
-            },
-
-            total_dim: visible.max(kids).dim(),
-            visible: visible,
-            thickness: scrolling.style.thickness(theme),
-            color: scrolling.style.color(theme),
-        }
-    }
-
-    /// Given some mouse input, update the State and return the resulting State.
-    pub fn handle_input(self, mouse: Mouse) -> State {
-        State {
-
-            maybe_vertical: self.maybe_vertical.map(|bar| {
-                let track = vertical_track(self.visible, self.thickness);
-                let handle = vertical_handle(&bar, track, self.total_dim[1]);
-                // Invert the visible y axis so that it points downward for vertical scrolling.
-                let visible = self.visible.y.invert();
-                let mouse_pos_scalar = mouse.xy[1] - track.top();
-                bar.handle_input(visible, track, handle, &mouse, mouse_pos_scalar, mouse.scroll.y)
-            }),
-
-            maybe_horizontal: self.maybe_horizontal.map(|bar| {
-                let track = horizontal_track(self.visible, self.thickness);
-                let handle = horizontal_handle(&bar, track, self.total_dim[0]);
-                let visible = self.visible.x;
-                let mouse_pos_scalar = mouse.xy[0] - track.left();
-                bar.handle_input(visible, track, handle, &mouse, mouse_pos_scalar, -mouse.scroll.x)
-            }),
-
-            .. self
-        }
-    }
-
-    /// Is the given xy over either scroll Bars.
-    pub fn is_over(&self, target_xy: Point) -> bool {
-        if self.maybe_vertical.is_some() {
-            if vertical_track(self.visible, self.thickness).is_over(target_xy) {
-                return true;
-            }
-        }
-        if self.maybe_horizontal.is_some() {
-            if horizontal_track(self.visible, self.thickness).is_over(target_xy) {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Converts the Bars' current offset to a positional offset along its visible area.
-    pub fn kids_pos_offset(&self) -> Dimensions {
-        let maybe_x_offset = self.maybe_horizontal.map(|bar| bar.kids_pos_offset());
-        let maybe_y_offset = self.maybe_vertical.map(|bar| bar.kids_pos_offset());
-        [maybe_x_offset.unwrap_or(0.0), maybe_y_offset.unwrap_or(0.0)]
-    }
-
-}
-
-
-impl Bar {
-
-    /// Construct a new Bar for a widget from a given visible range as well as the range occuppied
-    /// by the widget's child widgets.
-    ///
-    /// The given `kids` Range should be relative to the visible range.
-    ///
-    /// If there is some previous Bar its interaction will be carried through to the Bar.
-    pub fn new_if_scrollable(visible: Range, kids: Range, maybe_prev: Option<&Bar>) -> Option<Bar> {
-
-        // The range occuppied by kid widgets when the scroll offset is at 0.0.
-        let kids_at_origin = {
-            let offset_from_origin = maybe_prev.map(|bar| bar.kids_pos_offset()).unwrap_or(0.0);
-            kids.shift(-offset_from_origin)
-        };
-
-        // Total combined range of the visible and kids_at_origin ranges.
-        let total = visible.max_directed(kids_at_origin);
-
-        // The range that describes the area upon which the start of the visible range can scroll.
-        let scrollable = Range::new(total.start, total.end - visible.magnitude());
-
-        // We only need to calculate offsets if we actually have some scrollable area.
-        if scrollable.magnitude().is_normal() && scrollable.direction() == kids.direction() {
-
-            let interaction = maybe_prev.map(|bar| bar.interaction)
-                .unwrap_or(Interaction::Normal);
-
-            // The amount that the visible range overlaps the start of the kids range when at its
-            // origin position (non-scrolled).
-            let start_overlap = {
-                let start_diff_at_origin = kids_at_origin.start - visible.start;
-                if start_diff_at_origin.signum() == visible.direction() {
-                    start_diff_at_origin
-                } else {
-                    0.0
-                }
-            };
-
-            // The positional scroll offset.
-            let offset = maybe_prev.map(|bar| bar.offset).unwrap_or(0.0);
-
-            Some(Bar {
-                interaction: interaction,
-                scrollable: scrollable,
-                offset: offset,
-                start_overlap: start_overlap,
-            })
-        // Otherwise our offsets are zeroed.
-        } else {
-            None
-        }
-    }
-
-
-    /// Update a scroll `Bar` with the given mouse input.
-    pub fn handle_input(self,
-                        visible: Range,
-                        track: Rect,
-                        handle: Rect,
-                        mouse: &Mouse,
-                        mouse_pos_scalar: Scalar,
-                        mouse_scroll_scalar: Scalar) -> Bar
-    {
-        use self::Elem::{Handle, Track};
-        use self::Interaction::{Highlighted, Clicked};
-
-        // Determine whether or not the mouse is over part of the Scrollbar.
-        let is_over_elem = is_over_elem(track, handle, mouse, mouse_pos_scalar);
-
-        // Determine the new current `Interaction`.
-        let new_interaction = new_interaction(&self, is_over_elem, mouse, mouse_pos_scalar);
-
-        // Calculate the maximum bar offset.
-        let bar_offset_max = || {
-            let bar_mag = handle.len() * visible.direction();
-            track.len() * visible.direction() - bar_mag
-        };
-
-        // Calculate a positional offset given some bar offset.
-        let pos_offset_from_bar_offset = |bar_offset: Scalar, bar_offset_max: Scalar| {
-            map_range(bar_offset, 0.0, bar_offset_max, 0.0, self.scrollable.magnitude())
-        };
-
-        // Determine the new offset for the scrollbar.
-        let new_offset = match (self.interaction, new_interaction) {
-
-            // When the track is clicked and the handle snaps to the cursor.
-            (Highlighted(Track), Clicked(Handle(mouse_pos_scalar))) => {
-                // Should try snap the handle so that the mouse is in the middle of it.
-                let direction = visible.direction();
-                let half_handle_len = handle.len() * direction / 2.0;
-                let target_offset = mouse_pos_scalar - half_handle_len;
-                let target_pos_offset = pos_offset_from_bar_offset(target_offset, bar_offset_max());
-                ::utils::clamp(target_pos_offset, 0.0, self.scrollable.magnitude())
-            },
-
-            // When the handle is dragged.
-            (Clicked(Handle(prev_mouse_scalar)), Clicked(Handle(mouse_pos_scalar))) => {
-                let scroll_amount = mouse_pos_scalar - prev_mouse_scalar;// * visible.direction();
-                let pos_scroll_amount = pos_offset_from_bar_offset(scroll_amount, bar_offset_max());
-                self.add_to_scroll_offset(pos_scroll_amount)
-            },
-
-            // The mouse has been scrolled using a wheel/trackpad/touchpad.
-            (_, _) if mouse_scroll_scalar != 0.0 =>
-                self.add_to_scroll_offset(mouse_scroll_scalar),
-
-            // Otherwise, we'll assume the offset is unchanged.
-            _ => self.offset,
-        };
-
-        Bar { interaction: new_interaction, offset: new_offset, ..self }
-    }
-
-
-    /// A function for shifting some current offset by some amount while ensuring it remains within the
-    /// Bar's Range.
-    fn add_to_scroll_offset(&self, amount: Scalar) -> Scalar {
-        use utils::clamp;
-        let target_offset = self.offset + amount;
-        let min_offset = self.start_overlap;
-        let max_offset = self.scrollable.magnitude();
-
-        // If the offset is before the start, only let it be dragged towards the end.
-        let clamp_current_to_max = || clamp(target_offset, self.offset, max_offset);
-        // If the offset is past the end, only let it be dragged towards the start.
-        let clamp_min_to_current = || clamp(target_offset, min_offset, self.offset);
-        // Otherwise, clamp it between 0.0 and the max.
-        let clamp_min_to_max = || clamp(target_offset, min_offset, max_offset);
-
-        // For a positive range, check the start and end of the range normally.
-        if max_offset >= 0.0 {
-            if      self.offset < min_offset { clamp_current_to_max() }
-            else if self.offset > max_offset { clamp_min_to_current() }
-            else                             { clamp_min_to_max() }
-
-        // Otherwise, check the inverse.
-        } else {
-            if      self.offset > min_offset { clamp_current_to_max() }
-            else if self.offset < max_offset { clamp_min_to_current() }
-            else                             { clamp_min_to_max() }
-        }
-    }
-
-
-    /// Converts the Bar's current offset to the positional offset required to shift the children
-    /// widgets in accordance with the scrolling.
-    pub fn kids_pos_offset(&self) -> Scalar {
-        let Bar { offset, scrollable, .. } = *self;
-        if scrollable.len() == 0.0 { 0.0 } else { -offset }
-    }
-
-    /// Converts the given bar offset to a positional offset.
-    ///
-    /// TODO: Needs testing.
-    pub fn pos_offset_from_bar_offset(&self, bar_offset: Scalar, bar_len: Scalar) -> Scalar {
-        map_range(bar_offset, 0.0, bar_len, 0.0, self.scrollable.magnitude())
-    }
-
-}
-
-
-/// The area for a vertical scrollbar track as its dimensions and position.
-pub fn vertical_track(container: Rect, thickness: Scalar) -> Rect {
+pub fn track(container: Rect, thickness: Scalar) -> Rect {
     let w = thickness;
-    let x = container.x() + container.w() / 2.0 - w / 2.0;
-    Rect {
-        x: Range::from_pos_and_len(x, w),
-        y: container.y,
-    }
+    let h = container.h();
+    let y = container.y();
+    Rect::from_xy_dim([0.0, y], [w, h]).align_right_of(container)
 }
 
-/// The area for a vertical scrollbar handle as its dimensions and position.
-pub fn vertical_handle(bar: &Bar, track: Rect, total_len: Scalar) -> Rect {
-    let offset = partial_max(bar.start_overlap - bar.offset, 0.0);
-    let max_offset = bar.scrollable.len() - (bar.offset.abs() - offset);
-    let track_h = track.h();
-    let h = map_range(track_h, 0.0, total_len, 0.0, track_h);
-    let y = map_range(offset, 0.0, max_offset, track.top(), track.bottom() + h) - h / 2.0;
+pub fn handle(track: Rect, state: &State) -> Rect {
+    let track_len = track.h();
+    let len = track_len * (track_len / state.scrollable_range_len);
+    let handle_range = Range::from_pos_and_len(0.0, len);
+    let pos = {
+        let pos_min = handle_range.align_start_of(track.y).middle();
+        let pos_max = handle_range.align_end_of(track.y).middle();
+        let pos_bounds = Range::new(pos_min, pos_max);
+        state.offset_bounds.map_value_to(state.offset, &pos_bounds)
+    };
     Rect {
         x: track.x,
-        y: Range::from_pos_and_len(y, h),
+        y: Range::from_pos_and_len(pos, len),
     }
 }
-
-/// The area for a horizontal scrollbar track as its dimensions and position.
-pub fn horizontal_track(container: Rect, thickness: Scalar) -> Rect {
-    let h = thickness;
-    let y = container.y() - container.h() / 2.0 + h / 2.0;
-    Rect {
-        x: container.x,
-        y: Range::from_pos_and_len(y, h),
-    }
-}
-
-/// The area for a horizontal scrollbar handle as its dimensions and position.
-pub fn horizontal_handle(bar: &Bar, track: Rect, total_len: Scalar) -> Rect {
-    let offset = partial_max(bar.offset - bar.start_overlap, 0.0);
-    let max_offset = bar.scrollable.len() - (bar.offset.abs() - offset);
-    let track_w = track.w();
-    let w = map_range(track_w, 0.0, total_len, 0.0, track_w);
-    let x = map_range(offset, 0.0, max_offset, track.left(), track.right() - w) + w / 2.0;
-    Rect {
-        x: Range::from_pos_and_len(x, w),
-        y: track.y,
-    }
-}
-
-
-/// Whether or not the mouse is currently over the Bar, and if so, which Elem.
-fn is_over_elem(track: Rect, handle: Rect, mouse: &Mouse, mouse_scalar: Scalar) -> Option<Elem> {
-    if handle.is_over(mouse.xy) {
-        Some(Elem::Handle(mouse_scalar))
-    } else if track.is_over(mouse.xy) {
-        Some(Elem::Track)
-    } else {
-        None
-    }
-}
-
-/// Determine the new current `Interaction` for a Bar.
-/// The given mouse_scalar is the position of the mouse to be recorded by the Handle.
-/// For vertical handle this is mouse.y, for horizontal this is mouse.x.
-fn new_interaction(bar: &Bar,
-                   is_over_elem: Option<Elem>,
-                   mouse: &Mouse,
-                   mouse_scalar: Scalar) -> Interaction
-{
-    use self::Interaction::{Normal, Highlighted, Clicked};
-
-    // If there's no need for a scroll bar, leave the interaction as `Normal`.
-    if bar.scrollable.len() == 0.0 {
-        Normal
-    } else {
-        use self::Elem::Handle;
-        use mouse::ButtonPosition::{Down, Up};
-        match (is_over_elem, bar.interaction, mouse.left.position) {
-            (Some(_),    Normal,             Down) => Normal,
-            (Some(elem), _,                  Up)   => Highlighted(elem),
-            (Some(_),    Highlighted(_),     Down) |
-            (_,          Clicked(Handle(_)), Down) => Clicked(Handle(mouse_scalar)),
-            (_,          Clicked(elem),      Down) => Clicked(elem),
-            _                                      => Normal,
-        }
-    }
-}
-
-
-
-/// Whether or not the scrollbar should capture the mouse given previous and new states.
-pub fn capture_mouse(prev: &State, new: &State) -> bool {
-    match (prev.maybe_vertical, new.maybe_vertical) {
-        (Some(ref prev_bar), Some(ref new_bar)) =>
-            match (prev_bar.interaction, new_bar.interaction) {
-                (Interaction::Highlighted(_), Interaction::Clicked(_)) => return true,
-                _ => (),
-            },
-        _ => (),
-    }
-    match (prev.maybe_horizontal, new.maybe_horizontal) {
-        (Some(ref prev_bar), Some(ref new_bar)) =>
-            match (prev_bar.interaction, new_bar.interaction) {
-                (Interaction::Highlighted(_), Interaction::Clicked(_)) => return true,
-                _ => (),
-            },
-        _ => (),
-    }
-    false
-}
-
-
-/// Whether or not the scrollbar should uncapture the mouse given previous and new states.
-pub fn uncapture_mouse(prev: &State, new: &State) -> bool {
-    match (prev.maybe_vertical, new.maybe_vertical) {
-        (Some(ref prev_bar), Some(ref new_bar)) =>
-            match (prev_bar.interaction, new_bar.interaction) {
-                (Interaction::Clicked(_), Interaction::Highlighted(_)) |
-                (Interaction::Clicked(_), Interaction::Normal)         => return true,
-                _ => (),
-            },
-        _ => (),
-    }
-    match (prev.maybe_horizontal, new.maybe_horizontal) {
-        (Some(ref prev_bar), Some(ref new_bar)) =>
-            match (prev_bar.interaction, new_bar.interaction) {
-                (Interaction::Clicked(_), Interaction::Highlighted(_)) |
-                (Interaction::Clicked(_), Interaction::Normal)         => return true,
-                _ => (),
-            },
-        _ => (),
-    }
-    false
-}
-
-
-#[test]
-fn test_bar_new_no_scroll() {
-    // Create a `Bar` that shouldn't scroll.
-    let visible = Range::new(-5.0, 5.0);
-    let kids = Range::new(-3.0, 3.0);
-    let maybe_bar = Bar::new_if_scrollable(visible, kids, None);
-    assert_eq!(maybe_bar, None);
-}
-
-#[test]
-fn test_bar_new_no_scroll_rev_range() {
-    // Now with a reversed range.
-    let visible = Range::new(5.0, -5.0);
-    let kids = Range::new(3.0, -3.0);
-    let maybe_bar = Bar::new_if_scrollable(visible, kids, None);
-    assert_eq!(maybe_bar, None);
-}
-


### PR DESCRIPTION
~~**WIP - Do not merge yet**~~

Closes #659.
Fixes #660.
Closes #661.

Ok, refactoring complete!

I'm much happier with these changes, they're much clearer and I can confidently say that I understand the behaviour of each distinct step of the process - not something I can say for the old scrolling setup, which was a little hack-ish and resulted in some hard-to-track-down bugs.

This also fixes bugs in the graph logic related to the relative positioning of widgets. Previously, the graph only had a single edge to represent relative positioning across both axes. I've added an `Axis` enum to the `Position` variant, which allows us to track relative positioning uniquely across each axis. This allows for saying cool stuff like `.align_left_of(X).down_from(Y)`, and to know that relative positioning logic will be handled properly when evaluating scroll offsets, etc.

Finally, scrolling will now also properly consider the `Padding` of the `KidArea` of the widget that has `scroll_kids` enabled. I.e., you can now scroll past the edge of the last widget by the padding amount that is specified for that edge. This is just like how there's a little bit of white padding when you scroll past the widgets at the bottom of this github page.