### PR TITLE
Mouse input refactoring

### DIFF
--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -125,14 +125,14 @@ mod circular_button {
             // LMB is down over the button. But the button wasn't Highlighted last
             // update. This means the user clicked somewhere outside the button and
             // moved over the button holding LMB down. We do nothing in this case.
-            (true,  Normal,  Down(_, _)) => Normal,
+            (true,  Normal,  Down(_)) => Normal,
 
             // LMB is down over the button. The button was either Highlighted or Clicked
             // last update. If it was highlighted before, that means the user clicked
             // just now, and we transition to the Clicked state. If it was clicked
             // before, that means the user is still holding LMB down from a previous
             // click, in which case the state remains Clicked.
-            (true,  _,       Down(_, _)) => Clicked,
+            (true,  _,       Down(_)) => Clicked,
 
             // LMB is up. The mouse is hovering over the button. Regardless of what the
             // state was last update, the state should definitely be Highlighted now.
@@ -141,7 +141,7 @@ mod circular_button {
             // LMB is down, the mouse is not over the button, but the previous state was
             // Clicked. That means the user clicked the button and then moved the mouse
             // outside the button while holding LMB down. The button stays Clicked.
-            (false, Clicked, Down(_, _)) => Clicked,
+            (false, Clicked, Down(_)) => Clicked,
 
             // If none of the above applies, then nothing interesting is happening with
             // this button.

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -125,14 +125,14 @@ mod circular_button {
             // LMB is down over the button. But the button wasn't Highlighted last
             // update. This means the user clicked somewhere outside the button and
             // moved over the button holding LMB down. We do nothing in this case.
-            (true,  Normal,  Down) => Normal,
+            (true,  Normal,  Down(_, _)) => Normal,
 
             // LMB is down over the button. The button was either Highlighted or Clicked
             // last update. If it was highlighted before, that means the user clicked
             // just now, and we transition to the Clicked state. If it was clicked
             // before, that means the user is still holding LMB down from a previous
             // click, in which case the state remains Clicked.
-            (true,  _,       Down) => Clicked,
+            (true,  _,       Down(_, _)) => Clicked,
 
             // LMB is up. The mouse is hovering over the button. Regardless of what the
             // state was last update, the state should definitely be Highlighted now.
@@ -141,7 +141,7 @@ mod circular_button {
             // LMB is down, the mouse is not over the button, but the previous state was
             // Clicked. That means the user clicked the button and then moved the mouse
             // outside the button while holding LMB down. The button stays Clicked.
-            (false, Clicked, Down) => Clicked,
+            (false, Clicked, Down(_, _)) => Clicked,
 
             // If none of the above applies, then nothing interesting is happening with
             // this button.

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -120,8 +120,11 @@ mod circular_button {
     /// over the button and the previous interaction state.
     fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
         use conrod::MouseButtonPosition::{Down, Up};
+        use conrod::MouseButton;
         use self::Interaction::{Normal, Highlighted, Clicked};
-        match (is_over, prev, mouse.left.position) {
+
+        let lmb_position = mouse.buttons.get(MouseButton::Left).position;
+        match (is_over, prev, lmb_position) {
             // LMB is down over the button. But the button wasn't Highlighted last
             // update. This means the user clicked somewhere outside the button and
             // moved over the button holding LMB down. We do nothing in this case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ pub use mouse::{Mouse, MouseButton, NUM_MOUSE_BUTTONS};
 pub use mouse::ButtonMap as MouseButtonMap;
 pub use mouse::ButtonState as MouseButtonState;
 pub use mouse::ButtonPosition as MouseButtonPosition;
-pub use mouse::simple_events::Scroll as MouseScroll;
-pub use mouse::simple_events as simple_mouse_events;
+pub use mouse::events::Scroll as MouseScroll;
+pub use mouse::events as simple_mouse_events;
 pub use position::{Align, Corner, Depth, Direction, Dimension, Dimensions, Edge, Margin, Padding,
                    Place, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};
 pub use position::Matrix as PositionMatrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,8 @@ pub use label::{FontSize, Labelable};
 pub use mouse::Mouse;
 pub use mouse::ButtonState as MouseButtonState;
 pub use mouse::ButtonPosition as MouseButtonPosition;
-pub use mouse::Scroll as MouseScroll;
+pub use mouse::simple_events::Scroll as MouseScroll;
+pub use mouse::simple_events as simple_mouse_events;
 pub use position::{Align, Corner, Depth, Direction, Dimension, Dimensions, Edge, Margin, Padding,
                    Place, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};
 pub use position::Matrix as PositionMatrix;
@@ -108,10 +109,10 @@ mod widget;
 /// This is the recommended way of generating `WidgetId`s as it greatly lessens the chances of
 /// making errors when adding or removing widget ids.
 ///
-/// Each Widget must have its own unique identifier so that the `Ui` can keep track of its state 
+/// Each Widget must have its own unique identifier so that the `Ui` can keep track of its state
 /// between updates.
 ///
-/// To make this easier, we provide the `widget_ids` macro, which generates a unique `WidgetId` for 
+/// To make this easier, we provide the `widget_ids` macro, which generates a unique `WidgetId` for
 /// each identifier given in the list.
 ///
 /// The `with n` syntax reserves `n` number of `WidgetId`s for that identifier rather than just one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@ pub use frame::{Framing, Frameable};
 pub use glyph_cache::{GlyphCache, LineBreak};
 pub use graph::NodeIndex;
 pub use label::{FontSize, Labelable};
-pub use mouse::Mouse;
+
+pub use mouse::{Mouse, MouseButton, NUM_MOUSE_BUTTONS};
+pub use mouse::ButtonMap as MouseButtonMap;
 pub use mouse::ButtonState as MouseButtonState;
 pub use mouse::ButtonPosition as MouseButtonPosition;
 pub use mouse::simple_events::Scroll as MouseScroll;

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,10 +1,14 @@
-//! 
+//!
 //! A module for describing Mouse state.
 //!
 //! The `Ui` will continuously maintain the latest Mouse state, necessary for widget logic.
 //!
 
+pub use input::MouseButton;
+pub use graphics::math::Scalar;
 use position::Point;
+use time::{SteadyTime, Duration};
+use std::collections::HashMap;
 
 /// The current state of a Mouse button.
 #[derive(Copy, Clone, Debug)]
@@ -41,6 +45,37 @@ pub struct Mouse {
     pub unknown: ButtonState,
     /// Amount that the mouse has scrolled since the last render.
     pub scroll: Scroll,
+    /// Movements less than this threshold will not be considered drags
+    pub drag_distance_threshold: Scalar,
+    last_button_down_events: [Option<MouseButtonDown>; 9],
+}
+
+
+/// Used for simplified mouse event handling. Most widgets can probably
+/// just use these events
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SimpleMouseEvent {
+    Click(MouseClick),
+    Drag(MouseDragEvent),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct MouseClick {
+    mouse_button: MouseButton,
+    position: Point
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct MouseDragEvent {
+    mouse_button: MouseButton,
+    button_down_position: Point,
+    current_position: Point
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+struct MouseButtonDown {
+    time: SteadyTime,
+    position: Point
 }
 
 /// The amount of scrolling that has occurred since the last render event.
@@ -84,6 +119,8 @@ impl Mouse {
             right: ButtonState::new(),
             unknown: ButtonState::new(),
             scroll: Scroll { x: 0.0, y: 0.0 },
+            drag_distance_threshold: 2.0,
+            last_button_down_events: [None; 9],
         }
     }
 
@@ -92,5 +129,147 @@ impl Mouse {
         Mouse { xy: ::vecmath::vec2_sub(self.xy, xy), ..self }
     }
 
+    /// sets the new position of the mouse
+    pub fn move_to(&mut self, xy: Point) {
+        self.xy = xy;
+    }
+
+    /// Sends the mouse a button down event
+    pub fn button_down(&mut self, button: MouseButton) {
+        use input::MouseButton::*;
+
+        let button_down = MouseButtonDown {
+            time: SteadyTime::now(),
+            position: self.xy.clone()
+        };
+        self.set_last_button_down_time(button, Some(button_down));
+
+        let button_state = match button {
+            Left => &mut self.left,
+            Right => &mut self.right,
+            Middle => &mut self.middle,
+            _ => &mut self.unknown
+        };
+        button_state.position = ButtonPosition::Down;
+        button_state.was_just_pressed = true;
+    }
+
+    pub fn button_up(&mut self, button: MouseButton) {
+        use input::MouseButton::*;
+
+        self.set_last_button_down_time(button, None);
+        let button_state = match button {
+            Left => &mut self.left,
+            Right => &mut self.right,
+            Middle => &mut self.middle,
+            _ => &mut self.unknown
+        };
+        button_state.position = ButtonPosition::Up;
+        button_state.was_just_released = true;
+    }
+
+    pub fn was_clicked(&self, button: MouseButton) -> bool {
+        use input::MouseButton::*;
+        let button_state = match button {
+            Left => self.left,
+            Right => self.right,
+            Middle => self.middle,
+            _ => self.unknown
+        };
+        button_state.was_just_released
+    }
+
+    pub fn get_simple_event(&self) -> Option<SimpleMouseEvent> {
+        use input::MouseButton::{Left, Right, Middle};
+        None
+    }
+
+    fn get_last_button_down(&self, button: MouseButton) -> Option<MouseButtonDown> {
+        let index: u32 = button.into();
+        self.last_button_down_events[index as usize]
+    }
+
+    fn set_last_button_down_time(&mut self, button: MouseButton, maybe_last_down: Option<MouseButtonDown>) {
+        let index: u32 = button.into();
+        self.last_button_down_events[index as usize] = maybe_last_down;
+    }
+
 }
 
+#[test]
+fn move_to_sets_new_mouse_position() {
+    let mut mouse = Mouse::new();
+
+    let new_position = [2.0, 5.0];
+    mouse.move_to(new_position);
+    assert_eq!(new_position, mouse.xy);
+}
+
+#[test]
+fn button_down_sets_last_button_down_info_and_button_up_removes_it() {
+    use input::MouseButton::Left;
+
+    let mut mouse = Mouse::new();
+    assert!(mouse.get_last_button_down(Left).is_none());
+
+    mouse.button_down(Left);
+    assert!(mouse.get_last_button_down(Left).is_some());
+
+    mouse.button_up(Left);
+    assert!(mouse.get_last_button_down(Left).is_none());
+}
+
+#[test]
+fn button_down_sets_button_state_to_down() {
+    let mut mouse = Mouse::new();
+    mouse.left.position = ButtonPosition::Up;
+
+    mouse.button_down(MouseButton::Left);
+
+    assert_eq!(ButtonPosition::Down, mouse.left.position);
+}
+
+#[test]
+fn button_up_sets_button_state_to_up() {
+    let mut mouse = Mouse::new();
+    mouse.left.position = ButtonPosition::Down;
+
+    mouse.button_up(MouseButton::Left);
+    assert_eq!(ButtonPosition::Up, mouse.left.position);
+}
+
+#[test]
+fn get_simple_event_returns_click_if_button_goes_down_then_up_in_same_position() {
+    use input::MouseButton::Right;
+    let mut mouse = Mouse::new();
+    mouse.button_down(Right);
+    mouse.button_up(Right);
+    let expected_event = SimpleMouseEvent::Click(MouseClick{
+        mouse_button: Right,
+        position: mouse.xy.clone()
+    });
+
+    let actual_event = mouse.get_simple_event();
+    assert!(actual_event.is_some());
+    assert_eq!(expected_event, actual_event.unwrap());
+}
+
+#[test]
+fn get_simple_event_returns_drag_event_if_mouse_was_dragged() {
+    use input::MouseButton::Left;
+    let mut mouse = Mouse::new();
+    let new_position = [0.0, mouse.drag_distance_threshold + 1.0];
+    mouse.button_down(Left);
+    mouse.move_to(new_position);
+    mouse.button_up(Left);
+
+    let expected_event = SimpleMouseEvent::Drag(MouseDragEvent{
+        mouse_button: Left,
+        button_down_position: [0.0, 0.0],
+        current_position: new_position,
+    });
+
+    let actual_event = mouse.get_simple_event();
+    assert!(actual_event.is_some());
+    assert_eq!(expected_event, actual_event.unwrap());
+}

--- a/src/mouse/button_map.rs
+++ b/src/mouse/button_map.rs
@@ -1,0 +1,100 @@
+use super::MouseButton;
+use super::ButtonState;
+use std::slice::{IterMut, Iter};
+
+/// The max total number of buttons on a mouse.
+pub const NUM_MOUSE_BUTTONS: usize = 9;
+
+/// A map of `conrod::MouseButton` to `conrod::MouseButtonState`.
+/// Used by the `conrod::Mouse` to hold the state of all mouse buttons.
+#[derive(Copy, Clone, Debug)]
+pub struct ButtonMap {
+    button_states: [ButtonState; NUM_MOUSE_BUTTONS]
+}
+
+impl ButtonMap {
+    /// Returns a new button map with all states set to defaults.
+    pub fn new() -> ButtonMap {
+        ButtonMap{
+            button_states: [ButtonState::new(); NUM_MOUSE_BUTTONS]
+        }
+    }
+
+    /// Returns an immutable reference to the button State
+    /// for the given button.
+    ///
+    /// # Example
+    /// ```
+    /// use conrod::{MouseButton, MouseButtonMap};
+    ///
+    /// let map = MouseButtonMap::new();
+    /// let left_button_state = map.get(MouseButton::Left);
+    /// assert!(left_button_state.is_up());
+    /// ```
+    pub fn get(&self, button: MouseButton) -> &ButtonState {
+        &self.button_states[Self::button_idx(button)]
+    }
+
+    /// Returns a mutable reference to the button state for the given button.
+    ///
+    /// # Example
+    /// ```
+    /// use conrod::{MouseButton, MouseButtonMap};
+    ///
+    /// let mut map = MouseButtonMap::new();
+    /// {
+    ///     let right_button_state = map.get_mut(MouseButton::Right);
+    ///     right_button_state.was_just_pressed = true;
+    /// }
+    /// assert!(map.get(MouseButton::Right).was_just_pressed);
+    /// ```
+    pub fn get_mut(&mut self, button: MouseButton) -> &mut ButtonState {
+        &mut self.button_states[Self::button_idx(button)]
+    }
+
+    /// Simple way to update the ButtonState for a given MouseButton using a closure.
+    ///
+    /// # Example
+    /// ```
+    /// use conrod::{MouseButton, MouseButtonState, MouseButtonMap};
+    ///
+    /// let mut map = MouseButtonMap::new();
+    /// map.update(MouseButton::Right, |state| state.was_just_released = true);
+    /// assert!(map.get(MouseButton::Right).was_just_released);
+    /// ```
+    pub fn update<F: FnOnce(&mut ButtonState)>(&mut self, button: MouseButton, update_fn: F) {
+        let state = self.get_mut(button);
+        update_fn(state);
+    }
+
+    /// Returns a `Vec` containing all the button states in the map, combined
+    /// with their respective buttons.
+    ///
+    /// # Example
+    /// ```
+    /// use conrod::{MouseButton, NUM_MOUSE_BUTTONS, MouseButtonState, MouseButtonMap};
+    ///
+    /// let mut map = MouseButtonMap::new();
+    /// let button_states: Vec<(MouseButton, &MouseButtonState)> = map.all_buttons();
+    /// assert_eq!(NUM_MOUSE_BUTTONS, button_states.len());
+    /// ```
+    pub fn all_buttons(&self) -> Vec<(MouseButton, &ButtonState)> {
+        self.button_states.into_iter().enumerate()
+            .map(|idx_and_state| {
+                (MouseButton::from(idx_and_state.0 as u32), idx_and_state.1)
+            }).collect::<Vec<(MouseButton, &ButtonState)>>()
+    }
+
+    /// returns an iterator over mutable references to all the button states
+    pub fn iter_mut(&mut self) -> IterMut<ButtonState> {
+        self.button_states.iter_mut()
+    }
+
+    pub fn iter(&self) -> Iter<ButtonState> {
+        self.button_states.iter()
+    }
+
+    fn button_idx(button: MouseButton) -> usize {
+        u32::from(button) as usize
+    }
+}

--- a/src/mouse/button_map.rs
+++ b/src/mouse/button_map.rs
@@ -114,8 +114,8 @@ impl ButtonMap {
 #[test]
 fn relative_to_changes_all_mouse_events_to_relative_positions() {
     use input::MouseButton::*;
-    use super::simple_events::*;
-    use super::simple_events::SimpleMouseEvent::{Click, Drag};
+    use super::events::*;
+    use super::events::MouseEvent::{Click, Drag};
     use time::SteadyTime;
 
     let mut map_a = ButtonMap::new();

--- a/src/mouse/events.rs
+++ b/src/mouse/events.rs
@@ -15,6 +15,9 @@ use position::Scalar;
 /// just use these events
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MouseEvent {
+    /// When the mouse button has been pressed but not yet released or dragged.
+    /// This event is created as soon as the button is pressed.
+    Down(MouseButtonDown),
     /// Indicates that the mouse was clicked. A Click event is created when the mouse button is released, not depressed
     Click(MouseClick),
     /// Drag event is created when the mouse was moved over a certain threshold while a button was depressed
@@ -102,6 +105,7 @@ impl MouseEvent {
         use self::MouseEvent::*;
 
         match self {
+            &Down(button_down) => Down(button_down.relative_to(xy)),
             &Click(mouse_click) => Click(mouse_click.relative_to(xy)),
             &Drag(mouse_drag) => Drag(mouse_drag.relative_to(xy)),
             &Scroll(scroll_info) => Scroll(scroll_info)

--- a/src/mouse/events.rs
+++ b/src/mouse/events.rs
@@ -14,7 +14,7 @@ use position::Scalar;
 /// Used for simplified mouse event handling. Most widgets can probably
 /// just use these events
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum SimpleMouseEvent {
+pub enum MouseEvent {
     /// Indicates that the mouse was clicked. A Click event is created when the mouse button is released, not depressed
     Click(MouseClick),
     /// Drag event is created when the mouse was moved over a certain threshold while a button was depressed
@@ -95,11 +95,11 @@ impl MouseDragEvent {
     }
 }
 
-impl SimpleMouseEvent {
+impl MouseEvent {
 
     /// Returns a new copy of the event data relative to the given point
     pub fn relative_to(&self, xy: Point) -> Self {
-        use self::SimpleMouseEvent::*;
+        use self::MouseEvent::*;
 
         match self {
             &Click(mouse_click) => Click(mouse_click.relative_to(xy)),

--- a/src/mouse/events.rs
+++ b/src/mouse/events.rs
@@ -5,6 +5,7 @@
 use input::MouseButton;
 use position::Point;
 use time::SteadyTime;
+use ::vecmath::vec2_sub;
 
 #[cfg(test)]
 use position::Scalar;
@@ -17,7 +18,7 @@ use position::Scalar;
 pub enum MouseEvent {
     /// When the mouse button has been pressed but not yet released or dragged.
     /// This event is created as soon as the button is pressed.
-    Down(MouseButtonDown),
+    Down(ButtonDownEvent),
     /// Indicates that the mouse was clicked. A Click event is created when the mouse button is released, not depressed
     Click(MouseClick),
     /// Drag event is created when the mouse was moved over a certain threshold while a button was depressed
@@ -54,6 +55,16 @@ pub struct MouseDragEvent {
     pub button_released: bool
 }
 
+/// Event that is created when a mouse button if first pressed (but not yet released)
+/// a ButtonDownEvent will always precipitate either a Click or a Drag event.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct ButtonDownEvent {
+    /// The mouse button that was pressed
+    pub mouse_button: MouseButton,
+    /// The position of the mouse when the button was pressed
+    pub position: Point,
+}
+
 /// Holds info on when a mouse button was depressed or released.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct MouseButtonDown {
@@ -77,8 +88,6 @@ impl MouseClick {
 
     /// Returns a new copy of the event data relative to the given point
     pub fn relative_to(&self, xy: Point) -> MouseClick {
-        use ::vecmath::vec2_sub;
-
         MouseClick{
             position: vec2_sub(self.position, xy),
             ..*self
@@ -93,6 +102,17 @@ impl MouseDragEvent {
         MouseDragEvent{
             start: self.start.relative_to(xy),
             current: self.current.relative_to(xy),
+            ..*self
+        }
+    }
+}
+
+impl ButtonDownEvent {
+
+    /// Returns a new copy of the event data relative to the given point
+    pub fn relative_to(&self, xy: Point) -> ButtonDownEvent {
+        ButtonDownEvent {
+            position: vec2_sub(self.position, xy),
             ..*self
         }
     }
@@ -117,8 +137,6 @@ impl MouseButtonDown {
 
     /// Returns a new copy of the event data relative to the given point
     pub fn relative_to(&self, xy: Point) -> MouseButtonDown {
-        use ::vecmath::vec2_sub;
-
         MouseButtonDown{
             position: vec2_sub(self.position, xy),
             ..*self

--- a/src/mouse/mod.rs
+++ b/src/mouse/mod.rs
@@ -3,9 +3,11 @@
 //!
 //! The `Ui` will continuously maintain the latest Mouse state, necessary for widget logic.
 //!
+pub mod simple_events;
 
-pub use input::MouseButton;
 pub use graphics::math::Scalar;
+
+use self::simple_events::*;
 use position::Point;
 use time::{SteadyTime};
 
@@ -50,81 +52,6 @@ pub struct Mouse {
     pub simple_event: Option<SimpleMouseEvent>,
 }
 
-
-/// Used for simplified mouse event handling. Most widgets can probably
-/// just use these events
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum SimpleMouseEvent {
-    Click(MouseClick),
-    Drag(MouseDragEvent),
-}
-
-impl SimpleMouseEvent {
-
-    pub fn relative_to(&self, xy: Point) -> Self {
-        use self::SimpleMouseEvent::*;
-
-        match self {
-            &Click(mouse_click) => Click(mouse_click.relative_to(xy)),
-            &Drag(mouse_drag) => Drag(mouse_drag.relative_to(xy))
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct MouseClick {
-    mouse_button: MouseButton,
-    position: Point
-}
-
-impl MouseClick {
-
-    pub fn relative_to(&self, xy: Point) -> MouseClick {
-        use ::vecmath::vec2_sub;
-
-        MouseClick{
-            position: vec2_sub(self.position, xy),
-            ..*self
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct MouseDragEvent {
-    mouse_button: MouseButton,
-    start: MouseButtonDown,
-    current: MouseButtonDown,
-    button_released: bool
-}
-
-impl MouseDragEvent {
-
-    pub fn relative_to(&self, xy: Point) -> MouseDragEvent {
-        MouseDragEvent{
-            start: self.start.relative_to(xy),
-            current: self.current.relative_to(xy),
-            ..*self
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct MouseButtonDown {
-    pub time: SteadyTime,
-    pub position: Point
-}
-
-impl MouseButtonDown {
-
-    pub fn relative_to(&self, xy: Point) -> MouseButtonDown {
-        use ::vecmath::vec2_sub;
-
-        MouseButtonDown{
-            position: vec2_sub(self.position, xy),
-            ..*self
-        }
-    }
-}
 
 /// The amount of scrolling that has occurred since the last render event.
 #[derive(Copy, Clone, Debug)]
@@ -200,7 +127,7 @@ impl Mouse {
     pub fn move_to(&mut self, xy: Point) {
         use input::MouseButton::{Left, Middle, Right};
         use self::ButtonPosition::Down;
-        use self::SimpleMouseEvent::Drag;
+        use self::simple_events::SimpleMouseEvent::Drag;
 
         let buttons: Vec<(&ButtonState, MouseButton)> = vec![
             (&self.left, Left),

--- a/src/mouse/mod.rs
+++ b/src/mouse/mod.rs
@@ -143,13 +143,15 @@ impl Mouse {
         let mouse_position = self.xy.clone();
 
         self.buttons.update(button, |state| {
-            let button_down = MouseButtonDown{
+            state.position = ButtonPosition::Down(MouseButtonDown{
                 time: SteadyTime::now(),
                 position: mouse_position
-            };
-            state.position = ButtonPosition::Down(button_down);
+            });
             state.was_just_pressed = true;
-            state.event = Some(MouseEvent::Down(button_down))
+            state.event = Some(MouseEvent::Down(ButtonDownEvent{
+                mouse_button: button,
+                position: mouse_position
+            }));
         });
     }
 
@@ -352,7 +354,10 @@ fn button_down_creates_a_button_down_event() {
     let button_state = mouse.buttons.get(MouseButton::Left);
 
     match button_state.event {
-        Some(MouseEvent::Down(_)) => {},
+        Some(MouseEvent::Down(button_down_event)) => {
+            assert_eq!(mouse.xy, button_down_event.position);
+            assert_eq!(MouseButton::Left, button_down_event.mouse_button);
+        },
         _ => panic!("Expected a button down event")
     }
 }

--- a/src/mouse/mod.rs
+++ b/src/mouse/mod.rs
@@ -221,16 +221,23 @@ impl Mouse {
         })));
     }
 
+    /// resets the state of the mouse
+    pub fn reset(&mut self) {
+        self.left.reset_pressed_and_released();
+        self.right.reset_pressed_and_released();
+        self.middle.reset_pressed_and_released();
+        self.unknown.reset_pressed_and_released();
+        self.simple_event = None;
+        self.scroll.x = 0.0;
+        self.scroll.y = 0.0;
+    }
+
     /// Returns the current `SimpleMouseEvent` if there is one
     pub fn get_simple_event(&self) -> Option<SimpleMouseEvent> {
         self.simple_event
     }
 
     fn set_simple_event(&mut self, event: Option<SimpleMouseEvent>) {
-        if self.simple_event.is_some() {
-            let old_event = self.simple_event.take();
-            println!("Discarding old MouseEvent: {:?} in favor of {:?}", old_event, event);
-        }
         if event.is_some() {
             self.simple_event = event;
         }
@@ -242,6 +249,36 @@ fn distance_between(a: Point, b: Point) -> Scalar {
     let dx_2 = (a[0] - b[0]).powi(2);
     let dy_2 = (a[1] - b[1]).powi(2);
     (dx_2 + dy_2).abs().sqrt()
+}
+
+#[test]
+fn reset_should_reset_all_button_states_and_scroll_state() {
+    let mut mouse = Mouse::new();
+    mouse.left.was_just_pressed = true;
+    mouse.left.was_just_released = true;
+    mouse.right.was_just_pressed = true;
+    mouse.right.was_just_released = true;
+    mouse.middle.was_just_pressed = true;
+    mouse.middle.was_just_released = true;
+    mouse.unknown.was_just_pressed = true;
+    mouse.unknown.was_just_released = true;
+    mouse.scroll.x = 10.0;
+    mouse.scroll.y = 20.0;
+    mouse.simple_event = Some(SimpleMouseEvent::Scroll(Scroll{x: 2.0, y: 33.3}));
+
+    mouse.reset();
+
+    assert!(!mouse.left.was_just_pressed);
+    assert!(!mouse.left.was_just_released);
+    assert!(!mouse.right.was_just_pressed);
+    assert!(!mouse.right.was_just_released);
+    assert!(!mouse.middle.was_just_pressed);
+    assert!(!mouse.middle.was_just_released);
+    assert!(!mouse.unknown.was_just_pressed);
+    assert!(!mouse.unknown.was_just_released);
+    assert_eq!(0.0, mouse.scroll.x);
+    assert_eq!(0.0, mouse.scroll.y);
+    assert!(mouse.simple_event.is_none());
 }
 
 #[test]

--- a/src/mouse/mod.rs
+++ b/src/mouse/mod.rs
@@ -3,10 +3,14 @@
 //!
 //! The `Ui` will continuously maintain the latest Mouse state, necessary for widget logic.
 //!
+
 pub mod simple_events;
+mod button_map;
 
-pub use graphics::math::Scalar;
+pub use self::button_map::{ButtonMap, NUM_MOUSE_BUTTONS};
+pub use input::MouseButton;
 
+use graphics::math::Scalar;
 use self::simple_events::*;
 use position::Point;
 use time::{SteadyTime};
@@ -20,6 +24,8 @@ pub struct ButtonState {
     pub was_just_released: bool,
     /// The current position of the button.
     pub position: ButtonPosition,
+    /// SimpleMouseEvent for events corresponding to this button.
+    pub event: Option<SimpleMouseEvent>,
 }
 
 /// Represents the current state of a mouse button.
@@ -50,6 +56,8 @@ pub struct Mouse {
     pub drag_distance_threshold: Scalar,
     /// Simple mouse event that is waiting to be consumed
     pub simple_event: Option<SimpleMouseEvent>,
+    /// Map of MouseButton to ButtonState
+    pub button_map: ButtonMap,
 }
 
 
@@ -61,6 +69,7 @@ impl ButtonState {
             was_just_released: false,
             was_just_pressed: false,
             position: ButtonPosition::Up,
+            event: None
         }
     }
 
@@ -100,7 +109,8 @@ impl Mouse {
             unknown: ButtonState::new(),
             scroll: Scroll { x: 0.0, y: 0.0 },
             drag_distance_threshold: 2.0,
-            simple_event: None
+            simple_event: None,
+            button_map: ButtonMap::new(),
         }
     }
 

--- a/src/mouse/simple_events.rs
+++ b/src/mouse/simple_events.rs
@@ -12,6 +12,8 @@ pub enum SimpleMouseEvent {
     Click(MouseClick),
     /// Drag event is created when the mouse was moved over a certain threshold while a button was depressed
     Drag(MouseDragEvent),
+    /// Scroll event is created when whenever the scroll wheel is moved
+    Scroll(Scroll),
 }
 
 
@@ -42,6 +44,16 @@ pub struct MouseButtonDown {
     /// The location of the mouse when the button was pressed
     pub position: Point
 }
+
+/// The amount of scrolling that has occurred since the last render event.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Scroll {
+    /// Scrolling across the x axis.
+    pub x: f64,
+    /// Scrolling across the y axis.
+    pub y: f64,
+}
+
 
 impl MouseClick {
 
@@ -76,7 +88,8 @@ impl SimpleMouseEvent {
 
         match self {
             &Click(mouse_click) => Click(mouse_click.relative_to(xy)),
-            &Drag(mouse_drag) => Drag(mouse_drag.relative_to(xy))
+            &Drag(mouse_drag) => Drag(mouse_drag.relative_to(xy)),
+            &Scroll(scroll_info) => Scroll(scroll_info)
         }
     }
 }

--- a/src/mouse/simple_events.rs
+++ b/src/mouse/simple_events.rs
@@ -9,6 +9,8 @@ use time::SteadyTime;
 #[cfg(test)]
 use position::Scalar;
 
+// pub type MouseEventIterator = ();
+
 /// Used for simplified mouse event handling. Most widgets can probably
 /// just use these events
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/mouse/simple_events.rs
+++ b/src/mouse/simple_events.rs
@@ -1,6 +1,8 @@
+//! module for abstracting over most mouse events.
+//! Handles most common mouse events so that widgets don't have to
+//! store any mouse state.
 
-pub use input::MouseButton;
-
+use input::MouseButton;
 use position::Point;
 use time::SteadyTime;
 
@@ -20,6 +22,9 @@ pub enum SimpleMouseEvent {
 }
 
 
+/// Info on a simple mouse click event. This event gets dispatched when a
+/// mouse button goes down then up without moving more than the drag threshold
+/// while the button is depressed.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct MouseClick {
     /// Indicates Which button was clicked
@@ -28,6 +33,10 @@ pub struct MouseClick {
     pub position: Point
 }
 
+/// Info on a simple mouse drag event. This event gets dispached when a mouse
+/// button is depressed and the mouse is moved a distance greater than the
+/// drag threshold. Holds the start and end positions of the drag, as well as
+/// whether the mouse button is still being depressed.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct MouseDragEvent {
     /// Which mouse button is being held during the drag
@@ -40,6 +49,7 @@ pub struct MouseDragEvent {
     pub button_released: bool
 }
 
+/// Holds info on when a mouse button was depressed or released.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct MouseButtonDown {
     /// The time that the mouse button was pressed.

--- a/src/mouse/simple_events.rs
+++ b/src/mouse/simple_events.rs
@@ -4,6 +4,9 @@ pub use input::MouseButton;
 use position::Point;
 use time::SteadyTime;
 
+#[cfg(test)]
+use position::Scalar;
+
 /// Used for simplified mouse event handling. Most widgets can probably
 /// just use these events
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -105,4 +108,45 @@ impl MouseButtonDown {
             ..*self
         }
     }
+}
+
+#[test]
+fn click_event_should_be_made_relative_to_a_point() {
+    let click = MouseClick{
+        mouse_button: MouseButton::Left,
+        position: [10.0, 20.0]
+    };
+
+    let relative_click = click.relative_to([5.0, 10.0]);
+
+    assert_float_eq(5.0, relative_click .position[0]);
+    assert_float_eq(10.0, relative_click .position[1]);
+}
+
+#[test]
+fn drag_event_should_be_made_relative_to_a_point() {
+    let drag = MouseDragEvent{
+        mouse_button: MouseButton::Left,
+        start: MouseButtonDown{
+            time: SteadyTime::now(),
+            position: [4.0, -5.0]
+        },
+        current: MouseButtonDown{
+            time: SteadyTime::now(),
+            position: [24.0, -10.0]
+        },
+        button_released: false
+    };
+
+    let relative_drag = drag.relative_to([20.0, -5.0]);
+    assert_float_eq(-16.0, relative_drag.start.position[0]);
+    assert_float_eq(0.0, relative_drag.start.position[1]);
+    assert_float_eq(4.0, relative_drag.current.position[0]);
+    assert_float_eq(-5.0, relative_drag.current.position[1]);
+}
+
+#[cfg(test)]
+pub fn assert_float_eq(a: Scalar, b: Scalar) {
+    let epsilon = 0.0001;
+    assert!((a - epsilon) <= b && (a + epsilon) >= b, format!("{} != {}", a, b));
 }

--- a/src/mouse/simple_events.rs
+++ b/src/mouse/simple_events.rs
@@ -1,0 +1,95 @@
+
+pub use input::MouseButton;
+
+use position::Point;
+use time::SteadyTime;
+
+/// Used for simplified mouse event handling. Most widgets can probably
+/// just use these events
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SimpleMouseEvent {
+    /// Indicates that the mouse was clicked. A Click event is created when the mouse button is released, not depressed
+    Click(MouseClick),
+    /// Drag event is created when the mouse was moved over a certain threshold while a button was depressed
+    Drag(MouseDragEvent),
+}
+
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct MouseClick {
+    /// Indicates Which button was clicked
+    pub mouse_button: MouseButton,
+    /// The Point describing the click location
+    pub position: Point
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct MouseDragEvent {
+    /// Which mouse button is being held during the drag
+    pub mouse_button: MouseButton,
+    /// The time and location where the drag was initiated (when the button was pressed)
+    pub start: MouseButtonDown,
+    /// The current time and location of the mouse
+    pub current: MouseButtonDown,
+    /// This will be false if the button is still being held down, or true if the button was released
+    pub button_released: bool
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct MouseButtonDown {
+    /// The time that the mouse button was pressed.
+    pub time: SteadyTime,
+    /// The location of the mouse when the button was pressed
+    pub position: Point
+}
+
+impl MouseClick {
+
+    /// Returns a new copy of the event data relative to the given point
+    pub fn relative_to(&self, xy: Point) -> MouseClick {
+        use ::vecmath::vec2_sub;
+
+        MouseClick{
+            position: vec2_sub(self.position, xy),
+            ..*self
+        }
+    }
+}
+
+impl MouseDragEvent {
+
+    /// Returns a new copy of the event data relative to the given point
+    pub fn relative_to(&self, xy: Point) -> MouseDragEvent {
+        MouseDragEvent{
+            start: self.start.relative_to(xy),
+            current: self.current.relative_to(xy),
+            ..*self
+        }
+    }
+}
+
+impl SimpleMouseEvent {
+
+    /// Returns a new copy of the event data relative to the given point
+    pub fn relative_to(&self, xy: Point) -> Self {
+        use self::SimpleMouseEvent::*;
+
+        match self {
+            &Click(mouse_click) => Click(mouse_click.relative_to(xy)),
+            &Drag(mouse_drag) => Drag(mouse_drag.relative_to(xy))
+        }
+    }
+}
+
+impl MouseButtonDown {
+
+    /// Returns a new copy of the event data relative to the given point
+    pub fn relative_to(&self, xy: Point) -> MouseButtonDown {
+        use ::vecmath::vec2_sub;
+
+        MouseButtonDown{
+            position: vec2_sub(self.position, xy),
+            ..*self
+        }
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -265,7 +265,7 @@ impl<C> Ui<C> {
                         Middle => &mut self.mouse.middle,
                         _ => &mut self.mouse.unknown,
                     };
-                    mouse_button.position = mouse::ButtonPosition::Down(mouse::MouseButtonDown{
+                    mouse_button.position = mouse::ButtonPosition::Down(mouse::simple_events::MouseButtonDown{
                         time: SteadyTime::now(),
                         position: mouse_position
                     });

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -510,7 +510,7 @@ impl<C> Ui<C> {
         self.text_just_entered.clear();
 
         // Reset the mouse state.
-        self.mouse.scroll = mouse::Scroll { x: 0.0, y: 0.0 };
+        self.mouse.scroll = mouse::simple_events::Scroll { x: 0.0, y: 0.0 };
         self.mouse.left.reset_pressed_and_released();
         self.mouse.middle.reset_pressed_and_released();
         self.mouse.right.reset_pressed_and_released();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -168,6 +168,7 @@ impl<C> Ui<C> {
         }
     }
 
+<<<<<<< 935ee46b45fd33a68ae43cb87b1b83da7e6e51e4
     /// The **Rect** for the widget at the given index.
     ///
     /// Returns `None` if there is no widget for the given index.
@@ -181,6 +182,14 @@ impl<C> Ui<C> {
     /// Returns `None` if there is no widget for the given index.
     pub fn w_of<I: Into<widget::Index>>(&self, idx: I) -> Option<Scalar> {
         self.rect_of(idx).map(|rect| rect.w())
+    }
+
+    pub fn is_capturing_keyboard(&self, id: widget::Index) -> bool {
+        self.maybe_captured_keyboard == Some(Capturing::Captured(id))
+    }
+
+    pub fn is_capturing_mouse(&self, id: widget::Index) -> bool {
+        self.maybe_captured_mouse == Some(Capturing::Captured(id))
     }
 
     /// The absolute height of the widget at the given index.
@@ -248,6 +257,7 @@ impl<C> Ui<C> {
 
             match button_type {
                 Button::Mouse(button) => {
+                    self.focus_widget_under_mouse();
                     let mouse_button = match button {
                         Left => &mut self.mouse.left,
                         Right => &mut self.mouse.right,
@@ -267,6 +277,7 @@ impl<C> Ui<C> {
             use input::MouseButton::{Left, Middle, Right};
             match button_type {
                 Button::Mouse(button) => {
+                    self.focus_widget_under_mouse();
                     let mouse_button = match button {
                         Left => &mut self.mouse.left,
                         Right => &mut self.mouse.right,
@@ -285,6 +296,18 @@ impl<C> Ui<C> {
             self.text_just_entered.push(text.to_string())
         });
     }
+
+    fn focus_widget_under_mouse(&mut self) {
+        if let Some(widget_index) = self.maybe_widget_under_mouse {
+            self.change_focus_to(widget_index);
+        }
+    }
+
+    pub fn change_focus_to(&mut self, widget_index: widget::Index) {
+        self.maybe_captured_mouse = Some(Capturing::Captured(widget_index));
+        self.maybe_captured_keyboard = Some(Capturing::Captured(widget_index));
+    }
+
 
 
     /// Get the centred xy coords for some given `Dimension`s, `Position` and alignment.
@@ -624,7 +647,7 @@ pub fn infer_parent_from_position<C>(ui: &Ui<C>, x_pos: Position, y_pos: Positio
 
 /// Attempts to infer the parent of a widget from its *x*/*y* `Position`s and the current state of
 /// the `Ui`.
-/// 
+///
 /// If no parent can be inferred via the `Position`s, the `maybe_current_parent_idx` will be used.
 ///
 /// If `maybe_current_parent_idx` is `None`, the `Ui`'s `window` widget will be used.
@@ -688,7 +711,7 @@ pub fn get_mouse_state<C>(ui: &Ui<C>, idx: widget::Index) -> Option<Mouse> {
             Some(Capturing::Captured(captured_idx)) =>
                 if idx == captured_idx { Some(ui.mouse) } else { None },
             _ =>
-                if Some(idx) == ui.maybe_widget_under_mouse 
+                if Some(idx) == ui.maybe_widget_under_mouse
                 || Some(idx) == ui.maybe_top_scrollable_widget_under_mouse {
                     Some(ui.mouse)
                 } else {
@@ -702,7 +725,7 @@ pub fn get_mouse_state<C>(ui: &Ui<C>, idx: widget::Index) -> Option<Mouse> {
 /// Indicate that the widget with the given widget::Index has captured the mouse.
 ///
 /// Returns true if the mouse was successfully captured.
-/// 
+///
 /// Returns false if the mouse was already captured.
 pub fn mouse_captured_by<C>(ui: &mut Ui<C>, idx: widget::Index) -> bool {
     // If the mouse isn't already captured, set idx as the capturing widget.
@@ -819,4 +842,3 @@ pub fn post_update_cache<C, W>(ui: &mut Ui<C>, widget: widget::PostUpdateCache<W
 pub fn clear_with<C>(ui: &mut Ui<C>, color: Color) {
     ui.maybe_background_color = Some(color);
 }
-

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,6 +20,7 @@ use std::collections::HashSet;
 use std::io::Write;
 use theme::Theme;
 use widget::{self, Widget};
+use time::SteadyTime;
 
 
 /// Indicates whether or not the Mouse has been captured by a widget.
@@ -254,6 +255,7 @@ impl<C> Ui<C> {
             use input::Button;
             use input::MouseButton::{Left, Middle, Right};
 
+            let mouse_position = self.mouse.xy.clone();
             match button_type {
                 Button::Mouse(button) => {
                     self.widget_under_mouse_captures_keyboard();
@@ -263,7 +265,7 @@ impl<C> Ui<C> {
                         Middle => &mut self.mouse.middle,
                         _ => &mut self.mouse.unknown,
                     };
-                    mouse_button.position = mouse::ButtonPosition::Down;
+                    mouse_button.position = mouse::ButtonPosition::Down(SteadyTime::now(), mouse_position);
                     mouse_button.was_just_pressed = true;
                 },
                 Button::Keyboard(key) => self.keys_just_pressed.push(key),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -168,7 +168,6 @@ impl<C> Ui<C> {
         }
     }
 
-<<<<<<< 935ee46b45fd33a68ae43cb87b1b83da7e6e51e4
     /// The **Rect** for the widget at the given index.
     ///
     /// Returns `None` if there is no widget for the given index.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use backend::graphics::{Context, Graphics};
 use color::Color;
 use glyph_cache::GlyphCache;
 use graph::{self, Graph, NodeIndex};
-use mouse::{self, Mouse};
+use mouse::Mouse;
 use input;
 use input::{
     GenericEvent,
@@ -20,7 +20,6 @@ use std::collections::HashSet;
 use std::io::Write;
 use theme::Theme;
 use widget::{self, Widget};
-use time::SteadyTime;
 
 
 /// Indicates whether or not the Mouse has been captured by a widget.
@@ -184,10 +183,12 @@ impl<C> Ui<C> {
         self.rect_of(idx).map(|rect| rect.w())
     }
 
+    /// Returns true if the given widget is currently capturing the keyboard
     pub fn is_capturing_keyboard(&self, id: widget::Index) -> bool {
         self.maybe_captured_keyboard == Some(Capturing::Captured(id))
     }
 
+    /// Returns true if the given widget is currently capturing the mouse
     pub fn is_capturing_mouse(&self, id: widget::Index) -> bool {
         self.maybe_captured_mouse == Some(Capturing::Captured(id))
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -265,7 +265,10 @@ impl<C> Ui<C> {
                         Middle => &mut self.mouse.middle,
                         _ => &mut self.mouse.unknown,
                     };
-                    mouse_button.position = mouse::ButtonPosition::Down(SteadyTime::now(), mouse_position);
+                    mouse_button.position = mouse::ButtonPosition::Down(mouse::MouseButtonDown{
+                        time: SteadyTime::now(),
+                        position: mouse_position
+                    });
                     mouse_button.was_just_pressed = true;
                 },
                 Button::Keyboard(key) => self.keys_just_pressed.push(key),

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -79,10 +79,10 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
+        (true,  Normal,  Down(_, _)) => Normal,
+        (true,  _,       Down(_, _)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down) => Clicked,
+        (false, Clicked, Down(_, _)) => Clicked,
         _                      => Normal,
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -79,10 +79,10 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down(_, _)) => Normal,
-        (true,  _,       Down(_, _)) => Clicked,
+        (true,  Normal,  Down(_)) => Normal,
+        (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down(_, _)) => Clicked,
+        (false, Clicked, Down(_)) => Clicked,
         _                      => Normal,
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -77,8 +77,11 @@ impl Interaction {
 /// Check the current state of the button.
 fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
+    use mouse::MouseButton::Left;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left.position) {
+
+    let left_mouse_button = mouse.buttons.get(Left);
+    match (is_over, prev, left_mouse_button.position) {
         (true,  Normal,  Down(_)) => Normal,
         (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! Types and functionality related to the dragging behaviour of Widgets.
 //!
 
@@ -32,10 +32,10 @@ pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Po
 
     // Determine the new drag state.
     let new_state = match (is_over, state, mouse.left.position) {
-        (true,  Normal,     Down) => Normal,
+        (true,  Normal,     Down(_, _)) => Normal,
         (true,  _,          Up)   => Highlighted,
-        (true,  _,          Down) |
-        (false, Clicked(_), Down) => Clicked(mouse.xy),
+        (true,  _,          Down(_, _)) |
+        (false, Clicked(_), Down(_, _)) => Clicked(mouse.xy),
         _                         => Normal,
     };
 
@@ -48,6 +48,3 @@ pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Po
 
     (new_xy, new_state)
 }
-
-
-

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -23,6 +23,7 @@ pub enum State {
 pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Point, State) {
     use self::State::{Normal, Highlighted, Clicked};
     use mouse::ButtonPosition::{Up, Down};
+    use mouse::MouseButton::Left as LeftButton;
 
     // Find the absolute position of the draggable area.
     let abs_rect = rel_rect.shift(xy);
@@ -31,7 +32,8 @@ pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Po
     let is_over = abs_rect.is_over(mouse.xy);
 
     // Determine the new drag state.
-    let new_state = match (is_over, state, mouse.left.position) {
+    let left_button_position = mouse.buttons.get(LeftButton).position;
+    let new_state = match (is_over, state, left_button_position) {
         (true,  Normal,     Down(_)) => Normal,
         (true,  _,          Up)   => Highlighted,
         (true,  _,          Down(_)) |

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -32,10 +32,10 @@ pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Po
 
     // Determine the new drag state.
     let new_state = match (is_over, state, mouse.left.position) {
-        (true,  Normal,     Down(_, _)) => Normal,
+        (true,  Normal,     Down(_)) => Normal,
         (true,  _,          Up)   => Highlighted,
-        (true,  _,          Down(_, _)) |
-        (false, Clicked(_), Down(_, _)) => Clicked(mouse.xy),
+        (true,  _,          Down(_)) |
+        (false, Clicked(_), Down(_)) => Clicked(mouse.xy),
         _                         => Normal,
     };
 

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -158,6 +158,8 @@ impl<'a, F> Widget for DropDownList<'a, F> where
 
     /// Update the state of the DropDownList.
     fn update<C: CharacterCache>(mut self, args: widget::UpdateArgs<Self, C>) {
+        use mouse::MouseButton;
+
         let widget::UpdateArgs { idx, state, rect, style, mut ui, .. } = args;
 
         let (global_mouse, window_dim) = {
@@ -280,7 +282,7 @@ impl<'a, F> Widget for DropDownList<'a, F> where
 
                     MenuState::Closed
                 // Otherwise if the mouse was released somewhere else we should close the menu.
-                } else if global_mouse.left.was_just_pressed
+            } else if global_mouse.buttons.get(MouseButton::Left).was_just_pressed
                 && !canvas_rect.is_over(global_mouse.xy) {
                     MenuState::Closed
                 } else {

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -29,6 +29,7 @@ use std::default::Default;
 use std::fmt::Debug;
 use utils::{clamp, map_range, percentage, val_to_string};
 use widget;
+use mouse::MouseButton;
 
 
 /// Used for editing a series of 2D Points on a cartesian (X, Y) plane within some given range.
@@ -110,14 +111,6 @@ pub enum Elem {
     // CurvePoint(usize, (f64, f64)),
 }
 
-/// An enum to define which button is clicked.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum MouseButton {
-    Left,
-    Right,
-}
-
-
 /// `EnvPoint` must be implemented for any type that is used as a 2D point within the
 /// EnvelopeEditor.
 pub trait EnvelopePoint: Any + Clone + Debug + PartialEq {
@@ -175,9 +168,12 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
                        mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
     use self::Elem::{EnvPoint};//, CurvePoint};
-    use self::MouseButton::{Left, Right};
+    use mouse::MouseButton::{Left, Right};
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over_elem, prev, mouse.left.position, mouse.right.position) {
+
+    let left_button_position = mouse.buttons.get(Left).position;
+    let right_button_position = mouse.buttons.get(Right).position;
+    match (is_over_elem, prev, left_button_position, right_button_position) {
         (Some(_), Normal, Down(_), Up) => Normal,
         (Some(elem), _, Up, Up) => Highlighted(elem),
         (Some(elem), Highlighted(_), Down(_), Up) => Clicked(elem, Left),
@@ -467,6 +463,7 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
                                     react(env, idx);
                                 }
                             },
+                            _ => {}
                         }
                     },
                     (Clicked(_, prev_m_button), Clicked(_, m_button)) => {

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -178,11 +178,11 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
     use self::MouseButton::{Left, Right};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over_elem, prev, mouse.left.position, mouse.right.position) {
-        (Some(_), Normal, Down(_, _), Up) => Normal,
+        (Some(_), Normal, Down(_), Up) => Normal,
         (Some(elem), _, Up, Up) => Highlighted(elem),
-        (Some(elem), Highlighted(_), Down(_, _), Up) => Clicked(elem, Left),
-        (Some(_), Clicked(p_elem, m_button), Down(_, _), Up) |
-        (Some(_), Clicked(p_elem, m_button), Up, Down(_, _)) => {
+        (Some(elem), Highlighted(_), Down(_), Up) => Clicked(elem, Left),
+        (Some(_), Clicked(p_elem, m_button), Down(_), Up) |
+        (Some(_), Clicked(p_elem, m_button), Up, Down(_)) => {
             match p_elem {
                 EnvPoint(idx, _) => Clicked(EnvPoint(idx, (mouse.xy[0], mouse.xy[1])), m_button),
                 // CurvePoint(idx, _) =>
@@ -190,7 +190,7 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
                 _ => Clicked(p_elem, m_button),
             }
         },
-        (None, Clicked(p_elem, m_button), Down(_, _), Up) => {
+        (None, Clicked(p_elem, m_button), Down(_), Up) => {
             match (p_elem, m_button) {
                 (EnvPoint(idx, _), Left) =>
                     Clicked(EnvPoint(idx, (mouse.xy[0], mouse.xy[1])), Left),
@@ -199,7 +199,7 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
                 _ => Clicked(p_elem, Left),
             }
         },
-        (Some(_), Highlighted(p_elem), Up, Down(_, _)) => {
+        (Some(_), Highlighted(p_elem), Up, Down(_)) => {
             match p_elem {
                 EnvPoint(idx, _) => Clicked(EnvPoint(idx, (mouse.xy[0], mouse.xy[1])), Right),
                 // CurvePoint(idx, _) => Clicked(CurvePoint(idx, (mouse.xy[0], mouse.xy[1])), Right),

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -178,11 +178,11 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
     use self::MouseButton::{Left, Right};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over_elem, prev, mouse.left.position, mouse.right.position) {
-        (Some(_), Normal, Down, Up) => Normal,
+        (Some(_), Normal, Down(_, _), Up) => Normal,
         (Some(elem), _, Up, Up) => Highlighted(elem),
-        (Some(elem), Highlighted(_), Down, Up) => Clicked(elem, Left),
-        (Some(_), Clicked(p_elem, m_button), Down, Up) |
-        (Some(_), Clicked(p_elem, m_button), Up, Down) => {
+        (Some(elem), Highlighted(_), Down(_, _), Up) => Clicked(elem, Left),
+        (Some(_), Clicked(p_elem, m_button), Down(_, _), Up) |
+        (Some(_), Clicked(p_elem, m_button), Up, Down(_, _)) => {
             match p_elem {
                 EnvPoint(idx, _) => Clicked(EnvPoint(idx, (mouse.xy[0], mouse.xy[1])), m_button),
                 // CurvePoint(idx, _) =>
@@ -190,7 +190,7 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
                 _ => Clicked(p_elem, m_button),
             }
         },
-        (None, Clicked(p_elem, m_button), Down, Up) => {
+        (None, Clicked(p_elem, m_button), Down(_, _), Up) => {
             match (p_elem, m_button) {
                 (EnvPoint(idx, _), Left) =>
                     Clicked(EnvPoint(idx, (mouse.xy[0], mouse.xy[1])), Left),
@@ -199,7 +199,7 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
                 _ => Clicked(p_elem, Left),
             }
         },
-        (Some(_), Highlighted(p_elem), Up, Down) => {
+        (Some(_), Highlighted(p_elem), Up, Down(_, _)) => {
             match p_elem {
                 EnvPoint(idx, _) => Clicked(EnvPoint(idx, (mouse.xy[0], mouse.xy[1])), Right),
                 // CurvePoint(idx, _) => Clicked(CurvePoint(idx, (mouse.xy[0], mouse.xy[1])), Right),

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -703,6 +703,8 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
     C: CharacterCache,
     W: Widget,
 {
+    use mouse::MouseButton;
+
     let kind = widget.unique_kind();
 
     // Take the previous state of the widget from the cache if there is some to collect.
@@ -834,7 +836,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
                 let maybe_mouse = ui::get_mouse_state(ui, idx);
                 match (prev.maybe_floating, maybe_mouse) {
                     (Some(prev_floating), Some(mouse)) => {
-                        if mouse.left.is_down() {
+                        if mouse.buttons.get(MouseButton::Left).is_down() {
                             Some(new_floating())
                         } else {
                             Some(prev_floating)

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -695,7 +695,7 @@ pub trait Widget: Sized {
 /// For all following occasions, the pre-existing cached state will be compared and updated.
 ///
 /// Note that this is a very imperative, mutation oriented segment of code. We try to move as much
-/// imperativeness and mutation out of the users hands and into this function as possible, so that 
+/// imperativeness and mutation out of the users hands and into this function as possible, so that
 /// users have a clear, consise, purely functional `Widget` API. As a result, we try to keep this
 /// as verbosely annotated as possible. If anything is unclear, feel free to post an issue or PR
 /// with concerns/improvements to the github repo.
@@ -834,7 +834,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
                 let maybe_mouse = ui::get_mouse_state(ui, idx);
                 match (prev.maybe_floating, maybe_mouse) {
                     (Some(prev_floating), Some(mouse)) => {
-                        if mouse.left.position == ::mouse::ButtonPosition::Down {
+                        if mouse.left.is_down() {
                             Some(new_floating())
                         } else {
                             Some(prev_floating)
@@ -1266,7 +1266,7 @@ impl<W> Sizeable for W where W: Widget {
 //         }
 //     };
 // }
-// 
+//
 // style_retrieval! {
 //     fn_name: color,
 //     member: maybe_color,

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1056,6 +1056,14 @@ impl<'a, C> UiCell<'a, C> {
         ui::keyboard_uncaptured_by(self.ui, self.idx)
     }
 
+    pub fn is_capturing_keyboard(&self) -> bool {
+        self.ui.is_capturing_keyboard(self.idx)
+    }
+
+    pub fn is_capturing_mouse(&self) -> bool {
+        self.ui.is_capturing_mouse(self.idx)
+    }
+
     /// Generate a new, unique NodeIndex into a Placeholder node within the `Ui`'s widget graph.
     /// This should only be called once for each unique widget needed to avoid unnecessary bloat
     /// within the `Ui`'s widget graph.

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1058,10 +1058,12 @@ impl<'a, C> UiCell<'a, C> {
         ui::keyboard_uncaptured_by(self.ui, self.idx)
     }
 
+    /// Returns true if the widget is currently capturing the keyboard
     pub fn is_capturing_keyboard(&self) -> bool {
         self.ui.is_capturing_keyboard(self.idx)
     }
 
+    /// Returns true if the widget is currently capturing the mouse
     pub fn is_capturing_mouse(&self) -> bool {
         self.ui.is_capturing_mouse(self.idx)
     }

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -189,16 +189,16 @@ fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mou
     use self::Elem::ValueGlyph;
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over_elem, prev, mouse.left.position) {
-        (Some(_),    Normal,          Down(_, _)) => Normal,
+        (Some(_),    Normal,          Down(_)) => Normal,
         (Some(elem), _,               Up)   => Highlighted(elem),
-        (Some(elem), Highlighted(_),  Down(_, _)) => Clicked(elem),
-        (Some(_),    Clicked(p_elem), Down(_, _)) => {
+        (Some(elem), Highlighted(_),  Down(_)) => Clicked(elem),
+        (Some(_),    Clicked(p_elem), Down(_)) => {
             match p_elem {
                 ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.xy[1])),
                 _                  => Clicked(p_elem),
             }
         },
-        (None,       Clicked(p_elem), Down(_, _)) => {
+        (None,       Clicked(p_elem), Down(_)) => {
             match p_elem {
                 ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.xy[1])),
                 _                  => Clicked(p_elem),

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -186,9 +186,10 @@ fn is_over(mouse_xy: Point,
 /// Check and return the current state of the NumberDialer.
 fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
+    use mouse::MouseButton::Left as LeftButton;
     use self::Elem::ValueGlyph;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over_elem, prev, mouse.left.position) {
+    match (is_over_elem, prev, mouse.buttons.get(LeftButton).position) {
         (Some(_),    Normal,          Down(_)) => Normal,
         (Some(elem), _,               Up)   => Highlighted(elem),
         (Some(elem), Highlighted(_),  Down(_)) => Clicked(elem),

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -189,16 +189,16 @@ fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mou
     use self::Elem::ValueGlyph;
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over_elem, prev, mouse.left.position) {
-        (Some(_),    Normal,          Down) => Normal,
+        (Some(_),    Normal,          Down(_, _)) => Normal,
         (Some(elem), _,               Up)   => Highlighted(elem),
-        (Some(elem), Highlighted(_),  Down) => Clicked(elem),
-        (Some(_),    Clicked(p_elem), Down) => {
+        (Some(elem), Highlighted(_),  Down(_, _)) => Clicked(elem),
+        (Some(_),    Clicked(p_elem), Down(_, _)) => {
             match p_elem {
                 ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.xy[1])),
                 _                  => Clicked(p_elem),
             }
         },
-        (None,       Clicked(p_elem), Down) => {
+        (None,       Clicked(p_elem), Down(_, _)) => {
             match p_elem {
                 ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.xy[1])),
                 _                  => Clicked(p_elem),
@@ -569,4 +569,3 @@ impl<'a, T, F> Labelable<'a> for NumberDialer<'a, T, F>
         self
     }
 }
-

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! Types and functionality related to the scrolling behaviour of widgets.
 //!
 
@@ -76,7 +76,7 @@ pub struct Bar {
 }
 
 
-/// The current interaction with the 
+/// The current interaction with the
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Interaction {
     /// No interaction with the Scrollbar.
@@ -155,7 +155,7 @@ impl State {
     /// Construct a new State.
     /// The `visible` rect corresponds to a Widget's `kid_area` aka the viewable container.
     /// The `kids` rect is the area *actually occupied* by the children widgets.
-    pub fn new(scrolling: Scrolling, 
+    pub fn new(scrolling: Scrolling,
                visible: Rect,
                kids: Rect,
                theme: &Theme,
@@ -476,11 +476,11 @@ fn new_interaction(bar: &Bar,
         use self::Elem::Handle;
         use mouse::ButtonPosition::{Down, Up};
         match (is_over_elem, bar.interaction, mouse.left.position) {
-            (Some(_),    Normal,             Down) => Normal,
+            (Some(_),    Normal,             Down(_, _)) => Normal,
             (Some(elem), _,                  Up)   => Highlighted(elem),
-            (Some(_),    Highlighted(_),     Down) |
-            (_,          Clicked(Handle(_)), Down) => Clicked(Handle(mouse_scalar)),
-            (_,          Clicked(elem),      Down) => Clicked(elem),
+            (Some(_),    Highlighted(_),     Down(_, _)) |
+            (_,          Clicked(Handle(_)), Down(_, _)) => Clicked(Handle(mouse_scalar)),
+            (_,          Clicked(elem),      Down(_, _)) => Clicked(elem),
             _                                      => Normal,
         }
     }
@@ -551,4 +551,3 @@ fn test_bar_new_no_scroll_rev_range() {
     let maybe_bar = Bar::new_if_scrollable(visible, kids, None);
     assert_eq!(maybe_bar, None);
 }
-

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -468,6 +468,7 @@ fn new_interaction(bar: &Bar,
                    mouse_scalar: Scalar) -> Interaction
 {
     use self::Interaction::{Normal, Highlighted, Clicked};
+    use mouse::MouseButton::Left as LeftButton;
 
     // If there's no need for a scroll bar, leave the interaction as `Normal`.
     if bar.scrollable.len() == 0.0 {
@@ -475,7 +476,9 @@ fn new_interaction(bar: &Bar,
     } else {
         use self::Elem::Handle;
         use mouse::ButtonPosition::{Down, Up};
-        match (is_over_elem, bar.interaction, mouse.left.position) {
+
+        let left_button_position = mouse.buttons.get(LeftButton).position;
+        match (is_over_elem, bar.interaction, left_button_position) {
             (Some(_),    Normal,             Down(_)) => Normal,
             (Some(elem), _,                  Up)   => Highlighted(elem),
             (Some(_),    Highlighted(_),     Down(_)) |

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -476,11 +476,11 @@ fn new_interaction(bar: &Bar,
         use self::Elem::Handle;
         use mouse::ButtonPosition::{Down, Up};
         match (is_over_elem, bar.interaction, mouse.left.position) {
-            (Some(_),    Normal,             Down(_, _)) => Normal,
+            (Some(_),    Normal,             Down(_)) => Normal,
             (Some(elem), _,                  Up)   => Highlighted(elem),
-            (Some(_),    Highlighted(_),     Down(_, _)) |
-            (_,          Clicked(Handle(_)), Down(_, _)) => Clicked(Handle(mouse_scalar)),
-            (_,          Clicked(elem),      Down(_, _)) => Clicked(elem),
+            (Some(_),    Highlighted(_),     Down(_)) |
+            (_,          Clicked(Handle(_)), Down(_)) => Clicked(Handle(mouse_scalar)),
+            (_,          Clicked(elem),      Down(_)) => Clicked(elem),
             _                                      => Normal,
         }
     }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -95,10 +95,10 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
+        (true,  Normal,  Down(_, _)) => Normal,
+        (true,  _,       Down(_, _)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down) => Clicked,
+        (false, Clicked, Down(_, _)) => Clicked,
         _ => Normal,
     }
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -95,10 +95,10 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down(_, _)) => Normal,
-        (true,  _,       Down(_, _)) => Clicked,
+        (true,  Normal,  Down(_)) => Normal,
+        (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down(_, _)) => Clicked,
+        (false, Clicked, Down(_)) => Clicked,
         _ => Normal,
     }
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -93,8 +93,10 @@ impl Interaction {
 /// Check the current state of the slider.
 fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
+    use mouse::MouseButton::Left as LeftButton;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left.position) {
+
+    match (is_over, prev, mouse.buttons.get(LeftButton).position) {
         (true,  Normal,  Down(_)) => Normal,
         (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -20,6 +20,7 @@ use {
     Theme,
 };
 
+use mouse::MouseButton;
 use input::keyboard::Key::{Backspace, Left, Right, Return, A, E, LCtrl, RCtrl};
 use vecmath::vec2_sub;
 use widget::{self, Widget, KidArea, UpdateArgs};
@@ -248,8 +249,9 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
     use self::Interaction::{Captured, Uncaptured};
     use self::Uncaptured::{Normal, Highlighted};
 
+    let left_button_state = mouse.buttons.get(MouseButton::Left);
     match prev_interaction {
-        Interaction::Captured(mut prev) => match mouse.left.position {
+        Interaction::Captured(mut prev) => match left_button_state.position {
             Down(_) => match over_elem {
                 Elem::Nill => if prev.cursor.anchor == Anchor::None {
                     Uncaptured(Normal)
@@ -277,7 +279,7 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
             },
         },
 
-        Interaction::Uncaptured(prev) => match mouse.left.position {
+        Interaction::Uncaptured(prev) => match left_button_state.position {
             Down(_) => match over_elem {
                 Elem::Nill => Uncaptured(Normal),
                 Elem::Rect => match prev {

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -425,12 +425,13 @@ fn get_highlight_all_interaction(text: &str) -> Interaction {
 fn get_new_interaction_2<C, F>(text: &str, args: &UpdateArgs<TextBox<F>, C>) -> Interaction
                                                             where C: CharacterCache,
                                                             F: FnMut(&mut String) {
+    use ::mouse::MouseButton;
+
     let maybe_mouse = args.ui.input().maybe_mouse;
-    let maybe_mouse_event = maybe_mouse.and_then(|mouse| mouse.get_simple_event());
+    let maybe_mouse_event = maybe_mouse.and_then(|mouse| mouse.buttons.get(MouseButton::Left).event);
 
     maybe_mouse_event.and_then(|event| {
         use ::mouse::simple_events::SimpleMouseEvent::{Click, Drag};
-        use ::mouse::MouseButton;
         match event {
             Click(click_info) if click_info.mouse_button == MouseButton::Left => {
                 let clicked_elem = get_clicked_elem(text, click_info.position, args);

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -18,12 +18,11 @@ use {
     Scalar,
     Text,
     Theme,
-    Widget,
 };
+
 use input::keyboard::Key::{Backspace, Left, Right, Return, A, E, LCtrl, RCtrl};
 use vecmath::vec2_sub;
-use widget::{self, Widget, KidArea, UpdateArgs, UiCell};
-use widget::{self, Widget, UpdateArgs};
+use widget::{self, Widget, KidArea, UpdateArgs};
 
 
 pub type Idx = usize;
@@ -357,7 +356,7 @@ fn get_clicked_elem<C, F>(text: &str, args: &UpdateArgs<TextBox<F>, C>) -> Elem
             let relative_mouse = mouse.relative_to(xy);
             let glyph_cache = args.ui.glyph_cache();
             let text_w = glyph_cache.width(font_size, text);
-            let text_x = position::align_left_of(inner_dimension[0], text_w) + TEXT_PADDING;
+            let text_x = text_w / 2.0 - inner_dimension[0] / 2.0 + TEXT_PADDING;
             let text_start_x = text_x - text_w / 2.0;
             over_elem(args.ui.glyph_cache(),
                 relative_mouse.xy,
@@ -389,21 +388,6 @@ fn get_new_interaction_2<C, F>(text: &str, args: &UpdateArgs<TextBox<F>, C>) -> 
             }
         },
         _ => args.ui.input().maybe_mouse.map(|_mouse| {
-fn get_new_interaction_2<C, F>(args: &UpdateArgs<TextBox<F>, C>) -> Interaction
-                            where C: CharacterCache,
-                            F: FnMut(&mut String) {
-    let capturing = args.ui.is_capturing_mouse() || args.ui.is_capturing_keyboard();
-    if capturing {
-        let state: &widget::State<State> = args.state;
-        let v: &State = state.view();
-        let prev_interaction: Interaction = v.interaction;
-        let new_view = match prev_interaction {
-            Interaction::Captured(view) => view,
-            _ => View{ cursor: Cursor::from_range(0, 999), offset: 0f64 }
-        };
-        Interaction::Captured(new_view)
-    } else {
-        args.ui.input().maybe_mouse.map(|mouse| {
             Interaction::Uncaptured(Uncaptured::Highlighted)
         }).unwrap_or(Interaction::Uncaptured(Uncaptured::Normal))
     }
@@ -460,12 +444,9 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
     /// Update the state of the TextBox.
     fn update<C: CharacterCache>(mut self, args: widget::UpdateArgs<Self, C>) {
         let mut new_interaction = get_new_interaction_2(&self.text, &args);
-        let widget::UpdateArgs { state, rect, style, mut ui, .. } = args;
-        let mut new_interaction = get_new_interaction_2(&args);
         let widget::UpdateArgs { idx, state, rect, style, mut ui, .. } = args;
 
         let (xy, dim) = rect.xy_dim();
-        // let maybe_mouse = ui.input().maybe_mouse.map(|mouse| mouse.relative_to(xy));
         let frame = style.frame(ui.theme());
         let inner_rect = rect.pad(frame);
         let font_size = style.font_size(ui.theme());

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -431,7 +431,7 @@ fn get_new_interaction_2<C, F>(text: &str, args: &UpdateArgs<TextBox<F>, C>) -> 
     let maybe_mouse_event = maybe_mouse.and_then(|mouse| mouse.buttons.get(MouseButton::Left).event);
 
     maybe_mouse_event.and_then(|event| {
-        use ::mouse::simple_events::SimpleMouseEvent::{Click, Drag};
+        use ::mouse::events::MouseEvent::{Click, Drag};
         match event {
             Click(click_info) if click_info.mouse_button == MouseButton::Left => {
                 let clicked_elem = get_clicked_elem(text, click_info.position, args);

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -428,7 +428,7 @@ fn get_new_interaction_2<C, F>(text: &str, args: &UpdateArgs<TextBox<F>, C>) -> 
 
     maybe_mouse_event.and_then(|event| {
         use ::mouse::simple_events::SimpleMouseEvent::{Click, Drag};
-        use ::mouse::simple_events::MouseButton;
+        use ::mouse::MouseButton;
         match event {
             Click(click_info) if click_info.mouse_button == MouseButton::Left => {
                 let clicked_elem = get_clicked_elem(text, click_info.position, args);

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -361,8 +361,12 @@ fn get_new_interaction<C, F>(text: &str, args: &UpdateArgs<TextBox<F>, C>) -> In
         .flat_map(|mouse| mouse.events())
         // map MouseEvent to an Option<Interaction>
         .filter_map(|event| {
-            use ::mouse::events::MouseEvent::{Click, Drag};
+            use ::mouse::events::MouseEvent::{Click, Down, Drag};
             match event {
+                Down(down_info) if down_info.mouse_button == MouseButton::Left => {
+                    let clicked_elem = get_clicked_elem(text, down_info.position, args);
+                    Some(get_interaction_for_click(text, clicked_elem))
+                },
                 Click(click_info) if click_info.mouse_button == MouseButton::Left => {
                     let clicked_elem = get_clicked_elem(text, click_info.position, args);
                     Some(get_interaction_for_click(text, clicked_elem))

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -250,7 +250,7 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
 
     match prev_interaction {
         Interaction::Captured(mut prev) => match mouse.left.position {
-            Down(_, _) => match over_elem {
+            Down(_) => match over_elem {
                 Elem::Nill => if prev.cursor.anchor == Anchor::None {
                     Uncaptured(Normal)
                 } else {
@@ -278,7 +278,7 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
         },
 
         Interaction::Uncaptured(prev) => match mouse.left.position {
-            Down(_, _) => match over_elem {
+            Down(_) => match over_elem {
                 Elem::Nill => Uncaptured(Normal),
                 Elem::Rect => match prev {
                     Normal => prev_interaction,

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -250,7 +250,7 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
 
     match prev_interaction {
         Interaction::Captured(mut prev) => match mouse.left.position {
-            Down => match over_elem {
+            Down(_, _) => match over_elem {
                 Elem::Nill => if prev.cursor.anchor == Anchor::None {
                     Uncaptured(Normal)
                 } else {
@@ -278,7 +278,7 @@ fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mo
         },
 
         Interaction::Uncaptured(prev) => match mouse.left.position {
-            Down => match over_elem {
+            Down(_, _) => match over_elem {
                 Elem::Nill => Uncaptured(Normal),
                 Elem::Rect => match prev {
                     Normal => prev_interaction,

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -84,10 +84,10 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
+        (true,  Normal,  Down(_, _)) => Normal,
+        (true,  _,       Down(_, _)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down) => Clicked,
+        (false, Clicked, Down(_, _)) => Clicked,
         _                      => Normal,
     }
 }
@@ -249,4 +249,3 @@ impl<'a, F> Labelable<'a> for TitleBar<'a, F> {
         self
     }
 }
-

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -84,10 +84,10 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down(_, _)) => Normal,
-        (true,  _,       Down(_, _)) => Clicked,
+        (true,  Normal,  Down(_)) => Normal,
+        (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down(_, _)) => Clicked,
+        (false, Clicked, Down(_)) => Clicked,
         _                      => Normal,
     }
 }

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -82,8 +82,10 @@ impl Style {
 /// Check the current state of the button.
 fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
+    use mouse::MouseButton::Left as LeftButton;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left.position) {
+
+    match (is_over, prev, mouse.buttons.get(LeftButton).position) {
         (true,  Normal,  Down(_)) => Normal,
         (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -87,8 +87,10 @@ fn get_new_interaction(is_over: bool,
                        prev: Interaction,
                        mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
+    use mouse::MouseButton::Left as LeftButton;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left.position) {
+
+    match (is_over, prev, mouse.buttons.get(LeftButton).position) {
         (true,  Normal,  Down(_)) => Normal,
         (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -89,10 +89,10 @@ fn get_new_interaction(is_over: bool,
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
+        (true,  Normal,  Down(_, _)) => Normal,
+        (true,  _,       Down(_, _)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down) => Clicked,
+        (false, Clicked, Down(_, _)) => Clicked,
         _                      => Normal,
     }
 }
@@ -321,4 +321,3 @@ impl<'a, F> Labelable<'a> for Toggle<'a, F> {
         self
     }
 }
-

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -89,10 +89,10 @@ fn get_new_interaction(is_over: bool,
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down(_, _)) => Normal,
-        (true,  _,       Down(_, _)) => Clicked,
+        (true,  Normal,  Down(_)) => Normal,
+        (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down(_, _)) => Clicked,
+        (false, Clicked, Down(_)) => Clicked,
         _                      => Normal,
     }
 }

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -96,8 +96,10 @@ fn get_new_interaction(is_over: bool,
                        prev: Interaction,
                        mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
+    use mouse::MouseButton::Left as LeftButton;
     use self::Interaction::{Normal, Highlighted, Clicked};
-    match (is_over, prev, mouse.left.position) {
+
+    match (is_over, prev, mouse.buttons.get(LeftButton).position) {
         (true,  Normal,  Down(_)) => Normal,
         (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -98,10 +98,10 @@ fn get_new_interaction(is_over: bool,
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down(_, _)) => Normal,
-        (true,  _,       Down(_, _)) => Clicked,
+        (true,  Normal,  Down(_)) => Normal,
+        (true,  _,       Down(_)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down(_, _)) => Clicked,
+        (false, Clicked, Down(_)) => Clicked,
         _                      => Normal,
     }
 }

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -98,10 +98,10 @@ fn get_new_interaction(is_over: bool,
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
+        (true,  Normal,  Down(_, _)) => Normal,
+        (true,  _,       Down(_, _)) => Clicked,
         (true,  _,       Up)   => Highlighted,
-        (false, Clicked, Down) => Clicked,
+        (false, Clicked, Down(_, _)) => Clicked,
         _                      => Normal,
     }
 }
@@ -458,4 +458,3 @@ impl<'a, X, Y, F> Labelable<'a> for XYPad<'a, X, Y, F>
         self
     }
 }
-


### PR DESCRIPTION
This is the beginning of refactoring mouse input handling. The basic idea here is to simplify how widgets handle mouse input in most cases. A new mouse::events module was added that provides higher level event abstractions over low-level mouse events. Widgets can just call `Mouse::events()`, which returns an iterator over `MouseEvent`s. MouseEvents are simple things like Click, Drag, or Scroll. 

Part of the goal here is to obviate the need for widgets to 'capture' the mouse, except in a few rare cases. Turns out, having widgets making calls to capture/uncapture inputs makes it really difficult to add methods to the Ui that control which widgets take focus. Tabbing between text boxes, as well as having external sources capture inputs should get a lot easier once actually capturing input becomes unnecessary in most cases.

There is one breaking change here. Previously, the `Mouse` struct had four fields for it's buttons: `left`, `right`, `middle`, and `unknown`. I changed that to instead use a `ButtonMap`, which maps `input::MouseButton` enums to `ButtonState` structs. Where before, one could call `mouse.left` to get the state of the left mouse button, now you would call `mouse.buttons.get(MouseButton::Left)`. This seems a little more verbose, but it allows for all the mouse buttons to work and makes for some cleaner code when updating the state of the mouse. 

I refactored the TextBox widget to use the new mouse events. The rest of the widgets should follow shortly. I made sure to leave all the other state of the mouse visible. Eventually, we can talk about cleaning up some of the fields on `ButtonState`, but that's a discussion for after all the existing widgets are updated to use the new events. 
