### PR TITLE
Draw optimisation. Range::overlap bug fix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.29.1"
+version = "0.30.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "./src/lib.rs"
 
 
 [dependencies]
-daggy = "0.3.0"
+daggy = "0.4.0"
 pistoncore-input = "0.8.0"
 piston2d-graphics = "0.13.0"
 num = "0.1.27"

--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -53,7 +53,7 @@ pub fn draw_from_graph<G, C>(context: Context,
     // here.
     let is_visible = |idx: NodeIndex, container: &Container| -> bool {
         container.rect.overlap(window.rect).is_some()
-        && graph::algo::visible_area_of_widget(graph, idx).is_some()
+        && graph::algo::cropped_area_of_widget(graph, idx).is_some()
     };
 
     // The depth order describes the order in which widgets should be drawn.

--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -38,6 +38,12 @@ pub fn draw_from_graph<G, C>(context: Context,
     // (perhaps owned by the Ui) for this.
     let mut scroll_stack: Vec<Context> = Vec::new();
 
+    // Retrieve the core window widget so that we can use it to filter visible widgets.
+    let window = match graph.widget(::graph::NodeIndex::new(0)){
+        Some(window) => window,
+        None => return,
+    };
+
     // The depth order describes the order in which widgets should be drawn.
     for &visitable in depth_order {
         match visitable {
@@ -48,8 +54,10 @@ pub fn draw_from_graph<G, C>(context: Context,
                     // Check the stack for the current Context.
                     let context = *scroll_stack.last().unwrap_or(&context);
 
-                    // Draw the widget from its container.
-                    draw_from_container(&context, graphics, character_cache, container, theme);
+                    if container.rect.overlap(window.rect).is_some() {
+                        // Draw the widget from its container.
+                        draw_from_container(&context, graphics, character_cache, container, theme);
+                    }
 
                     // If the current widget is some scrollable widget, we need to add a context
                     // for it to the top of the stack.

--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -9,7 +9,7 @@
 
 
 use ::{Color, Point, Rect, Scalar};
-use graph::{Container, Graph, Visitable};
+use graph::{self, Container, Graph, NodeIndex, Visitable};
 use graphics;
 use std::iter::once;
 use theme::Theme;
@@ -39,9 +39,21 @@ pub fn draw_from_graph<G, C>(context: Context,
     let mut scroll_stack: Vec<Context> = Vec::new();
 
     // Retrieve the core window widget so that we can use it to filter visible widgets.
-    let window = match graph.widget(::graph::NodeIndex::new(0)){
+    let window_idx = NodeIndex::new(0);
+    let window = match graph.widget(window_idx){
         Some(window) => window,
+        // If we don't yet have the window widget, we won't have *any* widgets, so bail out.
         None => return,
+    };
+
+    // A function for checking whether or not a widget would be visible.
+    //
+    // TODO: Refactor this into a `visible_area_of_widget` graph algo. Also, consider calculating
+    // the visible area during the `set_widgets` stage, as it might be more optimal than doing so
+    // here.
+    let is_visible = |idx: NodeIndex, container: &Container| -> bool {
+        container.rect.overlap(window.rect).is_some()
+        && graph::algo::visible_area_of_widget(graph, idx).is_some()
     };
 
     // The depth order describes the order in which widgets should be drawn.
@@ -54,8 +66,8 @@ pub fn draw_from_graph<G, C>(context: Context,
                     // Check the stack for the current Context.
                     let context = *scroll_stack.last().unwrap_or(&context);
 
-                    if container.rect.overlap(window.rect).is_some() {
-                        // Draw the widget from its container.
+                    // Draw the widget, but only if it would actually be visible on the window.
+                    if is_visible(idx, container) {
                         draw_from_container(&context, graphics, character_cache, container, theme);
                     }
 

--- a/src/position/range.rs
+++ b/src/position/range.rs
@@ -226,7 +226,12 @@ impl Range {
 
     /// The Range that represents the range of the overlap between two Ranges if there is some.
     ///
-    /// The returned Range's `start` will always be <= its `end`.
+    /// Note that If one end of `self` aligns exactly with the opposite end of `other`, `Some`
+    /// `Range` will be returned with a magnitude of `0.0`. This is useful for algorithms that
+    /// involve calculating the visibility of widgets, as it allows for including widgets whose
+    /// bounding box may be a one dimensional straight line.
+    ///
+    /// The returned `Range`'s `start` will always be <= its `end`.
     ///
     /// # Examples
     ///
@@ -251,7 +256,7 @@ impl Range {
         let start = ::utils::partial_max(self.start, other.start);
         let end = ::utils::partial_min(self.end, other.end);
         let magnitude = end - start;
-        if magnitude > 0.0 {
+        if magnitude >= 0.0 {
             Some(Range::new(start, end))
         } else {
             None


### PR DESCRIPTION
This removes a several bottlenecks I was running into in a personal project, mentioned in #664:

1. Only draw widgets if they're within the window.
2. Only draw widgets if they're not cropped out.
3. Update to latest daggy version with optimised `add_edge` method.

This PR also bumps the version in order to publish the recent graph::algo::visible_area_of_widget -> cropped_area_of_widget function name change.