### PR TITLE
Add `widget_style!` macro for vastly simplifying widget Style struct definitions and implementations.

### DIFF
--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -214,13 +214,13 @@ pub fn draw_from_container<G, C>(context: &Context,
 
         primitive::shape::framed_rectangle::KIND => {
             if let Some(framed_rectangle) = container.unique_widget_state::<::FramedRectangle>() {
-                let frame = framed_rectangle.style.get_frame(theme);
+                let frame = framed_rectangle.style.frame(theme);
                 if frame > 0.0 {
-                    let frame_color = framed_rectangle.style.get_frame_color(theme);
+                    let frame_color = framed_rectangle.style.frame_color(theme);
                     let frame_rect = container.rect;
                     draw_rectangle(context, graphics, frame_rect, frame_color);
                 }
-                let color = framed_rectangle.style.get_color(theme);
+                let color = framed_rectangle.style.color(theme);
                 let rect = container.rect.pad(frame);
                 draw_rectangle(context, graphics, rect, color);
             }

--- a/src/color.rs
+++ b/src/color.rs
@@ -14,11 +14,6 @@
 use std::f32::consts::PI;
 use utils::{degrees, fmod, turns};
 
-macro_rules! make_color {
-	($r:expr, $g:expr, $b:expr) => ( Color::Rgba($r as f32 / 255.0, $g as f32 / 255.0, $b as f32 / 255.0, 1.0));
-	($r:expr, $g:expr, $b:expr, $a:expr) => ( Color::Rgba($r as f32 / 255.0, $g as f32 / 255.0, $b as f32 / 255.0, $a as f32 / 255.0));
-}
-
 /// Color supporting RGB and HSL variants.
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum Color {
@@ -370,6 +365,11 @@ pub fn radial(start: (f64, f64), start_r: f64,
 /// [Tango palette](http://tango.freedesktop.org/Tango_Icon_Theme_Guidelines) which provides
 /// aesthetically reasonable defaults for colors. Each color also comes with a light and dark
 /// version.
+
+macro_rules! make_color {
+	($r:expr, $g:expr, $b:expr) => ( Color::Rgba($r as f32 / 255.0, $g as f32 / 255.0, $b as f32 / 255.0, 1.0));
+	($r:expr, $g:expr, $b:expr, $a:expr) => ( Color::Rgba($r as f32 / 255.0, $g as f32 / 255.0, $b as f32 / 255.0, $a as f32 / 255.0));
+}
 
 /// Scarlet Red - Light - #EF2929                         
 pub const LIGHT_RED      :  Color = make_color!(239, 41, 41);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use widget::primitive::shape::framed_rectangle::FramedRectangle;
 pub use widget::primitive::shape::polygon::Polygon;
 pub use widget::primitive::shape::oval::Oval;
 pub use widget::primitive::shape::rectangle::Rectangle;
-pub use widget::primitive::text::Text;
+pub use widget::primitive::text::{Text, Wrap as TextWrap};
 
 pub use widget::button::Button;
 pub use widget::canvas::Canvas;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -94,7 +94,7 @@ impl Theme {
 
     /// Retrieve the unique default styling for a widget.
     ///
-    /// Attempts to cast the `Box<WidgetStyle>` to the **Widget**'s unique style **T**.
+    /// Attempts to cast the `Box<WidgetStyle>` to the **Widget**'s unique associated style **T**.
     pub fn widget_style<T>(&self, kind: &'static str) -> Option<UniqueDefault<T>>
         where T: widget::Style,
     {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -10,8 +10,8 @@ use {
     Labelable,
     Mouse,
     Positionable,
+    Scalar,
     Text,
-    Theme,
     Widget,
 };
 use widget;
@@ -27,19 +27,24 @@ pub struct Button<'a, F> {
     enabled: bool,
 }
 
-/// Styling for the Button, necessary for constructing its renderable Element.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Color of the Button's pressable area.
-    pub maybe_color: Option<Color>,
-    /// Width of the frame surrounding the button
-    pub maybe_frame: Option<f64>,
-    /// The color of the frame.
-    pub maybe_frame_color: Option<Color>,
-    /// The color of the Button's label.
-    pub maybe_label_color: Option<Color>,
-    /// The font size of the Button's label.
-    pub maybe_label_font_size: Option<u32>,
+/// Unique kind for the widget.
+pub const KIND: widget::Kind = "Button";
+
+widget_style!{
+    KIND;
+    /// Unique styling for the Button.
+    style Style {
+        /// Color of the Button's pressable area.
+        - color: Color { theme.shape_color },
+        /// Width of the frame surrounding the button
+        - frame: Scalar { theme.frame_width },
+        /// The color of the frame.
+        - frame_color: Color { theme.frame_color },
+        /// The color of the Button's label.
+        - label_color: Color { theme.label_color },
+        /// The font size of the Button's label.
+        - label_font_size: FontSize { theme.font_size_medium },
+    }
 }
 
 /// Represents the state of the Button widget.
@@ -49,9 +54,6 @@ pub struct State {
     label_idx: IndexSlot,
     interaction: Interaction,
 }
-
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "Button";
 
 /// Represents an interaction with the Button widget.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -91,7 +93,7 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
 impl<'a, F> Button<'a, F> {
 
     /// Create a button context to be built upon.
-    pub fn new() -> Button<'a, F> {
+    pub fn new() -> Self {
         Button {
             common: widget::CommonBuilder::new(),
             maybe_react: None,
@@ -213,71 +215,21 @@ impl<'a, F> Widget for Button<'a, F>
 
 }
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_label_color: None,
-            maybe_label_font_size: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label Color for an Element.
-    pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn label_font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
-    }
-
-}
-
 
 impl<'a, F> Colorable for Button<'a, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, F> Frameable for Button<'a, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -289,12 +241,12 @@ impl<'a, F> Labelable<'a> for Button<'a, F> {
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
+        self.style.label_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
+        self.style.label_font_size = Some(size);
         self
     }
 }

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -452,8 +452,8 @@ impl Style {
     /// Get the color for the Canvas' Element.
     pub fn color(&self, theme: &Theme) -> Color {
         self.framed_rectangle.maybe_color
-            .or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-                default.style.framed_rectangle.maybe_color.unwrap_or(theme.background_color)
+            .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
+                default.style.framed_rectangle.maybe_color
             }))
             .unwrap_or(theme.background_color)
     }
@@ -461,8 +461,8 @@ impl Style {
     /// Get the frame for an Element.
     pub fn frame(&self, theme: &Theme) -> f64 {
         self.framed_rectangle.maybe_frame
-            .or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-                default.style.framed_rectangle.maybe_frame.unwrap_or(theme.frame_width)
+            .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
+                default.style.framed_rectangle.maybe_frame
             }))
             .unwrap_or(theme.frame_width)
     }
@@ -470,8 +470,8 @@ impl Style {
     /// Get the frame Color for an Element.
     pub fn frame_color(&self, theme: &Theme) -> Color {
         self.framed_rectangle.maybe_frame_color
-            .or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-                default.style.framed_rectangle.maybe_frame_color.unwrap_or(theme.frame_color)
+            .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
+                default.style.framed_rectangle.maybe_frame_color
             }))
             .unwrap_or(theme.frame_color)
     }
@@ -479,8 +479,8 @@ impl Style {
     /// Get the font size of the title bar.
     pub fn title_bar_font_size(&self, theme: &Theme) -> FontSize {
         self.text.maybe_font_size
-            .or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-                default.style.text.maybe_font_size.unwrap_or(theme.font_size_medium)
+            .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
+                default.style.text.maybe_font_size
             }))
             .unwrap_or(theme.font_size_medium)
     }
@@ -515,19 +515,19 @@ impl Style {
         let default_style = theme.widget_style::<Style>(KIND);
         position::Padding {
             x: Range {
-                start: self.padding.maybe_left.or_else(|| default_style.as_ref().map(|default| {
-                    default.style.padding.maybe_left.unwrap_or(theme.padding.x.start)
+                start: self.padding.maybe_left.or_else(|| default_style.as_ref().and_then(|default| {
+                    default.style.padding.maybe_left
                 })).unwrap_or(theme.padding.x.start),
-                end: self.padding.maybe_right.or_else(|| default_style.as_ref().map(|default| {
-                    default.style.padding.maybe_right.unwrap_or(theme.padding.x.end)
+                end: self.padding.maybe_right.or_else(|| default_style.as_ref().and_then(|default| {
+                    default.style.padding.maybe_right
                 })).unwrap_or(theme.padding.x.end),
             },
             y: Range {
-                start: self.padding.maybe_bottom.or_else(|| default_style.as_ref().map(|default| {
-                    default.style.padding.maybe_bottom.unwrap_or(theme.padding.y.start)
+                start: self.padding.maybe_bottom.or_else(|| default_style.as_ref().and_then(|default| {
+                    default.style.padding.maybe_bottom
                 })).unwrap_or(theme.padding.y.start),
-                end: self.padding.maybe_top.or_else(|| default_style.as_ref().map(|default| {
-                    default.style.padding.maybe_top.unwrap_or(theme.padding.y.end)
+                end: self.padding.maybe_top.or_else(|| default_style.as_ref().and_then(|default| {
+                    default.style.padding.maybe_top
                 })).unwrap_or(theme.padding.y.end),
             },
         }

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -451,36 +451,36 @@ impl Style {
 
     /// Get the color for the Canvas' Element.
     pub fn color(&self, theme: &Theme) -> Color {
-        self.framed_rectangle.maybe_color
+        self.framed_rectangle.color
             .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
-                default.style.framed_rectangle.maybe_color
+                default.style.framed_rectangle.color
             }))
             .unwrap_or(theme.background_color)
     }
 
     /// Get the frame for an Element.
     pub fn frame(&self, theme: &Theme) -> f64 {
-        self.framed_rectangle.maybe_frame
+        self.framed_rectangle.frame
             .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
-                default.style.framed_rectangle.maybe_frame
+                default.style.framed_rectangle.frame
             }))
             .unwrap_or(theme.frame_width)
     }
 
     /// Get the frame Color for an Element.
     pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.framed_rectangle.maybe_frame_color
+        self.framed_rectangle.frame_color
             .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
-                default.style.framed_rectangle.maybe_frame_color
+                default.style.framed_rectangle.frame_color
             }))
             .unwrap_or(theme.frame_color)
     }
 
     /// Get the font size of the title bar.
     pub fn title_bar_font_size(&self, theme: &Theme) -> FontSize {
-        self.text.maybe_font_size
+        self.text.font_size
             .or_else(|| theme.widget_style::<Style>(KIND).and_then(|default| {
-                default.style.text.maybe_font_size
+                default.style.text.font_size
             }))
             .unwrap_or(theme.font_size_medium)
     }
@@ -503,9 +503,9 @@ impl Style {
 
     /// Get the color of the title bar label.
     pub fn title_bar_label_color(&self, theme: &Theme) -> Color {
-        self.text.maybe_color
+        self.text.color
             .or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-                default.style.text.maybe_color.unwrap_or(theme.label_color)
+                default.style.text.color.unwrap_or(theme.label_color)
             }))
             .unwrap_or(theme.label_color)
     }
@@ -538,18 +538,18 @@ impl Style {
 
 impl<'a> ::color::Colorable for Canvas<'a> {
     fn color(mut self, color: Color) -> Self {
-        self.style.framed_rectangle.maybe_color = Some(color);
+        self.style.framed_rectangle.color = Some(color);
         self
     }
 }
 
 impl<'a> ::frame::Frameable for Canvas<'a> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.framed_rectangle.maybe_frame = Some(width);
+        self.style.framed_rectangle.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.framed_rectangle.maybe_frame_color = Some(color);
+        self.style.framed_rectangle.frame_color = Some(color);
         self
     }
 }
@@ -559,11 +559,11 @@ impl<'a> ::label::Labelable<'a> for Canvas<'a> {
         self.title_bar(text)
     }
     fn label_color(mut self, color: Color) -> Self {
-        self.style.text.maybe_color = Some(color);
+        self.style.text.color = Some(color);
         self
     }
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.text.maybe_font_size = Some(size);
+        self.style.text.font_size = Some(size);
         self
     }
 }

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -19,7 +19,6 @@ use {
     Scalar,
     Sizeable,
     Text,
-    Theme,
     Widget,
 };
 use num::Float;
@@ -47,25 +46,30 @@ pub struct EnvelopeEditor<'a, E:'a, F> where E: EnvelopePoint {
     enabled: bool,
 }
 
-/// Styling for the EnvelopeEditor, necessary for constructing its renderable Element.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Coloring for the EnvelopeEditor's **FramedRectangle**.
-    pub maybe_color: Option<Color>,
-    /// Thickness of the **FramedRectangle**'s frame.
-    pub maybe_frame: Option<f64>,
-    /// Color of the frame.
-    pub maybe_frame_color: Option<Color>,
-    /// Color of the label.
-    pub maybe_label_color: Option<Color>,
-    /// The font size of the **EnvelopeEditor**'s label if one was given.
-    pub maybe_label_font_size: Option<FontSize>,
-    /// The font size of the value label.
-    pub maybe_value_font_size: Option<FontSize>,
-    /// The radius of the envelope points.
-    pub maybe_point_radius: Option<f64>,
-    /// The thickness of the envelope lines.
-    pub maybe_line_thickness: Option<f64>,
+/// Unique kind for the widget.
+pub const KIND: widget::Kind = "EnvelopeEditor";
+
+widget_style!{
+    KIND;
+    /// Styling for the EnvelopeEditor, necessary for constructing its renderable Element.
+    style Style {
+        /// Coloring for the EnvelopeEditor's **FramedRectangle**.
+        - color: Color { theme.shape_color },
+        /// Thickness of the **FramedRectangle**'s frame.
+        - frame: f64 { theme.frame_width },
+        /// Color of the frame.
+        - frame_color: Color { theme.frame_color },
+        /// Color of the label.
+        - label_color: Color { theme.label_color },
+        /// The font size of the **EnvelopeEditor**'s label if one was given.
+        - label_font_size: FontSize { theme.font_size_medium },
+        /// The font size of the value label.
+        - value_font_size: FontSize { 14 },
+        /// The radius of the envelope points.
+        - point_radius: Scalar { 6.0 },
+        /// The thickness of the envelope lines.
+        - line_thickness: Scalar { 2.0 },
+    }
 }
 
 /// Represents the state of the EnvelopeEditor widget.
@@ -84,9 +88,6 @@ pub struct State<E> where E: EnvelopePoint {
     point_path_idx: IndexSlot,
     point_indices: Vec<NodeIndex>,
 }
-
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "EnvelopeEditor";
 
 /// Describes an interaction with the EnvelopeEditor.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -216,21 +217,21 @@ impl<'a, E, F> EnvelopeEditor<'a, E, F> where E: EnvelopePoint {
     /// Set the radius of the envelope point circle.
     #[inline]
     pub fn point_radius(mut self, radius: f64) -> EnvelopeEditor<'a, E, F> {
-        self.style.maybe_point_radius = Some(radius);
+        self.style.point_radius = Some(radius);
         self
     }
 
     /// Set the width of the envelope lines.
     #[inline]
     pub fn line_thickness(mut self, width: f64) -> EnvelopeEditor<'a, E, F> {
-        self.style.maybe_line_thickness = Some(width);
+        self.style.line_thickness = Some(width);
         self
     }
 
     /// Set the font size for the displayed values.
     #[inline]
     pub fn value_font_size(mut self, size: FontSize) -> EnvelopeEditor<'a, E, F> {
-        self.style.maybe_value_font_size = Some(size);
+        self.style.value_font_size = Some(size);
         self
     }
 
@@ -696,90 +697,12 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
 }
 
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_label_color: None,
-            maybe_label_font_size: None,
-            maybe_value_font_size: None,
-            maybe_point_radius: None,
-            maybe_line_thickness: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label Color for an Element.
-    pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn label_font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
-    }
-
-    /// Get the value font size for an Element.
-    pub fn value_font_size(&self, theme: &Theme) -> FontSize {
-        const DEFAULT_VALUE_FONT_SIZE: u32 = 14;
-        self.maybe_value_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_value_font_size.unwrap_or(DEFAULT_VALUE_FONT_SIZE)
-        })).unwrap_or(DEFAULT_VALUE_FONT_SIZE)
-    }
-
-    /// Get the point radius size for an Element.
-    pub fn point_radius(&self, theme: &Theme) -> f64 {
-        const DEFAULT_POINT_RADIUS: f64 = 6.0;
-        self.maybe_point_radius.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_point_radius.unwrap_or(DEFAULT_POINT_RADIUS)
-        })).unwrap_or(DEFAULT_POINT_RADIUS)
-    }
-
-    /// Get the point radius size for an Element.
-    pub fn line_thickness(&self, theme: &Theme) -> f64 {
-        const DEFAULT_LINE_THICKNESS: f64 = 2.0;
-        self.maybe_line_thickness.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_line_thickness.unwrap_or(DEFAULT_LINE_THICKNESS)
-        })).unwrap_or(DEFAULT_LINE_THICKNESS)
-    }
-
-}
-
-
 impl<'a, E, F> Colorable for EnvelopeEditor<'a, E, F>
     where
         E: EnvelopePoint
 {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
@@ -789,11 +712,11 @@ impl<'a, E, F> Frameable for EnvelopeEditor<'a, E, F>
         E: EnvelopePoint
 {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -808,12 +731,12 @@ impl<'a, E, F> Labelable<'a> for EnvelopeEditor<'a, E, F>
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
+        self.style.label_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
+        self.style.label_font_size = Some(size);
         self
     }
 }

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -1,5 +1,5 @@
 
-use {CharacterCache, NodeIndex, Scalar, Theme, Widget};
+use {CharacterCache, NodeIndex, Scalar, Widget};
 use widget;
 
 
@@ -33,17 +33,19 @@ pub struct State {
     indices: Vec<Vec<NodeIndex>>,
 }
 
-/// Unique styling for the `Matrix`.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// The width of the padding for each matrix element's "cell".
-    maybe_cell_pad_w: Option<Scalar>,
-    /// The height of the padding for each matrix element's "cell".
-    maybe_cell_pad_h: Option<Scalar>,
-}
-
 /// Unique kind for the widget.
 pub const KIND: &'static str = "WidgetMatrix";
+
+widget_style!{
+    KIND;
+    /// Unique styling for the `Matrix`.
+    style Style {
+        /// The width of the padding for each matrix element's "cell".
+        - cell_pad_w: Scalar { 0.0 },
+        /// The height of the padding for each matrix element's "cell".
+        - cell_pad_h: Scalar { 0.0 },
+    }
+}
 
 impl<F> Matrix<F> {
 
@@ -70,8 +72,8 @@ impl<F> Matrix<F> {
 
     /// A builder method for adding padding to the cell.
     pub fn cell_padding(mut self, w: Scalar, h: Scalar) -> Matrix<F> {
-        self.style.maybe_cell_pad_w = Some(w);
-        self.style.maybe_cell_pad_h = Some(h);
+        self.style.cell_pad_w = Some(w);
+        self.style.cell_pad_h = Some(h);
         self
     }
 
@@ -175,35 +177,6 @@ impl<'a, F, W> Widget for Matrix<F> where
         if let Some(new_indices) = maybe_new_indices {
             state.update(|state| state.indices = new_indices);
         }
-    }
-
-}
-
-
-impl Style {
-
-    /// Constructor for a new default Matrix Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_cell_pad_w: None,
-            maybe_cell_pad_h: None,
-        }
-    }
-
-    /// Get the width of the padding for each matrix element's cell.
-    pub fn cell_pad_w(&self, theme: &Theme) -> Scalar {
-        const DEFAULT_CELL_PAD_W: Scalar = 0.0;
-        self.maybe_cell_pad_w.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_cell_pad_w.unwrap_or(DEFAULT_CELL_PAD_W)
-        })).unwrap_or(DEFAULT_CELL_PAD_W)
-    }
-
-    /// Get the height of the padding for each matrix element's cell.
-    pub fn cell_pad_h(&self, theme: &Theme) -> Scalar {
-        const DEFAULT_CELL_PAD_H: Scalar = 0.0;
-        self.maybe_cell_pad_h.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_cell_pad_h.unwrap_or(DEFAULT_CELL_PAD_H)
-        })).unwrap_or(DEFAULT_CELL_PAD_H)
     }
 
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -10,6 +10,9 @@ use ui::{self, Ui, UserInput};
 pub use self::id::Id;
 pub use self::index::Index;
 
+#[macro_use]
+pub mod style;
+
 pub mod drag;
 mod id;
 mod index;

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -14,9 +14,9 @@ use {
     Point,
     Positionable,
     Rectangle,
+    Scalar,
     Sizeable,
     Text,
-    Theme,
     Widget,
 };
 use num::{Float, NumCast};
@@ -43,23 +43,25 @@ pub struct NumberDialer<'a, T, F> {
     enabled: bool,
 }
 
-/// Styling for the NumberDialer, necessary for constructing its renderable Element.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Color of the NumberDialer's rectangle.
-    pub maybe_color: Option<Color>,
-    /// The frame around the NumberDialer's rectangle.
-    pub maybe_frame: Option<f64>,
-    /// The color of the rectangle frame.
-    pub maybe_frame_color: Option<Color>,
-    /// The color of the NumberDialer's label.
-    pub maybe_label_color: Option<Color>,
-    /// The font size for the NumberDialer's label.
-    pub maybe_label_font_size: Option<u32>,
-}
-
 /// Unique kind for the widget.
 pub const KIND: widget::Kind = "NumberDialer";
+
+widget_style!{
+    KIND;
+    /// Unique graphical styling for the NumberDialer.
+    style Style {
+        /// Color of the NumberDialer's rectangle.
+        - color: Color { theme.shape_color },
+        /// The color of the rectangle frame.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the rectangle frame.
+        - frame_color: Color { theme.frame_color },
+        /// The color of the NumberDialer's label.
+        - label_color: Color { theme.label_color },
+        /// The font size for the NumberDialer's label.
+        - label_font_size: FontSize { theme.font_size_medium }
+    }
+}
 
 /// Represents the specific elements that the NumberDialer is made up of. This is used to specify
 /// which element is Highlighted or Clicked when storing State.
@@ -483,71 +485,20 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
 }
 
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_label_color: None,
-            maybe_label_font_size: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label Color for an Element.
-    pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn label_font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
-    }
-
-}
-
-
 impl<'a, T, F> Colorable for NumberDialer<'a, T, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, T, F> Frameable for NumberDialer<'a, T, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -560,12 +511,12 @@ impl<'a, T, F> Labelable<'a> for NumberDialer<'a, T, F>
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
+        self.style.label_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
+        self.style.label_font_size = Some(size);
         self
     }
 }

--- a/src/widget/primitive/shape/framed_rectangle.rs
+++ b/src/widget/primitive/shape/framed_rectangle.rs
@@ -6,7 +6,6 @@ use {
     Frameable,
     Scalar,
     Sizeable,
-    Theme,
     Widget,
 };
 use widget;
@@ -21,20 +20,21 @@ pub struct FramedRectangle {
     pub style: Style,
 }
 
-
-/// Unique styling for the **FramedRectangle** widget.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Shape styling for the inner rectangle.
-    pub maybe_color: Option<Color>,
-    /// The thickness of the frame.
-    pub maybe_frame: Option<Scalar>,
-    /// The color of the frame.
-    pub maybe_frame_color: Option<Color>,
-}
-
 /// Unique kind for the Widget.
 pub const KIND: widget::Kind = "FramedRectangle";
+
+widget_style!{
+    KIND;
+    /// Unique styling for the **FramedRectangle** widget.
+    style Style {
+        /// Shape styling for the inner rectangle.
+        - color: Color { theme.shape_color },
+        /// The thickness of the frame.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the frame.
+        - frame_color: Color { theme.frame_color },
+    }
+}
 
 impl FramedRectangle {
 
@@ -87,40 +87,9 @@ impl Widget for FramedRectangle {
 }
 
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn get_color(&self, theme: &Theme) -> Color {
-        self.maybe_color.unwrap_or_else(|| theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn get_frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.unwrap_or_else(|| theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn get_frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.unwrap_or_else(|| theme.frame_color)
-    }
-
-}
-
-
-
-
 impl Colorable for FramedRectangle {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
@@ -128,11 +97,11 @@ impl Colorable for FramedRectangle {
 
 impl Frameable for FramedRectangle {
     fn frame(mut self, width: Scalar) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -16,7 +16,6 @@ use {
     Rectangle,
     Scalar,
     Text,
-    Theme,
     Widget,
 };
 use num::{Float, NumCast, ToPrimitive};
@@ -39,19 +38,21 @@ pub struct Slider<'a, T, F> {
     enabled: bool,
 }
 
-/// Styling for the Slider, necessary for constructing its renderable Element.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// The color of the slidable rectangle.
-    pub maybe_color: Option<Color>,
-    /// The length of the frame around the edges of the slidable rectangle.
-    pub maybe_frame: Option<Scalar>,
-    /// The color of the Slider's frame.
-    pub maybe_frame_color: Option<Color>,
-    /// The color of the Slider's label.
-    pub maybe_label_color: Option<Color>,
-    /// The font-size for the Slider's label.
-    pub maybe_label_font_size: Option<u32>,
+widget_style!{
+    KIND;
+    /// Graphical styling unique to the Slider widget.
+    style Style {
+        /// The color of the slidable rectangle.
+        - color: Color { theme.shape_color },
+        /// The length of the frame around the edges of the slidable rectangle.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the Slider's frame.
+        - frame_color: Color { theme.frame_color },
+        /// The color of the Slider's label.
+        - label_color: Color { theme.label_color },
+        /// The font-size for the Slider's label.
+        - label_font_size: FontSize { theme.font_size_medium }
+    }
 }
 
 /// Represents the state of the Slider widget.
@@ -350,71 +351,20 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
 }
 
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_label_color: None,
-            maybe_label_font_size: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label Color for an Element.
-    pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn label_font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
-    }
-
-}
-
-
 impl<'a, T, F> Colorable for Slider<'a, T, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, T, F> Frameable for Slider<'a, T, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -426,12 +376,12 @@ impl<'a, T, F> Labelable<'a> for Slider<'a, T, F> {
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
+        self.style.label_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
+        self.style.label_font_size = Some(size);
         self
     }
 }

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -1,0 +1,196 @@
+
+
+
+/// Defines a struct called `$Style`.
+///
+/// Each given `$field_name` `$FieldType` pair will be defined as `Option` fields.
+macro_rules! define_widget_style_struct {
+
+    (
+        $(#[$Style_attr:meta])*
+        style $Style:ident {
+            $( $(#[$field_attr:meta])* - $field_name:ident: $FieldType:ty { $default:expr }),* $(,)*
+        }
+    ) => {
+        $(#[$Style_attr])*
+        #[derive(Copy, Clone, Debug, PartialEq)]
+        pub struct $Style {
+            $(
+                $(#[$field_attr])*
+                pub $field_name: Option<$FieldType>,
+            )*
+        }
+    };
+
+    (
+        $(#[$Style_attr:meta])*
+        style $Style:ident {
+            $(
+                $(#[$field_attr:meta])*
+                - $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }
+             ),* $(,)*
+        }
+    ) => {
+        define_widget_style_struct!{
+            $(#[$Style_attr])*
+            style $Style {
+                $( $(#[$field_attr])* - $field_name: $FieldType {},)*
+            }
+        }
+    };
+
+}
+
+
+/// Produces a default instance of `$Style` (aka all fields set to `None`).
+macro_rules! default_widget_style_struct {
+
+    (
+        $Style:ident {
+            $(
+                $(#[$field_attr:meta])*
+                - $field_name:ident: $FieldType:ty { $default:expr }
+             ),* $(,)*
+        }
+    ) => {
+        $Style {
+            $(
+                $field_name: None,
+            )*
+        }
+    };
+
+    (
+        $Style:ident {
+            $(
+                $(#[$field_attr:meta])*
+                - $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }
+             ),* $(,)*
+        }
+    ) => {
+        default_widget_style_struct!{
+            $Style {
+                $(
+                    $(#[$field_attr])*
+                    - $field_name: $FieldType {},
+                )*
+            }
+        };
+    };
+
+}
+
+/// Implements the static method `new` for the `$Style` type.
+macro_rules! impl_widget_style_new {
+    ($Style:ident { $($fields:tt)* }) => {
+        impl $Style {
+            /// Construct the default `Style`, initialising all fields to `None`.
+            pub fn new() -> Self {
+                default_widget_style_struct!($Style { $($fields)* })
+            }
+        }
+    };
+}
+
+
+macro_rules! impl_widget_style_retrieval_method {
+    ($KIND:ident, $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }) => {
+        /// Retrieves the value from the `Style`.
+        ///
+        /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
+        pub fn $field_name(&self, theme: &$crate::Theme) -> $FieldType {
+            self.$field_name
+                .or_else(|| theme.widget_style::<Self>($KIND).and_then(|default| {
+                    default.style.$field_name
+                }))
+                .unwrap_or_else(|| theme.$($theme_field).+)
+        }
+    };
+    ($KIND:ident, $field_name:ident: $FieldType:ty { $default:expr }) => {
+        /// Retrieves the value from the `Style`.
+        ///
+        /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
+        pub fn $field_name(&self, theme: &$crate::Theme) -> $FieldType {
+            self.$field_name
+                .or_else(|| theme.widget_style::<Self>($KIND).and_then(|default| {
+                    default.style.$field_name
+                }))
+                .unwrap_or_else(|| $default)
+        }
+    };
+}
+
+macro_rules! impl_widget_style_retrieval_methods {
+
+    // Retrieval methods with a field on the `theme` to use as the default.
+    (
+        $KIND:ident,
+        $(#[$field_attr:meta])*
+        - $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }, $($rest:tt)*
+    ) => {
+        impl_widget_style_retrieval_method!($KIND, $field_name: $FieldType { theme.$($theme_field).+});
+        impl_widget_style_retrieval_methods!($KIND, $($rest)*);
+    };
+
+    // Retrieval methods with an expression to use as the default.
+    (
+        $KIND:ident,
+        $(#[$field_attr:meta])*
+        - $field_name:ident: $FieldType:ty { $default:expr }, $($rest:tt)*
+    ) => {
+        impl_widget_style_retrieval_method!($KIND, $field_name: $FieldType { $default });
+        impl_widget_style_retrieval_methods!($KIND, $($rest)*);
+    };
+
+    // The last retrieval method with no trailing comma.
+    (
+        $KIND:ident,
+        $(#[$field_attr:meta])*
+        - $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }
+    ) => {
+        impl_widget_style_retrieval_method!($KIND, $field_name: $FieldType { theme.$($theme_field).+});
+    };
+
+    // The last retrieval method with no trailing comma.
+    (
+        $KIND:ident,
+        $(#[$field_attr:meta])*
+        - $field_name:ident: $FieldType:ty { $default:expr }
+    ) => {
+        impl_widget_style_retrieval_method!($KIND, $field_name: $FieldType { $default });
+    };
+
+    // All methods have been implemented.
+    ($KIND:ident,) => {};
+}
+
+
+
+/// A macro for removing the boilerplate present in widget `Style` type implementations.
+#[macro_export]
+macro_rules! widget_style {
+    (
+        $KIND:ident;
+        $(#[$Style_attr:meta])*
+        style $Style:ident {
+            $($fields:tt)*
+        }
+    ) => {
+
+        // The `Style` struct.
+        define_widget_style_struct!{
+            $(#[$Style_attr])*
+            style $Style {
+                $($fields)*
+            }
+        }
+
+        // The `new` method for the `Style` struct.
+        impl_widget_style_new!($Style { $($fields)* });
+
+        // The "field, theme or default" retrieval methods.
+        impl $Style {
+            impl_widget_style_retrieval_methods!($KIND, $($fields)*);
+        }
+    };
+}

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -4,6 +4,8 @@
 /// Defines a struct called `$Style`.
 ///
 /// Each given `$field_name` `$FieldType` pair will be defined as `Option` fields.
+#[doc(hidden)]
+#[macro_export]
 macro_rules! define_widget_style_struct {
 
     (
@@ -43,6 +45,8 @@ macro_rules! define_widget_style_struct {
 
 
 /// Produces a default instance of `$Style` (aka all fields set to `None`).
+#[doc(hidden)]
+#[macro_export]
 macro_rules! default_widget_style_struct {
 
     (
@@ -81,6 +85,8 @@ macro_rules! default_widget_style_struct {
 }
 
 /// Implements the static method `new` for the `$Style` type.
+#[doc(hidden)]
+#[macro_export]
 macro_rules! impl_widget_style_new {
     ($Style:ident { $($fields:tt)* }) => {
         impl $Style {
@@ -93,6 +99,8 @@ macro_rules! impl_widget_style_new {
 }
 
 
+#[doc(hidden)]
+#[macro_export]
 macro_rules! impl_widget_style_retrieval_method {
     ($KIND:ident, $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }) => {
         /// Retrieves the value from the `Style`.
@@ -120,6 +128,8 @@ macro_rules! impl_widget_style_retrieval_method {
     };
 }
 
+#[doc(hidden)]
+#[macro_export]
 macro_rules! impl_widget_style_retrieval_methods {
 
     // Retrieval methods with a field on the `theme` to use as the default.
@@ -166,7 +176,158 @@ macro_rules! impl_widget_style_retrieval_methods {
 
 
 
-/// A macro for removing the boilerplate present in widget `Style` type implementations.
+
+/// A macro for vastly simplifying the definition and implementation of a widget's associated
+/// `Style` type.
+///
+/// For more information on the purpose of this `Style` type, see the associated `type Style` docs
+/// in the [`Widget` trait documentation](./trait.Widget.html).
+///
+/// Using the macro looks like this:
+///
+/// ```
+/// # #[macro_use] extern crate conrod;
+/// # fn main() {}
+/// # const KIND: conrod::WidgetKind = "Example";
+/// widget_style!{
+///     KIND;
+///     // Doc comment or attr for the generated `Style` struct can go here.
+///     style Style {
+///         // Fields and their type T (which get converted to `Option<T>` in the struct definition)
+///         // along with their default expression go here.
+///         // You can also write doc comments or attr above each field.
+///         - color: conrod::Color { theme.shape_color },
+///         - label_color: conrod::Color { conrod::color::BLUE },
+///         // .. more fields.
+///     }
+/// }
+/// ```
+///
+/// An invocation of the macro expands into two things:
+///
+/// 1. A struct definition with the given name following the `style` token.
+/// 2. An `impl Style` block with a `new` constructor as well as a style retrieval method for each
+///    given field. These retrieval methods do the following:
+///
+///    1. Attempt to use the value at the field.
+///    2. If the field is `None`, attempts to retreive a default from the `widget_styling` map in
+///       the `Ui`'s current `Theme`.
+///    3. If no defaults were found, evaluates the given default expression (or `theme.field`).
+///
+///
+/// # Examples
+///
+/// The following is a typical usage example for the `widget_style!` macro.
+///
+/// ```
+/// #[macro_use]
+/// extern crate conrod;
+/// 
+/// struct MyWidget {
+///     style: Style,
+///     // Other necessary fields...
+/// }
+///
+/// /// A unique string used to dynamically identify the widget type.
+/// ///
+/// /// Conrod uses this to store unique styling for each widget in a `HashMap` within the `Theme`.
+/// const KIND: conrod::WidgetKind = "MyWidget";
+///
+/// widget_style!{
+///     KIND;
+///     /// Unique, awesome styling for a `MyWidget`.
+///     style Style {
+///         /// The totally amazing color to use for the `MyWidget`.
+///         ///
+///         /// If the `color` is unspecified and there is no default given via the `Theme`, the
+///         /// `Theme`'s standard `shape_color` field will be used as a fallback.
+///         - color: conrod::Color { theme.shape_color },
+///         /// The extremely pretty color to use for the `MyWidget`'s label.
+///         ///
+///         /// If the `label_color` is unspecified and there is no default given via the `Theme`,
+///         /// the label will fallback to `conrod::color::PURPLE`.
+///         - label_color: conrod::Color { conrod::color::PURPLE },
+///     }
+/// }
+///
+/// // We can now retrieve the `color` or `label_color` for a `MyWidget` like so:
+/// // let color = my_widget.style.color(&theme);
+/// // let label_color = my_widget.style.label_color(&theme);
+/// 
+/// # fn main() {}
+/// ```
+///
+/// And here is what it expands into:
+///
+/// ```
+/// #[macro_use]
+/// extern crate conrod;
+///
+/// struct MyWidget {
+///     style: Style,
+///     // Other necessary fields...
+/// }
+///
+/// /// A unique string used to dynamically identify the widget type.
+/// ///
+/// /// Conrod uses this to store unique styling for each widget in a `HashMap` within the `Theme`.
+/// const KIND: conrod::WidgetKind = "MyWidget";
+///
+/// /// Unique, awesome styling for a `MyWidget`.
+/// #[derive(Copy, Clone, Debug, PartialEq)]
+/// pub struct Style {
+///     /// The totally amazing color to use for the `MyWidget`.
+///     ///
+///     /// If the `color` is unspecified and there is no default given via the `Theme`, the
+///     /// `Theme`'s standard `shape_color` field will be used as a fallback.
+///     color: Option<conrod::Color>,
+///     /// The extremely pretty color to use for the `MyWidget`'s label.
+///     ///
+///     /// If the `label_color` is unspecified and there is no default given via the `Theme`,
+///     /// the label will fallback to `conrod::color::PURPLE`.
+///     label_color: Option<conrod::Color>,
+/// }
+///
+/// impl Style {
+///
+///     /// Construct the default `Style`, initialising all fields to `None`.
+///     pub fn new() -> Self {
+///         Style {
+///             color: None,
+///             label_color: None,
+///         }
+///     }
+/// 
+///     /// Retrieves the value from the `Style`.
+///     ///
+///     /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
+///     pub fn color(&self, theme: &conrod::Theme) -> conrod::Color {
+///         self.color
+///             .or_else(|| theme.widget_style::<Self>(KIND).and_then(|default| {
+///                 default.style.color
+///             }))
+///             .unwrap_or_else(|| theme.shape_color)
+///     }
+///
+///     /// Retrieves the value from the `Style`.
+///     ///
+///     /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
+///     pub fn label_color(&self, theme: &conrod::Theme) -> conrod::Color {
+///         self.label_color
+///             .or_else(|| theme.widget_style::<Self>(KIND).and_then(|default| {
+///                 default.style.label_color
+///             }))
+///             .unwrap_or_else(|| conrod::color::PURPLE)
+///     }
+///
+/// }
+///
+/// // We can now retrieve the `color` or `label_color` for a `MyWidget` like so:
+/// // let color = my_widget.style.color(&theme);
+/// // let label_color = my_widget.style.label_color(&theme);
+///
+/// # fn main() {}
+/// ```
 #[macro_export]
 macro_rules! widget_style {
     (

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -148,25 +148,25 @@ impl<'a> Tabs<'a> {
 
     /// Set the padding from the left edge.
     pub fn pad_left(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.padding.maybe_left = Some(pad);
+        self.style.canvas.pad_left = Some(pad);
         self
     }
 
     /// Set the padding from the right edge.
     pub fn pad_right(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.padding.maybe_right = Some(pad);
+        self.style.canvas.pad_right = Some(pad);
         self
     }
 
     /// Set the padding from the top edge.
     pub fn pad_top(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.padding.maybe_top = Some(pad);
+        self.style.canvas.pad_top = Some(pad);
         self
     }
 
     /// Set the padding from the bottom edge.
     pub fn pad_bottom(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.padding.maybe_bottom = Some(pad);
+        self.style.canvas.pad_bottom = Some(pad);
         self
     }
 
@@ -423,18 +423,18 @@ impl Style {
 
 impl<'a> ::color::Colorable for Tabs<'a> {
     fn color(mut self, color: Color) -> Self {
-        self.style.canvas.framed_rectangle.color = Some(color);
+        self.style.canvas.color = Some(color);
         self
     }
 }
 
 impl<'a> ::frame::Frameable for Tabs<'a> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.canvas.framed_rectangle.frame = Some(width);
+        self.style.canvas.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.canvas.framed_rectangle.frame_color = Some(color);
+        self.style.canvas.frame_color = Some(color);
         self
     }
 }

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -423,18 +423,18 @@ impl Style {
 
 impl<'a> ::color::Colorable for Tabs<'a> {
     fn color(mut self, color: Color) -> Self {
-        self.style.canvas.framed_rectangle.maybe_color = Some(color);
+        self.style.canvas.framed_rectangle.color = Some(color);
         self
     }
 }
 
 impl<'a> ::frame::Frameable for Tabs<'a> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.canvas.framed_rectangle.maybe_frame = Some(width);
+        self.style.canvas.framed_rectangle.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.canvas.framed_rectangle.maybe_frame_color = Some(color);
+        self.style.canvas.framed_rectangle.frame_color = Some(color);
         self
     }
 }

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -17,7 +17,6 @@ use {
     Rectangle,
     Scalar,
     Text,
-    Theme,
     Widget,
 };
 use input::keyboard::Key::{Backspace, Left, Right, Return, A, E, LCtrl, RCtrl};
@@ -40,20 +39,25 @@ pub struct TextBox<'a, F> {
     enabled: bool,
 }
 
-/// Styling for the TextBox, necessary for constructing its renderable Element.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Color of the rectangle behind the text. If you don't want to see the rectangle, set the
-    /// color with a zeroed alpha.
-    pub maybe_color: Option<Color>,
-    /// The frame around the rectangle behind the text.
-    pub maybe_frame: Option<Scalar>,
-    /// The color of the frame.
-    pub maybe_frame_color: Option<Color>,
-    /// The font size for the text.
-    pub maybe_font_size: Option<u32>,
-    /// The color of the text.
-    pub maybe_text_color: Option<Color>,
+/// Unique kind for the widget type.
+pub const KIND: widget::Kind = "TextBox";
+
+widget_style!{
+    KIND;
+    /// Unique graphical styling for the TextBox.
+    style Style {
+        /// Color of the rectangle behind the text. If you don't want to see the rectangle, set the
+        /// color with a zeroed alpha.
+        - color: Color { theme.shape_color },
+        /// The frame around the rectangle behind the text.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the frame.
+        - frame_color: Color { theme.frame_color },
+        /// The font size for the text.
+        - font_size: FontSize { 24 },
+        /// The color of the text.
+        - text_color: Color { theme.label_color },
+    }
 }
 
 /// The State of the TextBox widget that will be cached within the Ui.
@@ -66,9 +70,6 @@ pub struct State {
     highlight_idx: IndexSlot,
     control_pressed: bool
 }
-
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "TextBox";
 
 /// Represents the state of the text_box widget.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -321,7 +322,7 @@ impl<'a, F> TextBox<'a, F> {
 
     /// Set the font size of the text.
     pub fn font_size(mut self, font_size: FontSize) -> TextBox<'a, F> {
-        self.style.maybe_font_size = Some(font_size);
+        self.style.font_size = Some(font_size);
         self
     }
 
@@ -606,72 +607,21 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
 
 }
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_font_size: None,
-            maybe_text_color: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or_else(|| theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or_else(|| theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or_else(|| theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn font_size(&self, theme: &Theme) -> FontSize {
-        const DEFAULT_FONT_SIZE: u32 = 24;
-        self.maybe_font_size.or_else(|| theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_font_size.unwrap_or(DEFAULT_FONT_SIZE)
-        })).unwrap_or(DEFAULT_FONT_SIZE)
-    }
-
-    /// Get the Color for of the Text.
-    pub fn text_color(&self, theme: &Theme) -> Color {
-        self.maybe_text_color.or_else(|| theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_text_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-}
 
 impl<'a, F> Colorable for TextBox<'a, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, F> Frameable for TextBox<'a, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
-

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -1,4 +1,5 @@
 use {
+    Align,
     CharacterCache,
     Color,
     Colorable,
@@ -6,7 +7,6 @@ use {
     FontSize,
     Frameable,
     FramedRectangle,
-    FramedRectangleStyle,
     IndexSlot,
     Labelable,
     Mouse,
@@ -14,7 +14,7 @@ use {
     Scalar,
     Sizeable,
     Text,
-    TextStyle,
+    TextWrap,
     Ui,
 };
 use widget::{self, Widget};
@@ -40,13 +40,28 @@ pub struct State {
     label_idx: IndexSlot,
 }
 
-/// Unique styling for the **TitleBar** widget.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Shape styling for the rectangle.
-    pub framed_rectangle: FramedRectangleStyle,
-    /// Styling for the label.
-    pub text: TextStyle,
+widget_style!{
+    KIND;
+    /// Unique styling for the **TitleBar** widget.
+    style Style {
+        /// The color of the TitleBar's rectangle surface.
+        - color: Color { theme.background_color },
+        /// The width of the frame surrounding the TitleBar's rectangle.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the TitleBar's frame.
+        - frame_color: Color { theme.frame_color },
+
+        /// The color of the title bar's text.
+        - text_color: Color { theme.label_color },
+        /// The font size for the title bar's text.
+        - font_size: FontSize { theme.font_size_medium },
+        /// The way in which the title bar's text should wrap.
+        - maybe_wrap: Option<TextWrap> { Some(TextWrap::Whitespace) },
+        /// The distance between lines for multi-line title bar text.
+        - line_spacing: Scalar { 1.0 },
+        /// The horizontal alignment of the title bar text.
+        - text_align: Align { Align::Middle },
+    }
 }
 
 /// Some interaction with the **TitleBar**.
@@ -64,19 +79,6 @@ pub const KIND: widget::Kind = "TitleBar";
 ///
 /// This is used to determine the size of the TitleBar.
 const LABEL_PADDING: f64 = 4.0;
-
-
-impl Style {
-
-    /// A new default Style.
-    pub fn new() -> Self {
-        Style {
-            framed_rectangle: FramedRectangleStyle::new(),
-            text: TextStyle::new(),
-        }
-    }
-
-}
 
 
 /// Check the current state of the button.
@@ -109,15 +111,45 @@ impl<'a, F> TitleBar<'a, F>
         }.w_of(idx).mid_top_of(idx)
     }
 
-    /// Pass some styling for the **TitleBar**'s **Label**.
-    pub fn label_style(mut self, style: TextStyle) -> Self {
-        self.style.text = style;
+    /// Build the **TitleBar** with the given color.
+    pub fn color(mut self, color: Color) -> Self {
+        self.style.color = Some(color);
         self
     }
 
-    /// Pass some styling for the **TitleBar**'s **FramedRectangle**.
-    pub fn rect_style(mut self, style: FramedRectangleStyle) -> Self {
-        self.style.framed_rectangle = style;
+    /// Build the **TitleBar** with the given frame width.
+    pub fn frame(mut self, frame: Scalar) -> Self {
+        self.style.frame = Some(frame);
+        self
+    }
+
+    /// Build the **TitleBar** with the given frame color.
+    pub fn frame_color(mut self, frame_color: Color) -> Self {
+        self.style.frame_color = Some(frame_color);
+        self
+    }
+
+    /// Align the text to the left of its bounding **Rect**'s *x* axis range.
+    pub fn align_text_left(mut self) -> Self {
+        self.style.text_align = Some(Align::Start);
+        self
+    }
+
+    /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
+    pub fn align_text_middle(mut self) -> Self {
+        self.style.text_align = Some(Align::Middle);
+        self
+    }
+
+    /// Align the text to the right of its bounding **Rect**'s *x* axis range.
+    pub fn align_text_right(mut self) -> Self {
+        self.style.text_align = Some(Align::End);
+        self
+    }
+
+    /// The height of the space used between consecutive lines.
+    pub fn line_spacing(mut self, height: Scalar) -> Self {
+        self.style.line_spacing = Some(height);
         self
     }
 
@@ -167,7 +199,7 @@ impl<'a, F> Widget for TitleBar<'a, F>
     }
 
     fn default_y_dimension<C: CharacterCache>(&self, ui: &Ui<C>) -> Dimension {
-        let font_size = self.style.text.font_size(&ui.theme);
+        let font_size = self.style.font_size(&ui.theme);
         let h = calc_height(font_size);
         Dimension::Absolute(h)
     }
@@ -188,17 +220,33 @@ impl<'a, F> Widget for TitleBar<'a, F>
         // FramedRectangle widget.
         let rectangle_idx = state.view().rectangle_idx.get(&mut ui);
         let dim = rect.dim();
+        let color = style.color(ui.theme());
+        let frame = style.frame(ui.theme());
+        let frame_color = style.frame_color(ui.theme());
         FramedRectangle::new(dim)
-            .with_style(style.framed_rectangle)
+            .color(color)
+            .frame(frame)
+            .frame_color(frame_color)
             .middle_of(idx)
             .graphics_for(idx)
             .set(rectangle_idx, &mut ui);
 
         // Label widget.
         let label_idx = state.view().label_idx.get(&mut ui);
-        Text::new(label)
-            .with_style(style.text)
+        let text_color = style.text_color(ui.theme());
+        let text_align = style.text_align(ui.theme());
+        let font_size = style.font_size(ui.theme());
+        let line_spacing = style.line_spacing(ui.theme());
+        let maybe_wrap = style.maybe_wrap(ui.theme());
+        let mut text = Text::new(label);
+        text.style.maybe_wrap = Some(maybe_wrap);
+        text.style.text_align = Some(text_align);
+        text
+            .padded_w_of(rectangle_idx, frame)
             .middle_of(rectangle_idx)
+            .color(text_color)
+            .font_size(font_size)
+            .line_spacing(line_spacing)
             .graphics_for(idx)
             .set(label_idx, &mut ui);
 
@@ -217,18 +265,18 @@ impl<'a, F> Widget for TitleBar<'a, F>
 
 impl<'a, F> Colorable for TitleBar<'a, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.framed_rectangle.color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, F> Frameable for TitleBar<'a, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.framed_rectangle.frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.framed_rectangle.frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -240,12 +288,12 @@ impl<'a, F> Labelable<'a> for TitleBar<'a, F> {
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.text.color = Some(color);
+        self.style.text_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.text.font_size = Some(size);
+        self.style.font_size = Some(size);
         self
     }
 }

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -217,18 +217,18 @@ impl<'a, F> Widget for TitleBar<'a, F>
 
 impl<'a, F> Colorable for TitleBar<'a, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.framed_rectangle.maybe_color = Some(color);
+        self.style.framed_rectangle.color = Some(color);
         self
     }
 }
 
 impl<'a, F> Frameable for TitleBar<'a, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.framed_rectangle.maybe_frame = Some(width);
+        self.style.framed_rectangle.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.framed_rectangle.maybe_frame_color = Some(color);
+        self.style.framed_rectangle.frame_color = Some(color);
         self
     }
 }
@@ -240,12 +240,12 @@ impl<'a, F> Labelable<'a> for TitleBar<'a, F> {
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.text.maybe_color = Some(color);
+        self.style.text.color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.text.maybe_font_size = Some(size);
+        self.style.text.font_size = Some(size);
         self
     }
 }

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -12,7 +12,6 @@ use {
     Positionable,
     Scalar,
     Text,
-    Theme,
     Widget,
 };
 use widget;
@@ -34,23 +33,25 @@ pub struct Toggle<'a, F> {
     enabled: bool,
 }
 
-/// Styling for the Toggle including coloring, framing and labelling.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// Color of the Toggle's pressable area.
-    pub maybe_color: Option<Color>,
-    /// The width of the rectangular frame surrounding the Toggle.
-    pub maybe_frame: Option<Scalar>,
-    /// The color of the Toggle's frame.
-    pub maybe_frame_color: Option<Color>,
-    /// The color of the Toggle's Text label.
-    pub maybe_label_color: Option<Color>,
-    /// The font size for the Toggle's Text label.
-    pub maybe_label_font_size: Option<u32>,
-}
-
 /// Unique kind for the widget type.
 pub const KIND: widget::Kind = "Toggle";
+
+widget_style!{
+    KIND;
+    /// Styling for the Toggle including coloring, framing and labelling.
+    style Style {
+        /// Color of the Toggle's pressable area.
+        - color: Color { theme.shape_color },
+        /// The width of the rectangular frame surrounding the Toggle.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the Toggle's frame.
+        - frame_color: Color { theme.frame_color },
+        /// The color of the Toggle's Text label.
+        - label_color: Color { theme.label_color },
+        /// The font size for the Toggle's Text label.
+        - label_font_size: FontSize { theme.font_size_medium },
+    }
+}
 
 /// The way in which the Toggle is being interacted with.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -236,71 +237,20 @@ impl<'a, F> Widget for Toggle<'a, F>
 }
 
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_label_color: None,
-            maybe_label_font_size: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label Color for an Element.
-    pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn label_font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
-    }
-
-}
-
-
 impl<'a, F> Colorable for Toggle<'a, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, F> Frameable for Toggle<'a, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -312,12 +262,12 @@ impl<'a, F> Labelable<'a> for Toggle<'a, F> {
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
+        self.style.label_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
+        self.style.label_font_size = Some(size);
         self
     }
 }

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -14,7 +14,6 @@ use {
     Scalar,
     Sizeable,
     Text,
-    Theme,
     Widget,
 };
 use num::Float;
@@ -36,23 +35,28 @@ pub struct XYPad<'a, X, Y, F> {
     enabled: bool,
 }
 
-/// Styling for the XYPad, necessary for constructing its renderable Element.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Style {
-    /// The color of the XYPad's rectangle.
-    pub maybe_color: Option<Color>,
-    /// The width of the frame surrounding the rectangle.
-    pub maybe_frame: Option<Scalar>,
-    /// The color of the surrounding rectangle frame.
-    pub maybe_frame_color: Option<Color>,
-    /// The color of the XYPad's label and value label text.
-    pub maybe_label_color: Option<Color>,
-    /// The font size for the XYPad's label.
-    pub maybe_label_font_size: Option<FontSize>,
-    /// The font size for the XYPad's *value* label.
-    pub maybe_value_font_size: Option<FontSize>,
-    /// The thickness of the XYPad's crosshair lines.
-    pub maybe_line_thickness: Option<f64>,
+/// Unique kind for the widget type.
+pub const KIND: widget::Kind = "XYPad";
+
+widget_style!{
+    KIND;
+    /// Unique graphical styling for the XYPad.
+    style Style {
+        /// The color of the XYPad's rectangle.
+        - color: Color { theme.shape_color },
+        /// The width of the frame surrounding the rectangle.
+        - frame: Scalar { theme.frame_width },
+        /// The color of the surrounding rectangle frame.
+        - frame_color: Color { theme.frame_color },
+        /// The color of the XYPad's label and value label text.
+        - label_color: Color { theme.label_color },
+        /// The font size for the XYPad's label.
+        - label_font_size: FontSize { theme.font_size_medium },
+        /// The font size for the XYPad's *value* label.
+        - value_font_size: FontSize { 14 },
+        /// The thickness of the XYPad's crosshair lines.
+        - line_thickness: Scalar { 2.0 },
+    }
 }
 
 /// The state of the XYPad.
@@ -67,9 +71,6 @@ pub struct State<X, Y> {
     v_line_idx: IndexSlot,
     value_label_idx: IndexSlot,
 }
-
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "XYPad";
 
 /// The interaction state of the XYPad.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -124,13 +125,13 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
 
     /// Set the width of the XYPad's crosshair lines.
     pub fn line_thickness(mut self, width: f64) -> Self {
-        self.style.maybe_line_thickness = Some(width);
+        self.style.line_thickness = Some(width);
         self
     }
 
     /// Set the font size for the displayed crosshair value.
     pub fn value_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_value_font_size = Some(size);
+        self.style.value_font_size = Some(size);
         self
     }
 
@@ -355,88 +356,20 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
 }
 
 
-impl Style {
-
-    /// Construct the default Style.
-    pub fn new() -> Style {
-        Style {
-            maybe_color: None,
-            maybe_frame: None,
-            maybe_frame_color: None,
-            maybe_label_color: None,
-            maybe_label_font_size: None,
-            maybe_value_font_size: None,
-            maybe_line_thickness: None,
-        }
-    }
-
-    /// Get the Color for an Element.
-    pub fn color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
-    }
-
-    /// Get the frame for an Element.
-    pub fn frame(&self, theme: &Theme) -> f64 {
-        self.maybe_frame.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame.unwrap_or(theme.frame_width)
-        })).unwrap_or(theme.frame_width)
-    }
-
-    /// Get the frame Color for an Element.
-    pub fn frame_color(&self, theme: &Theme) -> Color {
-        self.maybe_frame_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_frame_color.unwrap_or(theme.frame_color)
-        })).unwrap_or(theme.frame_color)
-    }
-
-    /// Get the label Color for an Element.
-    pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
-    }
-
-    /// Get the label font size for an Element.
-    pub fn label_font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
-    }
-
-    /// Get the value font size for an Element.
-    pub fn value_font_size(&self, theme: &Theme) -> FontSize {
-        const DEFAULT_VALUE_FONT_SIZE: u32 = 14;
-        self.maybe_value_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_value_font_size.unwrap_or(DEFAULT_VALUE_FONT_SIZE)
-        })).unwrap_or(DEFAULT_VALUE_FONT_SIZE)
-    }
-
-    /// Get the point radius size for an Element.
-    pub fn line_thickness(&self, theme: &Theme) -> f64 {
-        const DEFAULT_LINE_THICKNESS: f64 = 2.0;
-        self.maybe_line_thickness.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_line_thickness.unwrap_or(DEFAULT_LINE_THICKNESS)
-        })).unwrap_or(DEFAULT_LINE_THICKNESS)
-    }
-
-}
-
 impl<'a, X, Y, F> Colorable for XYPad<'a, X, Y, F> {
     fn color(mut self, color: Color) -> Self {
-        self.style.maybe_color = Some(color);
+        self.style.color = Some(color);
         self
     }
 }
 
 impl<'a, X, Y, F> Frameable for XYPad<'a, X, Y, F> {
     fn frame(mut self, width: f64) -> Self {
-        self.style.maybe_frame = Some(width);
+        self.style.frame = Some(width);
         self
     }
     fn frame_color(mut self, color: Color) -> Self {
-        self.style.maybe_frame_color = Some(color);
+        self.style.frame_color = Some(color);
         self
     }
 }
@@ -449,12 +382,12 @@ impl<'a, X, Y, F> Labelable<'a> for XYPad<'a, X, Y, F>
     }
 
     fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
+        self.style.label_color = Some(color);
         self
     }
 
     fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
+        self.style.label_font_size = Some(size);
         self
     }
 }


### PR DESCRIPTION
**WIP - Do not merge yet.**

Pretty stoked with this one! We're able to remove a huge amount of style-related code in favour of a macro that is, imo, much more readable than the verbose Style impls that were everywhere before.

Todo:
- [x] Review remaining widgets to see if either their styling can be refactored to utilise this, or if the `widget_style!` macro can be extended to handle their unique cases.
- [x] Add thorough documenation to the `widget_style!` macro explaining how everything works and why it's necessary.