### PR TITLE
Add a macro for simplifying builder method implementations. Update widgets to take advantage of it.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.30.0"
+version = "0.31.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/widget/builder.rs
+++ b/src/widget/builder.rs
@@ -1,6 +1,8 @@
 //! The `builder_method!` macro module.
 
 /// A macro for simplifying implementation of methods for the `builder pattern`.
+///
+/// See the [`builder_methods! docs](./macro.builder_methods!.html) for more background and details.
 #[macro_export]
 macro_rules! builder_method {
 
@@ -46,7 +48,121 @@ macro_rules! builder_method {
 
 }
 
-
+/// A macro to simplify implementation of
+/// ["builder-pattern"](https://en.wikipedia.org/wiki/Builder_pattern) methods.
+///
+/// The Builder Pattern
+/// ===================
+///
+/// Conrod (and much of the Rust ecosystem) makes extensive use of the builder pattern in order to
+/// provide an expressive widget API. After much iteration, we settled upon the builder pattern as
+/// the best approach to interacting with highly optional types, or in our case, widgets.
+///
+/// Almost all widgets implement at least a few methods in order to take advantage of this pattern.
+/// We call them "builder methods".
+///
+/// The builder pattern looks like this:
+///
+/// ```
+/// # extern crate conrod;
+/// # use conrod::color::{Color, BLACK, LIGHT_PURPLE};
+///
+/// struct Button {
+///     color: Option<Color>,
+/// }
+///
+/// impl Button {
+///
+///     /// Construct a default Button.
+///     pub fn new() -> Self {
+///         Button { color: None }
+///     }
+///     
+///     /// A Color "builder method".
+///     ///
+///     /// Builds the Button with the given Color.
+///     pub fn color(mut self, color: Color) -> Self {
+///         self.color = Some(color);
+///         self
+///     }
+///
+/// }
+///
+/// fn main() {
+///     // Here we build a purple button.
+///     let purple_button = Button::new().color(LIGHT_PURPLE);
+///     assert!(button_color(&purple_button) == LIGHT_PURPLE);
+///
+///     // Here we build a button with some default colour (which in our case is BLACK).
+///     let button = Button::new();
+///     assert!(button_color(&button) == BLACK);
+/// }
+///
+/// // A function that returns a button's color or some default if the button's color is `None`.
+/// fn button_color(button: &Button) -> Color {
+///     button.color.unwrap_or(BLACK)
+/// }
+/// ```
+///
+/// This allows us to support large numbers of optionally specified parameters on widgets, rather
+/// than forcing a user to give them all as `Option` arguments to some function.
+///
+/// builder_method!
+/// ================
+///
+/// This macro allows you to easily implement any number of builder methods for either trait or
+/// direct implementations.
+///
+/// Here's what implementing the color method for our `Button` now looks like:
+///
+/// ```
+/// # #[macro_use] extern crate conrod;
+/// # use conrod::color::Color;
+/// # struct Button { color: Option<Color> }
+/// # fn main() {}
+/// impl Button {
+///     builder_method!(pub color { color = Some(Color) });
+/// }
+/// ```
+///
+/// Breaking it down
+/// ----------------
+///
+/// - The first `color` is an `ident` which specifies the name of the builder function. The
+/// preceding `pub` visiblity token is optional.
+/// - The second `color` is the field of `self` to which we assign the given value when building.
+/// - `Color` is the type which the builder method receives as an argument. The encapsulating
+/// `Some(*)` is optional, and can be removed for cases where the field itself is a normal type and
+/// not an `Option` type.
+///
+/// Multiple `builder_methods!`
+/// ---------------------------
+///
+/// We can also use the macro to implement multiple builder methods at once. The following is an
+/// example of this directly from conrod's `Tabs` widget implementation. It expands to 9 unique
+/// builder methods - one for every line.
+///
+/// ```txt
+/// builder_methods!{
+///     pub bar_width { style.maybe_bar_width = Some(Scalar) }
+///     pub starting_tab_idx { maybe_starting_tab_idx = Some(usize) }
+///     pub label_color { style.maybe_label_color = Some(Color) }
+///     pub label_font_size { style.maybe_label_font_size = Some(FontSize) }
+///     pub canvas_style { style.canvas = canvas::Style }
+///     pub pad_left { style.canvas.pad_left = Some(Scalar) }
+///     pub pad_right { style.canvas.pad_right = Some(Scalar) }
+///     pub pad_bottom { style.canvas.pad_bottom = Some(Scalar) }
+///     pub pad_top { style.canvas.pad_top = Some(Scalar) }
+/// }
+/// ```
+///
+/// Note that the `builder_methods!` macro is designed to work harmony with
+/// [`widget_style!`][1] - a macro which simplifies implementation of a widget's associated `Style`
+/// type. If you are designing your own widget and you haven't looked at it yet, we recommend you
+/// [check out the docs][1].
+///
+/// [1]: ./macro.widget_style!.html
+#[macro_export]
 macro_rules! builder_methods {
     (pub $fn_name:ident { $($assignee:ident).+ = Some($Type:ty) } $($rest:tt)*) => {
         builder_method!(pub $fn_name { $($assignee).+ = Some($Type) });

--- a/src/widget/builder.rs
+++ b/src/widget/builder.rs
@@ -7,6 +7,7 @@ macro_rules! builder_method {
     // A public builder method that assigns the given `$Type` value to the optional `$assignee`.
     (pub $fn_name:ident { $($assignee:ident).+ = Some($Type:ty) }) => {
         /// Build the type's self.$($assignee).+ with the given $Type.
+        #[inline]
         pub fn $fn_name(mut self, $fn_name: $Type) -> Self {
             self.$($assignee).+ = Some($fn_name);
             self
@@ -16,6 +17,7 @@ macro_rules! builder_method {
     // A builder method that assigns the given `$Type` value to the optional `$assignee`.
     ($fn_name:ident { $($assignee:ident).+ = Some($Type:ty) }) => {
         /// Build the type's self.$($assignee).+ with the given $Type.
+        #[inline]
         fn $fn_name(mut self, $fn_name: $Type) -> Self {
             self.$($assignee).+ = Some($fn_name);
             self
@@ -25,6 +27,7 @@ macro_rules! builder_method {
     // A public builder method that assigns the given `$Type` value to the `$assignee`.
     (pub $fn_name:ident { $($assignee:ident).+ = $Type:ty }) => {
         /// Build the type's self.$($assignee).+ with the given $Type.
+        #[inline]
         pub fn $fn_name(mut self, $fn_name: $Type) -> Self {
             self.$($assignee).+ = $fn_name;
             self
@@ -34,6 +37,7 @@ macro_rules! builder_method {
     // A builder method that assigns the given `$Type` value to the `$assignee`.
     ($fn_name:ident { $($assignee:ident).+ = $Type:ty }) => {
         /// Build the type's self.$($assignee).+ with the given $Type.
+        #[inline]
         fn $fn_name(mut self, $fn_name: $Type) -> Self {
             self.$($assignee).+ = $fn_name;
             self

--- a/src/widget/builder.rs
+++ b/src/widget/builder.rs
@@ -1,0 +1,68 @@
+//! The `builder_method!` macro module.
+
+/// A macro for simplifying implementation of methods for the `builder pattern`.
+#[macro_export]
+macro_rules! builder_method {
+
+    // A public builder method that assigns the given `$Type` value to the optional `$assignee`.
+    (pub $fn_name:ident { $($assignee:ident).+ = Some($Type:ty) }) => {
+        /// Build the type's self.$($assignee).+ with the given $Type.
+        pub fn $fn_name(mut self, $fn_name: $Type) -> Self {
+            self.$($assignee).+ = Some($fn_name);
+            self
+        }
+    };
+
+    // A builder method that assigns the given `$Type` value to the optional `$assignee`.
+    ($fn_name:ident { $($assignee:ident).+ = Some($Type:ty) }) => {
+        /// Build the type's self.$($assignee).+ with the given $Type.
+        fn $fn_name(mut self, $fn_name: $Type) -> Self {
+            self.$($assignee).+ = Some($fn_name);
+            self
+        }
+    };
+
+    // A public builder method that assigns the given `$Type` value to the `$assignee`.
+    (pub $fn_name:ident { $($assignee:ident).+ = $Type:ty }) => {
+        /// Build the type's self.$($assignee).+ with the given $Type.
+        pub fn $fn_name(mut self, $fn_name: $Type) -> Self {
+            self.$($assignee).+ = $fn_name;
+            self
+        }
+    };
+
+    // A builder method that assigns the given `$Type` value to the `$assignee`.
+    ($fn_name:ident { $($assignee:ident).+ = $Type:ty }) => {
+        /// Build the type's self.$($assignee).+ with the given $Type.
+        fn $fn_name(mut self, $fn_name: $Type) -> Self {
+            self.$($assignee).+ = $fn_name;
+            self
+        }
+    };
+
+}
+
+
+macro_rules! builder_methods {
+    (pub $fn_name:ident { $($assignee:ident).+ = Some($Type:ty) } $($rest:tt)*) => {
+        builder_method!(pub $fn_name { $($assignee).+ = Some($Type) });
+        builder_methods!($($rest)*);
+    };
+
+    ($fn_name:ident { $($assignee:ident).+ = Some($Type:ty) } $($rest:tt)*) => {
+        builder_method!($fn_name { $($assignee).+ = Some($Type) });
+        builder_methods!($($rest)*);
+    };
+    
+    (pub $fn_name:ident { $($assignee:ident).+ = $Type:ty } $($rest:tt)*) => {
+        builder_method!(pub $fn_name { $($assignee).+ = $Type });
+        builder_methods!($($rest)*);
+    };
+
+    ($fn_name:ident { $($assignee:ident).+ = $Type:ty } $($rest:tt)*) => {
+        builder_method!($fn_name { $($assignee).+ = $Type });
+        builder_methods!($($rest)*);
+    };
+
+    ($($rest:tt)*) => {};
+}

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -21,9 +21,11 @@ use widget;
 pub struct Button<'a, F> {
     common: widget::CommonBuilder,
     maybe_label: Option<&'a str>,
+    /// The reaction for the Button. The reaction will be triggered upon release of the button.
     maybe_react: Option<F>,
     /// Unique styling for the Button.
     pub style: Style,
+    /// Whether or not user input is enabled.
     enabled: bool,
 }
 
@@ -103,16 +105,9 @@ impl<'a, F> Button<'a, F> {
         }
     }
 
-    /// Set the reaction for the Button. The reaction will be triggered upon release of the button.
-    pub fn react(mut self, reaction: F) -> Self {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
@@ -217,36 +212,20 @@ impl<'a, F> Widget for Button<'a, F>
 
 
 impl<'a, F> Colorable for Button<'a, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, F> Frameable for Button<'a, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
 impl<'a, F> Labelable<'a> for Button<'a, F> {
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -132,7 +132,7 @@ enum Direction {
 impl<'a> Canvas<'a> {
 
     /// Construct a new Canvas builder.
-    pub fn new() -> Canvas<'a> {
+    pub fn new() -> Self {
         Canvas {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
@@ -141,10 +141,13 @@ impl<'a> Canvas<'a> {
         }
     }
 
-    /// Show or hide the title bar.
-    pub fn title_bar(mut self, label: &'a str) -> Self {
-        self.maybe_title_bar_label = Some(label);
-        self
+    builder_methods!{
+        pub title_bar { maybe_title_bar_label = Some(&'a str) }
+        pub pad_left { style.pad_left = Some(Scalar) }
+        pub pad_right { style.pad_right = Some(Scalar) }
+        pub pad_bottom { style.pad_bottom = Some(Scalar) }
+        pub pad_top { style.pad_top = Some(Scalar) }
+        pub with_style { style = Style }
     }
 
     /// Set the length of the Split as an absolute scalar.
@@ -187,34 +190,6 @@ impl<'a> Canvas<'a> {
         self.flow(Direction::Y(Backwards), splits)
     }
 
-    /// Set the padding of the left of the area where child widgets will be placed.
-    #[inline]
-    pub fn pad_left(mut self, pad: Scalar) -> Self {
-        self.style.pad_left = Some(pad);
-        self
-    }
-
-    /// Set the padding of the right of the area where child widgets will be placed.
-    #[inline]
-    pub fn pad_right(mut self, pad: Scalar) -> Self {
-        self.style.pad_right = Some(pad);
-        self
-    }
-
-    /// Set the padding of the bottom of the area where child widgets will be placed.
-    #[inline]
-    pub fn pad_bottom(mut self, pad: Scalar) -> Self {
-        self.style.pad_bottom = Some(pad);
-        self
-    }
-
-    /// Set the padding of the top of the area where child widgets will be placed.
-    #[inline]
-    pub fn pad_top(mut self, pad: Scalar) -> Self {
-        self.style.pad_top = Some(pad);
-        self
-    }
-
     /// Set the padding for all edges of the area where child widgets will be placed.
     #[inline]
     pub fn pad(self, pad: Scalar) -> Self {
@@ -228,12 +203,6 @@ impl<'a> Canvas<'a> {
             .pad_right(pad.x.end)
             .pad_bottom(pad.y.start)
             .pad_top(pad.y.end)
-    }
-
-    /// Build the **Canvas** with the given **Style**.
-    pub fn with_style(mut self, style: Style) -> Self {
-        self.style = style;
-        self
     }
 
 }
@@ -458,20 +427,13 @@ impl Style {
 }
 
 impl<'a> ::color::Colorable for Canvas<'a> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a> ::frame::Frameable for Canvas<'a> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
@@ -479,13 +441,9 @@ impl<'a> ::label::Labelable<'a> for Canvas<'a> {
     fn label(self, text: &'a str) -> Self {
         self.title_bar(text)
     }
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.title_bar_text_color = Some(color);
-        self
-    }
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.title_bar_font_size = Some(size);
-        self
+    builder_methods!{
+        label_color { style.title_bar_text_color = Some(Color) }
+        label_font_size { style.title_bar_font_size = Some(FontSize) }
     }
 }
 

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -84,7 +84,7 @@ pub enum MenuState {
 impl<'a, F> DropDownList<'a, F> {
 
     /// Construct a new DropDownList.
-    pub fn new(strings: &'a mut Vec<String>, selected: &'a mut Option<Idx>) -> DropDownList<'a, F> {
+    pub fn new(strings: &'a mut Vec<String>, selected: &'a mut Option<Idx>) -> Self {
         DropDownList {
             common: widget::CommonBuilder::new(),
             strings: strings,
@@ -96,16 +96,9 @@ impl<'a, F> DropDownList<'a, F> {
         }
     }
 
-    /// Set the DropDownList's reaction. It will be triggered upon selection of a list item.
-    pub fn react(mut self, reaction: F) -> DropDownList<'a, F> {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
     /// Set the maximum height of the DropDownList (before the scrollbar appears) as a number of
@@ -317,36 +310,20 @@ impl Style {
 
 
 impl<'a, F> Colorable for DropDownList<'a, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, F> Frameable for DropDownList<'a, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
 impl<'a, F> Labelable<'a> for DropDownList<'a, F> {
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -37,7 +37,9 @@ use widget;
 pub struct EnvelopeEditor<'a, E:'a, F> where E: EnvelopePoint {
     common: widget::CommonBuilder,
     env: &'a mut Vec<E>,
-    skew_y_range: f32,
+    /// The value skewing for the envelope's y-axis. This is useful for displaying exponential
+    /// ranges such as frequency.
+    pub skew_y_range: f32,
     min_x: E::X, max_x: E::X,
     min_y: E::Y, max_y: E::Y,
     maybe_react: Option<F>,
@@ -214,34 +216,6 @@ fn get_new_interaction(is_over_elem: Option<Elem>,
 
 impl<'a, E, F> EnvelopeEditor<'a, E, F> where E: EnvelopePoint {
 
-    /// Set the radius of the envelope point circle.
-    #[inline]
-    pub fn point_radius(mut self, radius: f64) -> EnvelopeEditor<'a, E, F> {
-        self.style.point_radius = Some(radius);
-        self
-    }
-
-    /// Set the width of the envelope lines.
-    #[inline]
-    pub fn line_thickness(mut self, width: f64) -> EnvelopeEditor<'a, E, F> {
-        self.style.line_thickness = Some(width);
-        self
-    }
-
-    /// Set the font size for the displayed values.
-    #[inline]
-    pub fn value_font_size(mut self, size: FontSize) -> EnvelopeEditor<'a, E, F> {
-        self.style.value_font_size = Some(size);
-        self
-    }
-
-    /// Set the value skewing for the envelope's y-axis. This is useful for displaying exponential
-    /// ranges such as frequency.
-    #[inline]
-    pub fn skew_y(self, skew: f32) -> EnvelopeEditor<'a, E, F> {
-        EnvelopeEditor { skew_y_range: skew, ..self }
-    }
-
     /// Construct an EnvelopeEditor widget.
     pub fn new(env: &'a mut Vec<E>, min_x: E::X, max_x: E::X, min_y: E::Y, max_y: E::Y)
     -> EnvelopeEditor<'a, E, F> {
@@ -258,27 +232,23 @@ impl<'a, E, F> EnvelopeEditor<'a, E, F> where E: EnvelopePoint {
         }
     }
 
-    /// Set the reaction for the EnvelopeEditor.
-    pub fn react(mut self, reaction: F) -> EnvelopeEditor<'a, E, F> {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub point_radius { style.point_radius = Some(Scalar) }
+        pub line_thickness { style.line_thickness = Some(Scalar) }
+        pub value_font_size { style.value_font_size = Some(FontSize) }
+        pub skew_y { skew_y_range = f32 }
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
 
 
 impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
-    where
-        E: EnvelopePoint,
-        E::X: Any,
-        E::Y: Any,
-        F: FnMut(&mut Vec<E>, usize),
+    where E: EnvelopePoint,
+          E::X: Any,
+          E::Y: Any,
+          F: FnMut(&mut Vec<E>, usize),
 {
     type State = State<E>;
     type Style = Style;
@@ -701,23 +671,16 @@ impl<'a, E, F> Colorable for EnvelopeEditor<'a, E, F>
     where
         E: EnvelopePoint
 {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, E, F> Frameable for EnvelopeEditor<'a, E, F>
     where
         E: EnvelopePoint
 {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
@@ -725,18 +688,9 @@ impl<'a, E, F> Labelable<'a> for EnvelopeEditor<'a, E, F>
     where
         E: EnvelopePoint
 {
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -10,9 +10,9 @@ use ui::{self, Ui, UserInput};
 pub use self::id::Id;
 pub use self::index::Index;
 
-// Provides the `widget_style!` macro.
-#[macro_use]
-mod style;
+// Macro providing modules.
+#[macro_use] mod builder;
+#[macro_use] mod style;
 
 // Widget functionality modules.
 pub mod drag;

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -38,8 +38,13 @@ pub struct NumberDialer<'a, T, F> {
     max: T,
     maybe_label: Option<&'a str>,
     precision: u8,
+    /// The reaction function for the NumberDialer.
+    ///
+    /// It will be triggered when the value is updated or if the mouse button is released while the
+    /// cursor is above the widget.
     maybe_react: Option<F>,
     style: Style,
+    /// If true, will allow user input. If false, will disallow user inputs.
     enabled: bool,
 }
 
@@ -228,17 +233,9 @@ impl<'a, T, F> NumberDialer<'a, T, F> where T: Float {
         }
     }
 
-    /// Set the reaction for the NumberDialer. It will be triggered when the value is updated or if
-    /// the mouse button is released while the cursor is above the widget.
-    pub fn react(mut self, reaction: F) -> Self {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
@@ -486,38 +483,21 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
 
 
 impl<'a, T, F> Colorable for NumberDialer<'a, T, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, T, F> Frameable for NumberDialer<'a, T, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
-impl<'a, T, F> Labelable<'a> for NumberDialer<'a, T, F>
-{
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+impl<'a, T, F> Labelable<'a> for NumberDialer<'a, T, F> {
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }
 

--- a/src/widget/primitive/shape/framed_rectangle.rs
+++ b/src/widget/primitive/shape/framed_rectangle.rs
@@ -46,11 +46,7 @@ impl FramedRectangle {
         }.wh(dim)
     }
 
-    /// Build the **FramedRectangle** with the given styling.
-    pub fn with_style(mut self, style: Style) -> Self {
-        self.style = style;
-        self
-    }
+    builder_method!(pub with_style { style = Style });
 
 }
 
@@ -88,20 +84,13 @@ impl Widget for FramedRectangle {
 
 
 impl Colorable for FramedRectangle {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 
 impl Frameable for FramedRectangle {
-    fn frame(mut self, width: Scalar) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -31,11 +31,23 @@ pub struct Slider<'a, T, F> {
     value: T,
     min: T,
     max: T,
-    skew: f32,
-    maybe_react: Option<F>,
+    /// The amount in which the slider's display should be skewed.
+    ///
+    /// Higher skew amounts (above 1.0) will weight lower values.
+    ///
+    /// Lower skew amounts (below 1.0) will weight heigher values.
+    ///
+    /// All skew amounts should be greater than 0.0.
+    pub skew: f32,
+    /// Set the reaction for the Slider.
+    ///
+    /// It will be triggered if the value is updated or if the mouse button is released while the
+    /// cursor is above the rectangle.
+    pub maybe_react: Option<F>,
     maybe_label: Option<&'a str>,
     style: Style,
-    enabled: bool,
+    /// Whether or not user input is enabled for the Slider.
+    pub enabled: bool,
 }
 
 widget_style!{
@@ -121,33 +133,10 @@ impl<'a, T, F> Slider<'a, T, F> {
         }
     }
 
-    /// Set the amount in which the slider's display should be skewed.
-    ///
-    /// Higher skew amounts (above 1.0) will weight lower values.
-    ///
-    /// Lower skew amounts (below 1.0) will weight heigher values.
-    ///
-    /// All skew amounts should be greater than 0.0.
-    pub fn skew(mut self, skew: f32) -> Self {
-        self.skew = skew;
-        self
-    }
-
-    /// Set the reaction for the Slider.
-    ///
-    /// It will be triggered if the value is updated or if the mouse button is released while the
-    /// cursor is above the rectangle.
-    pub fn react(mut self, reaction: F) -> Self {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow adjusting the slider.
-    ///
-    /// If false, will disallow adjusting the slider.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub skew { skew = f32 }
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
@@ -352,36 +341,20 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
 
 
 impl<'a, T, F> Colorable for Slider<'a, T, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, T, F> Frameable for Slider<'a, T, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
 impl<'a, T, F> Labelable<'a> for Slider<'a, T, F> {
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -93,18 +93,6 @@ impl<'a> Tabs<'a> {
         }
     }
 
-    /// Set the exact width of the tab bar.
-    pub fn bar_width(mut self, width: Scalar) -> Self {
-        self.style.maybe_bar_width = Some(width);
-        self
-    }
-
-    /// Set the initially selected tab with an index for our tab list.
-    pub fn starting_tab_idx(mut self, idx: usize) -> Self {
-        self.maybe_starting_tab_idx = Some(idx);
-        self
-    }
-
     /// Set the initially selected tab with a Canvas via its widget::Id.
     pub fn starting_canvas(mut self, canvas_id: widget::Id) -> Self {
         let maybe_idx = self.tabs.iter().enumerate()
@@ -112,6 +100,11 @@ impl<'a> Tabs<'a> {
             .map(|(idx, &(_, _))| idx);
         self.maybe_starting_tab_idx = maybe_idx;
         self
+    }
+
+    /// Set the padding for all edges.
+    pub fn pad(self, pad: Scalar) -> Tabs<'a> {
+        self.pad_left(pad).pad_right(pad).pad_top(pad).pad_bottom(pad)
     }
 
     /// Layout the tabs horizontally.
@@ -126,54 +119,18 @@ impl<'a> Tabs<'a> {
         self
     }
 
-    /// The color of the tab labels.
-    pub fn label_color(mut self, color: Color) -> Self {
-        self.style.maybe_label_color = Some(color);
-        self
+    builder_methods!{
+        pub bar_width { style.maybe_bar_width = Some(Scalar) }
+        pub starting_tab_idx { maybe_starting_tab_idx = Some(usize) }
+        pub label_color { style.maybe_label_color = Some(Color) }
+        pub label_font_size { style.maybe_label_font_size = Some(FontSize) }
+        pub canvas_style { style.canvas = canvas::Style }
+        pub pad_left { style.canvas.pad_left = Some(Scalar) }
+        pub pad_right { style.canvas.pad_right = Some(Scalar) }
+        pub pad_bottom { style.canvas.pad_bottom = Some(Scalar) }
+        pub pad_top { style.canvas.pad_top = Some(Scalar) }
     }
 
-    /// The font size for the tab labels.
-    pub fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.maybe_label_font_size = Some(size);
-        self
-    }
-
-    ///// Styling inherited by the inner canvas. /////
-
-    /// The style that will be used for the selected Canvas.
-    pub fn canvas_style(mut self, canvas_style: canvas::Style) -> Self {
-        self.style.canvas = canvas_style;
-        self
-    }
-
-    /// Set the padding from the left edge.
-    pub fn pad_left(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.pad_left = Some(pad);
-        self
-    }
-
-    /// Set the padding from the right edge.
-    pub fn pad_right(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.pad_right = Some(pad);
-        self
-    }
-
-    /// Set the padding from the top edge.
-    pub fn pad_top(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.pad_top = Some(pad);
-        self
-    }
-
-    /// Set the padding from the bottom edge.
-    pub fn pad_bottom(mut self, pad: Scalar) -> Tabs<'a> {
-        self.style.canvas.pad_bottom = Some(pad);
-        self
-    }
-
-    /// Set the padding for all edges.
-    pub fn pad(self, pad: Scalar) -> Tabs<'a> {
-        self.pad_left(pad).pad_right(pad).pad_top(pad).pad_bottom(pad)
-    }
 }
 
 

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -34,9 +34,13 @@ const TEXT_PADDING: Scalar = 5.0;
 pub struct TextBox<'a, F> {
     common: widget::CommonBuilder,
     text: &'a mut String,
-    maybe_react: Option<F>,
+    /// The reaction for the TextBox.
+    ///
+    /// If `Some`, this will be triggered upon pressing of the `Enter`/`Return` key.
+    pub maybe_react: Option<F>,
     style: Style,
-    enabled: bool,
+    /// Whether or not user input is enabled for the TextBox.
+    pub enabled: bool,
 }
 
 /// Unique kind for the widget type.
@@ -320,23 +324,10 @@ impl<'a, F> TextBox<'a, F> {
         }
     }
 
-    /// Set the font size of the text.
-    pub fn font_size(mut self, font_size: FontSize) -> TextBox<'a, F> {
-        self.style.font_size = Some(font_size);
-        self
-    }
-
-    /// Set the reaction for the TextBox. It will be triggered upon pressing of the
-    /// `Enter`/`Return` key.
-    pub fn react(mut self, reaction: F) -> TextBox<'a, F> {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub font_size { style.font_size = Some(FontSize) }
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
@@ -609,19 +600,12 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
 
 
 impl<'a, F> Colorable for TextBox<'a, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, F> Frameable for TextBox<'a, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -111,24 +111,6 @@ impl<'a, F> TitleBar<'a, F>
         }.w_of(idx).mid_top_of(idx)
     }
 
-    /// Build the **TitleBar** with the given color.
-    pub fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
-
-    /// Build the **TitleBar** with the given frame width.
-    pub fn frame(mut self, frame: Scalar) -> Self {
-        self.style.frame = Some(frame);
-        self
-    }
-
-    /// Build the **TitleBar** with the given frame color.
-    pub fn frame_color(mut self, frame_color: Color) -> Self {
-        self.style.frame_color = Some(frame_color);
-        self
-    }
-
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
     pub fn align_text_left(mut self) -> Self {
         self.style.text_align = Some(Align::Start);
@@ -147,16 +129,9 @@ impl<'a, F> TitleBar<'a, F>
         self
     }
 
-    /// The height of the space used between consecutive lines.
-    pub fn line_spacing(mut self, height: Scalar) -> Self {
-        self.style.line_spacing = Some(height);
-        self
-    }
-
-    /// Pass the title bar some function to call upon interaction changes.
-    pub fn react(mut self, f: F) -> Self {
-        self.maybe_react = Some(f);
-        self
+    builder_methods!{
+        pub line_spacing { style.line_spacing = Some(Scalar) }
+        pub react { maybe_react = Some(F) }
     }
 
 }
@@ -264,37 +239,21 @@ impl<'a, F> Widget for TitleBar<'a, F>
 
 
 impl<'a, F> Colorable for TitleBar<'a, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, F> Frameable for TitleBar<'a, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
 impl<'a, F> Labelable<'a> for TitleBar<'a, F> {
-    fn label(mut self, text: &'a str) -> Self {
-        self.label = text;
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.text_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.font_size = Some(size);
-        self
+    builder_methods!{
+        label { label = &'a str }
+        label_color { style.text_color = Some(Color) }
+        label_font_size { style.font_size = Some(FontSize) }
     }
 }
 

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -27,10 +27,12 @@ use widget;
 pub struct Toggle<'a, F> {
     common: widget::CommonBuilder,
     value: bool,
-    maybe_react: Option<F>,
+    /// Set the reaction for the Toggle. It will be triggered upon release of the button.
+    pub maybe_react: Option<F>,
     maybe_label: Option<&'a str>,
     style: Style,
-    enabled: bool,
+    /// If true, will allow user inputs. If false, will disallow user inputs.
+    pub enabled: bool,
 }
 
 /// Unique kind for the widget type.
@@ -113,16 +115,9 @@ impl<'a, F> Toggle<'a, F> {
         }
     }
 
-    /// Set the reaction for the Toggle. It will be triggered upon release of the button.
-    pub fn react(mut self, reaction: F) -> Self {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
@@ -238,37 +233,20 @@ impl<'a, F> Widget for Toggle<'a, F>
 
 
 impl<'a, F> Colorable for Toggle<'a, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, F> Frameable for Toggle<'a, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
 impl<'a, F> Labelable<'a> for Toggle<'a, F> {
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }
-

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -30,9 +30,14 @@ pub struct XYPad<'a, X, Y, F> {
     x: X, min_x: X, max_x: X,
     y: Y, min_y: Y, max_y: Y,
     maybe_label: Option<&'a str>,
-    maybe_react: Option<F>,
+    /// The reaction function for the XYPad.
+    ///
+    /// It will be triggered when the value is updated or if the mouse button is released while the
+    /// cursor is above the rectangle.
+    pub maybe_react: Option<F>,
     style: Style,
-    enabled: bool,
+    /// Indicates whether the XYPad will respond to user input.
+    pub enabled: bool,
 }
 
 /// Unique kind for the widget type.
@@ -123,40 +128,19 @@ impl<'a, X, Y, F> XYPad<'a, X, Y, F> {
         }
     }
 
-    /// Set the width of the XYPad's crosshair lines.
-    pub fn line_thickness(mut self, width: f64) -> Self {
-        self.style.line_thickness = Some(width);
-        self
-    }
-
-    /// Set the font size for the displayed crosshair value.
-    pub fn value_font_size(mut self, size: FontSize) -> Self {
-        self.style.value_font_size = Some(size);
-        self
-    }
-
-    /// Set the reaction for the XYPad.
-    ///
-    /// It will be triggered when the value is updated or if the mouse button is released while the
-    /// cursor is above the rectangle.
-    pub fn react(mut self, reaction: F) -> Self {
-        self.maybe_react = Some(reaction);
-        self
-    }
-
-    /// If true, will allow user inputs.  If false, will disallow user inputs.
-    pub fn enabled(mut self, flag: bool) -> Self {
-        self.enabled = flag;
-        self
+    builder_methods!{
+        pub line_thickness { style.line_thickness = Some(Scalar) }
+        pub value_font_size { style.value_font_size = Some(FontSize) }
+        pub react { maybe_react = Some(F) }
+        pub enabled { enabled = bool }
     }
 
 }
 
 impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
-    where
-        X: Float + ToString + ::std::fmt::Debug + ::std::any::Any,
-        Y: Float + ToString + ::std::fmt::Debug + ::std::any::Any,
-        F: FnOnce(X, Y),
+    where X: Float + ToString + ::std::fmt::Debug + ::std::any::Any,
+          Y: Float + ToString + ::std::fmt::Debug + ::std::any::Any,
+          F: FnOnce(X, Y),
 {
     type State = State<X, Y>;
     type Style = Style;
@@ -357,38 +341,21 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
 
 
 impl<'a, X, Y, F> Colorable for XYPad<'a, X, Y, F> {
-    fn color(mut self, color: Color) -> Self {
-        self.style.color = Some(color);
-        self
-    }
+    builder_method!(color { style.color = Some(Color) });
 }
 
 impl<'a, X, Y, F> Frameable for XYPad<'a, X, Y, F> {
-    fn frame(mut self, width: f64) -> Self {
-        self.style.frame = Some(width);
-        self
-    }
-    fn frame_color(mut self, color: Color) -> Self {
-        self.style.frame_color = Some(color);
-        self
+    builder_methods!{
+        frame { style.frame = Some(Scalar) }
+        frame_color { style.frame_color = Some(Color) }
     }
 }
 
-impl<'a, X, Y, F> Labelable<'a> for XYPad<'a, X, Y, F>
-{
-    fn label(mut self, text: &'a str) -> Self {
-        self.maybe_label = Some(text);
-        self
-    }
-
-    fn label_color(mut self, color: Color) -> Self {
-        self.style.label_color = Some(color);
-        self
-    }
-
-    fn label_font_size(mut self, size: FontSize) -> Self {
-        self.style.label_font_size = Some(size);
-        self
+impl<'a, X, Y, F> Labelable<'a> for XYPad<'a, X, Y, F> {
+    builder_methods!{
+        label { maybe_label = Some(&'a str) }
+        label_color { style.label_color = Some(Color) }
+        label_font_size { style.label_font_size = Some(FontSize) }
     }
 }
 


### PR DESCRIPTION
Another macro effort to cut down on boilerplate.

So far I've been trying to be quite conservative with the use of macros in conrod in order to retain easy readability and immediate familiarity to new users. Often, deciphering complex macros can feel like learning a new language just to understand some src.

However, I think the wins here are undeniably worth it, and imo the src still seems as readable - perhaps even more concise now that a lot of unnecessary noise has been removed. I'm definitely keen to get other opinions on this though, as I did write the thing :)