### PR TITLE
rustfmt'd the src directory

### DIFF
--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -8,7 +8,7 @@
 //! future in favour of a simplified conrod-specific graphics and character caching backend trait.
 
 
-use ::{Color, Point, Rect, Scalar};
+use {Color, Point, Rect, Scalar};
 use graph::{self, Container, Graph, NodeIndex, Visitable};
 use graphics;
 use std::iter::once;
@@ -29,7 +29,7 @@ pub fn draw_from_graph<G, C>(context: Context,
                              depth_order: &[Visitable],
                              theme: &Theme)
     where G: Graphics,
-          C: CharacterCache<Texture=G::Texture>,
+          C: CharacterCache<Texture = G::Texture>
 {
 
     // A stack of contexts, one for each scroll group.
@@ -40,7 +40,7 @@ pub fn draw_from_graph<G, C>(context: Context,
 
     // Retrieve the core window widget so that we can use it to filter visible widgets.
     let window_idx = NodeIndex::new(0);
-    let window = match graph.widget(window_idx){
+    let window = match graph.widget(window_idx) {
         Some(window) => window,
         // If we don't yet have the window widget, we won't have *any* widgets, so bail out.
         None => return,
@@ -52,8 +52,8 @@ pub fn draw_from_graph<G, C>(context: Context,
     // the visible area during the `set_widgets` stage, as it might be more optimal than doing so
     // here.
     let is_visible = |idx: NodeIndex, container: &Container| -> bool {
-        container.rect.overlap(window.rect).is_some()
-        && graph::algo::cropped_area_of_widget(graph, idx).is_some()
+        container.rect.overlap(window.rect).is_some() &&
+        graph::algo::cropped_area_of_widget(graph, idx).is_some()
     };
 
     // The depth order describes the order in which widgets should be drawn.
@@ -75,13 +75,13 @@ pub fn draw_from_graph<G, C>(context: Context,
                     // for it to the top of the stack.
                     //
                     // TODO: Make this more generic than just "if scrolling crop to kid_area".
-                    if container.maybe_x_scroll_state.is_some()
-                    || container.maybe_y_scroll_state.is_some() {
+                    if container.maybe_x_scroll_state.is_some() ||
+                       container.maybe_y_scroll_state.is_some() {
                         let context = crop_context(context, container.kid_area.rect);
                         scroll_stack.push(context);
                     }
                 }
-            },
+            }
 
             Visitable::Scrollbar(idx) => {
                 if let Some(widget) = graph.widget(idx) {
@@ -149,8 +149,16 @@ fn crop_context(context: Context, rect: Rect) -> Context {
     // can't represent the negative coords with `u16` (the target DrawState dimension type).
     // We'll hold onto the lost negative values (x_neg and y_neg) so that we can compensate
     // with the width and height.
-    let x_neg = if x < 0 { x } else { 0 };
-    let y_neg = if y < 0 { y } else { 0 };
+    let x_neg = if x < 0 {
+        x
+    } else {
+        0
+    };
+    let y_neg = if y < 0 {
+        y
+    } else {
+        0
+    };
     let mut x = ::std::cmp::max(0, x) as u16;
     let mut y = ::std::cmp::max(0, y) as u16;
     let mut w = ::std::cmp::max(0, (w as i32 + x_neg)) as u16;
@@ -164,12 +172,28 @@ fn crop_context(context: Context, rect: Rect) -> Context {
             h = 0;
         } else {
             // If there is some intersection, calculate the overlapping rect.
-            let (a_l, a_r, a_b, a_t) = (x, x+w, y, y+h);
-            let (b_l, b_r, b_b, b_t) = (rect.x, rect.x+rect.w, rect.y, rect.y+rect.h);
-            let l = if a_l > b_l { a_l } else { b_l };
-            let r = if a_r < b_r { a_r } else { b_r };
-            let b = if a_b > b_b { a_b } else { b_b };
-            let t = if a_t < b_t { a_t } else { b_t };
+            let (a_l, a_r, a_b, a_t) = (x, x + w, y, y + h);
+            let (b_l, b_r, b_b, b_t) = (rect.x, rect.x + rect.w, rect.y, rect.y + rect.h);
+            let l = if a_l > b_l {
+                a_l
+            } else {
+                b_l
+            };
+            let r = if a_r < b_r {
+                a_r
+            } else {
+                b_r
+            };
+            let b = if a_b > b_b {
+                a_b
+            } else {
+                b_b
+            };
+            let t = if a_t < b_t {
+                a_t
+            } else {
+                b_t
+            };
             x = l;
             y = b;
             w = r - l;
@@ -189,7 +213,7 @@ pub fn draw_from_container<G, C>(context: &Context,
                                  container: &Container,
                                  theme: &Theme)
     where G: Graphics,
-          C: CharacterCache<Texture=G::Texture>,
+          C: CharacterCache<Texture = G::Texture>
 {
     use widget::primitive::shape::Style as ShapeStyle;
 
@@ -201,16 +225,16 @@ pub fn draw_from_container<G, C>(context: &Context,
                     ShapeStyle::Fill(_) => {
                         let color = rectangle.style.get_color(theme);
                         draw_rectangle(context, graphics, container.rect, color);
-                    },
+                    }
                     ShapeStyle::Outline(line_style) => {
                         let (l, r, b, t) = container.rect.l_r_b_t();
                         let points = [[l, b], [l, t], [r, t], [r, b], [l, b]];
                         let points = points.iter().cloned();
                         draw_lines(context, graphics, theme, points, line_style);
-                    },
+                    }
                 }
             }
-        },
+        }
 
         primitive::shape::framed_rectangle::KIND => {
             if let Some(framed_rectangle) = container.unique_widget_state::<::FramedRectangle>() {
@@ -224,7 +248,7 @@ pub fn draw_from_container<G, C>(context: &Context,
                 let rect = container.rect.pad(frame);
                 draw_rectangle(context, graphics, rect, color);
             }
-        },
+        }
 
         primitive::shape::oval::KIND => {
             if let Some(oval) = container.unique_widget_state::<::Oval>() {
@@ -235,7 +259,7 @@ pub fn draw_from_container<G, C>(context: &Context,
                 let t = 2.0 * PI / CIRCLE_RESOLUTION as Scalar;
                 let hw = w / 2.0;
                 let hh = h / 2.0;
-                let f = |i: Scalar| [x + hw * (t*i).cos(), y + hh * (t*i).sin()];
+                let f = |i: Scalar| [x + hw * (t * i).cos(), y + hh * (t * i).sin()];
                 let mut points = [[0.0, 0.0]; NUM_POINTS];
                 for i in 0..NUM_POINTS {
                     points[i] = f(i as f64);
@@ -246,14 +270,14 @@ pub fn draw_from_container<G, C>(context: &Context,
                         let color = oval.style.get_color(theme).to_fsa();
                         let polygon = graphics::Polygon::new(color);
                         polygon.draw(&points, &context.draw_state, context.transform, graphics);
-                    },
+                    }
                     ShapeStyle::Outline(line_style) => {
                         let points = points.iter().cloned();
                         draw_lines(context, graphics, theme, points, line_style)
-                    },
+                    }
                 }
             }
-        },
+        }
 
         primitive::shape::polygon::KIND => {
             use widget::primitive::shape::Style;
@@ -266,23 +290,23 @@ pub fn draw_from_container<G, C>(context: &Context,
                         let points = &polygon.state.points[..];
                         let polygon = graphics::Polygon::new(color);
                         polygon.draw(points, &context.draw_state, context.transform, graphics);
-                    },
+                    }
                     ShapeStyle::Outline(line_style) => {
                         let mut points = polygon.state.points.iter().cloned();
                         let first = points.next();
                         let points = first.into_iter().chain(points).chain(first);
                         draw_lines(context, graphics, theme, points, line_style);
-                    },
+                    }
                 }
             }
-        },
+        }
 
         primitive::line::KIND => {
             if let Some(line) = container.unique_widget_state::<::Line>() {
                 let points = once(line.state.start).chain(once(line.state.end));
                 draw_lines(context, graphics, theme, points, line.style);
             }
-        },
+        }
 
         primitive::point_path::KIND => {
             use widget::primitive::point_path::{State, Style};
@@ -290,7 +314,7 @@ pub fn draw_from_container<G, C>(context: &Context,
                 let points = point_path.state.points.iter().cloned();
                 draw_lines(context, graphics, theme, points, point_path.style);
             }
-        },
+        }
 
         primitive::text::KIND => {
             if let Some(text) = container.unique_widget_state::<::Text>() {
@@ -313,7 +337,7 @@ pub fn draw_from_container<G, C>(context: &Context,
                         .draw(line, character_cache, draw_state, transform, graphics);
                 }
             }
-        },
+        }
 
         _ => (),
     }
@@ -321,11 +345,8 @@ pub fn draw_from_container<G, C>(context: &Context,
 
 
 /// Draw a rectangle at the given Rect.
-pub fn draw_rectangle<G>(context: &Context,
-                         graphics: &mut G,
-                         rect: Rect,
-                         color: Color)
-    where G: Graphics,
+pub fn draw_rectangle<G>(context: &Context, graphics: &mut G, rect: Rect, color: Color)
+    where G: Graphics
 {
     let (l, b, w, h) = rect.l_b_w_h();
     let lbwh = [l, b, w, h];
@@ -341,7 +362,7 @@ pub fn draw_lines<G, I>(context: &Context,
                         mut points: I,
                         style: primitive::line::Style)
     where G: Graphics,
-          I: Iterator<Item=Point>,
+          I: Iterator<Item = Point>
 {
     use widget::primitive::line::{Cap, Pattern};
 
@@ -362,7 +383,7 @@ pub fn draw_lines<G, I>(context: &Context,
                     line.draw(coords, &context.draw_state, context.transform, graphics);
                     start = end;
                 }
-            },
+            }
             Pattern::Dashed => unimplemented!(),
             Pattern::Dotted => unimplemented!(),
         }
@@ -376,7 +397,7 @@ pub fn draw_scrolling<G>(context: &Context,
                          kid_area_rect: Rect,
                          maybe_x_scroll_state: Option<widget::scroll::StateX>,
                          maybe_y_scroll_state: Option<widget::scroll::StateY>)
-    where G: Graphics,
+    where G: Graphics
 {
     use widget::scroll;
 
@@ -385,18 +406,19 @@ pub fn draw_scrolling<G>(context: &Context,
                        kid_area_rect: Rect,
                        scroll_state: &scroll::State<A>)
         where G: Graphics,
-              A: scroll::Axis,
+              A: scroll::Axis
     {
         use widget::scroll::Elem::{Handle, Track};
         use widget::scroll::Interaction::{Highlighted, Clicked};
 
         let color = scroll_state.color;
         let track_color = match scroll_state.interaction {
-            Clicked(Track) => color.highlighted(),
-            Highlighted(_) | Clicked(_) => color,
-            _ if scroll_state.is_scrolling => color,
-            _ => return,
-        }.alpha(0.2);
+                              Clicked(Track) => color.highlighted(),
+                              Highlighted(_) | Clicked(_) => color,
+                              _ if scroll_state.is_scrolling => color,
+                              _ => return,
+                          }
+                          .alpha(0.2);
         let handle_color = match scroll_state.interaction {
             Clicked(Handle(_)) => color.clicked(),
             Highlighted(_) | Clicked(_) => color,

--- a/src/background.rs
+++ b/src/background.rs
@@ -10,20 +10,18 @@ pub struct Background {
 }
 
 impl Background {
-
     /// Construct a background.
     pub fn new() -> Background {
-        Background {
-            maybe_color: None,
-        }
+        Background { maybe_color: None }
     }
 
     /// Set the color used clear the background with before drawing widgets.
-    pub fn set<C>(&mut self, ui: &mut Ui<C>) where C: CharacterCache {
+    pub fn set<C>(&mut self, ui: &mut Ui<C>)
+        where C: CharacterCache
+    {
         let color = self.maybe_color.unwrap_or(ui.theme.background_color);
         ui::clear_with(ui, color);
     }
-
 }
 
 impl Colorable for Background {
@@ -32,4 +30,3 @@ impl Colorable for Background {
         self
     }
 }
-

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! A library providing simple `Color` and `Gradient` types along with useful transformations and
 //! presets.
 //!
@@ -61,13 +61,16 @@ pub fn rgb_bytes(r: u8, g: u8, b: u8) -> Color {
 /// transparency.
 #[inline]
 pub fn hsla(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Color {
-    Color::Hsla(hue - turns((hue / (2.0 * PI)).floor()), saturation, lightness, alpha)
+    Color::Hsla(hue - turns((hue / (2.0 * PI)).floor()),
+                saturation,
+                lightness,
+                alpha)
 }
 
 
 /// Create [HSL colors](http://en.wikipedia.org/wiki/HSL_and_HSV). This gives you access to colors
 /// more like a color wheel, where all hues are arranged in a circle that you specify with radians.
-/// 
+///
 ///   red        = hsl(degrees(0.0)   , 1.0 , 0.5)
 ///   green      = hsl(degrees(120.0) , 1.0 , 0.5)
 ///   blue       = hsl(degrees(240.0) , 1.0 , 0.5)
@@ -84,11 +87,11 @@ pub fn hsl(hue: f32, saturation: f32, lightness: f32) -> Color {
 
 /// Produce a gray based on the input. 0.0 is white, 1.0 is black.
 pub fn grayscale(p: f32) -> Color {
-    Color::Hsla(0.0, 0.0, 1.0-p, 1.0)
+    Color::Hsla(0.0, 0.0, 1.0 - p, 1.0)
 }
 /// Produce a gray based on the input. 0.0 is white, 1.0 is black.
 pub fn greyscale(p: f32) -> Color {
-    Color::Hsla(0.0, 0.0, 1.0-p, 1.0)
+    Color::Hsla(0.0, 0.0, 1.0 - p, 1.0)
 }
 
 
@@ -100,12 +103,17 @@ pub fn random() -> Color {
 
 /// Clamp a f32 between 0f32 and 1f32.
 fn clampf32(f: f32) -> f32 {
-    if f < 0.0 { 0.0 } else if f > 1.0 { 1.0 } else { f }
+    if f < 0.0 {
+        0.0
+    } else if f > 1.0 {
+        1.0
+    } else {
+        f
+    }
 }
 
 
 impl Color {
-
     /// Produce a complementary color. The two colors will accent each other. This is the same as
     /// rotating the hue by 180 degrees.
     pub fn complement(self) -> Color {
@@ -114,7 +122,7 @@ impl Color {
             Color::Rgba(r, g, b, a) => {
                 let (h, s, l) = rgb_to_hsl(r, g, b);
                 hsla(h + degrees(180.0), s, l, a)
-            },
+            }
         }
     }
 
@@ -129,7 +137,11 @@ impl Color {
     /// Return either black or white, depending which contrasts the Color the most. This will be
     /// useful for determining a readable color for text on any given background Color.
     pub fn plain_contrast(self) -> Color {
-        if self.luminance() > 0.5 { BLACK } else { WHITE }
+        if self.luminance() > 0.5 {
+            BLACK
+        } else {
+            WHITE
+        }
     }
 
     /// Extract the components of a color in the HSL format.
@@ -139,7 +151,7 @@ impl Color {
             Color::Rgba(r, g, b, a) => {
                 let (h, s, l) = rgb_to_hsl(r, g, b);
                 Hsla(h, s, l, a)
-            },
+            }
         }
     }
 
@@ -150,7 +162,7 @@ impl Color {
             Color::Hsla(h, s, l, a) => {
                 let (r, g, b) = hsl_to_rgb(h, s, l);
                 Rgba(r, g, b, a)
-            },
+            }
         }
     }
 
@@ -201,9 +213,11 @@ impl Color {
         let luminance = self.luminance();
         let Rgba(r, g, b, a) = self.to_rgb();
         let (r, g, b) = {
-            if      luminance > 0.8 { (r - 0.2, g - 0.2, b - 0.2) }
-            else if luminance < 0.2 { (r + 0.2, g + 0.2, b + 0.2) }
-            else {
+            if luminance > 0.8 {
+                (r - 0.2, g - 0.2, b - 0.2)
+            } else if luminance < 0.2 {
+                (r + 0.2, g + 0.2, b + 0.2)
+            } else {
                 (clampf32((1.0 - r) * 0.5 * r + r),
                  clampf32((1.0 - g) * 0.1 * g + g),
                  clampf32((1.0 - b) * 0.1 * b + b))
@@ -218,9 +232,11 @@ impl Color {
         let luminance = self.luminance();
         let Rgba(r, g, b, a) = self.to_rgb();
         let (r, g, b) = {
-            if      luminance > 0.8 { (r      , g - 0.2, b - 0.2) }
-            else if luminance < 0.2 { (r + 0.4, g + 0.2, b + 0.2) }
-            else {
+            if luminance > 0.8 {
+                (r, g - 0.2, b - 0.2)
+            } else if luminance < 0.2 {
+                (r + 0.4, g + 0.2, b + 0.2)
+            } else {
                 (clampf32((1.0 - r) * 0.75 + r),
                  clampf32((1.0 - g) * 0.25 + g),
                  clampf32((1.0 - b) * 0.25 + b))
@@ -271,7 +287,6 @@ impl Color {
         let Rgba(r, g, _, a) = self.to_rgb();
         *self = rgba(r, g, b, a);
     }
-
 }
 
 
@@ -287,7 +302,9 @@ pub struct Rgba(pub f32, pub f32, pub f32, pub f32);
 
 /// Convert an f32 color to a byte.
 #[inline]
-pub fn f32_to_byte(c: f32) -> u8 { (c * 255.0) as u8 }
+pub fn f32_to_byte(c: f32) -> u8 {
+    (c * 255.0) as u8
+}
 
 
 /// Pure function for converting rgb to hsl.
@@ -300,14 +317,22 @@ pub fn rgb_to_hsl(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
         // If there's no difference in the channels we have grayscale, so the hue is undefined.
         0.0
     } else {
-        degrees(60.0) * if      c_max == r { fmod(((g - b) / c), 6) }
-                        else if c_max == g { ((b - r) / c) + 2.0 }
-                        else               { ((r - g) / c) + 4.0 }
+        degrees(60.0) *
+        if c_max == r {
+            fmod(((g - b) / c), 6)
+        } else if c_max == g {
+            ((b - r) / c) + 2.0
+        } else {
+            ((r - g) / c) + 4.0
+        }
     };
 
     let lightness = (c_max + c_min) / 2.0;
-    let saturation = if lightness == 0.0 { 0.0 }
-                     else { c / (1.0 - (2.0 * lightness - 1.0).abs()) };
+    let saturation = if lightness == 0.0 {
+        0.0
+    } else {
+        c / (1.0 - (2.0 * lightness - 1.0).abs())
+    };
     (hue, saturation, lightness)
 }
 
@@ -352,9 +377,12 @@ pub fn linear(start: (f64, f64), end: (f64, f64), colors: Vec<(f64, Color)>) -> 
 
 
 /// Create a radial gradient. 
-pub fn radial(start: (f64, f64), start_r: f64,
-              end: (f64, f64), end_r: f64,
-              colors: Vec<(f64, Color)>) -> Gradient {
+pub fn radial(start: (f64, f64),
+              start_r: f64,
+              end: (f64, f64),
+              end_r: f64,
+              colors: Vec<(f64, Color)>)
+              -> Gradient {
     Gradient::Radial(start, start_r, end, end_r, colors)
 }
 
@@ -371,83 +399,83 @@ macro_rules! make_color {
 	($r:expr, $g:expr, $b:expr, $a:expr) => ( Color::Rgba($r as f32 / 255.0, $g as f32 / 255.0, $b as f32 / 255.0, $a as f32 / 255.0));
 }
 
-/// Scarlet Red - Light - #EF2929                         
-pub const LIGHT_RED      :  Color = make_color!(239, 41, 41);
-/// Scarlet Red - Regular - #CC0000                       
-pub const RED            :  Color = make_color!(204, 0, 0);
-/// Scarlet Red - Dark - #A30000                          
-pub const DARK_RED       :  Color = make_color!(164, 0, 0);
+/// Scarlet Red - Light - #EF2929
+pub const LIGHT_RED: Color = make_color!(239, 41, 41);
+/// Scarlet Red - Regular - #CC0000
+pub const RED: Color = make_color!(204, 0, 0);
+/// Scarlet Red - Dark - #A30000
+pub const DARK_RED: Color = make_color!(164, 0, 0);
 
-/// Orange - Light - #FCAF3E                              
-pub const LIGHT_ORANGE   :  Color = make_color!(252, 175, 62);
-/// Orange - Regular - #F57900                            
-pub const ORANGE         :  Color = make_color!(245, 121, 0);
-/// Orange - Dark - #CE5C00                               
-pub const DARK_ORANGE    :  Color = make_color!(206, 92, 0);
+/// Orange - Light - #FCAF3E
+pub const LIGHT_ORANGE: Color = make_color!(252, 175, 62);
+/// Orange - Regular - #F57900
+pub const ORANGE: Color = make_color!(245, 121, 0);
+/// Orange - Dark - #CE5C00
+pub const DARK_ORANGE: Color = make_color!(206, 92, 0);
 
-/// Butter - Light - #FCE94F                              
-pub const LIGHT_YELLOW   :  Color = make_color!(1, 233, 79);
-/// Butter - Regular - #EDD400                            
-pub const YELLOW         :  Color = make_color!(237, 212, 0);
-/// Butter - Dark - #C4A000                               
-pub const DARK_YELLOW    :  Color = make_color!(196, 160, 0);
+/// Butter - Light - #FCE94F
+pub const LIGHT_YELLOW: Color = make_color!(1, 233, 79);
+/// Butter - Regular - #EDD400
+pub const YELLOW: Color = make_color!(237, 212, 0);
+/// Butter - Dark - #C4A000
+pub const DARK_YELLOW: Color = make_color!(196, 160, 0);
 
-/// Chameleon - Light - #8AE234                           
-pub const LIGHT_GREEN     :  Color = make_color!(138, 226, 52);
-/// Chameleon - Regular - #73D216                         
-pub const GREEN          :  Color = make_color!(115, 210, 22);
-/// Chameleon - Dark - #4E9A06                            
-pub const DARK_GREEN     :  Color = make_color!(78, 154, 6);
+/// Chameleon - Light - #8AE234
+pub const LIGHT_GREEN: Color = make_color!(138, 226, 52);
+/// Chameleon - Regular - #73D216
+pub const GREEN: Color = make_color!(115, 210, 22);
+/// Chameleon - Dark - #4E9A06
+pub const DARK_GREEN: Color = make_color!(78, 154, 6);
 
-/// Sky Blue - Light - #729FCF                            
-pub const LIGHT_BLUE     :  Color = make_color!(114, 159, 207);
-/// Sky Blue - Regular - #3465A4                          
-pub const BLUE           :  Color = make_color!(52, 101, 164);
-/// Sky Blue - Dark - #204A87                             
-pub const DARK_BLUE      :  Color = make_color!(32, 74, 135);
+/// Sky Blue - Light - #729FCF
+pub const LIGHT_BLUE: Color = make_color!(114, 159, 207);
+/// Sky Blue - Regular - #3465A4
+pub const BLUE: Color = make_color!(52, 101, 164);
+/// Sky Blue - Dark - #204A87
+pub const DARK_BLUE: Color = make_color!(32, 74, 135);
 
-/// Plum - Light - #AD7FA8                                
-pub const LIGHT_PURPLE   :  Color = make_color!(173, 127, 168);
-/// Plum - Regular - #75507B                              
-pub const PURPLE         :  Color = make_color!(117, 80, 123);
-/// Plum - Dark - #5C3566                                 
-pub const DARK_PURPLE    :  Color = make_color!(92, 53, 102);
+/// Plum - Light - #AD7FA8
+pub const LIGHT_PURPLE: Color = make_color!(173, 127, 168);
+/// Plum - Regular - #75507B
+pub const PURPLE: Color = make_color!(117, 80, 123);
+/// Plum - Dark - #5C3566
+pub const DARK_PURPLE: Color = make_color!(92, 53, 102);
 
-/// Chocolate - Light - #E9B96E                           
-pub const LIGHT_BROWN    :  Color = make_color!(233, 185, 110);
-/// Chocolate - Regular - #C17D11                         
-pub const BROWN          :  Color = make_color!(193, 125, 17);
-/// Chocolate - Dark - #8F5902                            
-pub const DARK_BROWN     :  Color = make_color!(143, 89, 2);
+/// Chocolate - Light - #E9B96E
+pub const LIGHT_BROWN: Color = make_color!(233, 185, 110);
+/// Chocolate - Regular - #C17D11
+pub const BROWN: Color = make_color!(193, 125, 17);
+/// Chocolate - Dark - #8F5902
+pub const DARK_BROWN: Color = make_color!(143, 89, 2);
 
-/// Straight Black.                                       
-pub const BLACK          :  Color = make_color!(0, 0, 0);
-/// Straight White.                                       
-pub const WHITE          :  Color = make_color!(255, 255, 255);
+/// Straight Black.
+pub const BLACK: Color = make_color!(0, 0, 0);
+/// Straight White.
+pub const WHITE: Color = make_color!(255, 255, 255);
 
-/// Alluminium - Light                                    
-pub const LIGHT_GRAY     :  Color = make_color!(238, 238, 236);
-/// Alluminium - Regular                                  
-pub const GRAY           :  Color = make_color!(211, 215, 207);
-/// Alluminium - Dark                                     
-pub const DARK_GRAY      :  Color = make_color!(186, 189, 182);
+/// Alluminium - Light
+pub const LIGHT_GRAY: Color = make_color!(238, 238, 236);
+/// Alluminium - Regular
+pub const GRAY: Color = make_color!(211, 215, 207);
+/// Alluminium - Dark
+pub const DARK_GRAY: Color = make_color!(186, 189, 182);
 
-/// Aluminium - Light - #EEEEEC                           
-pub const LIGHT_GREY     :  Color = make_color!(238, 238, 236);
-/// Aluminium - Regular - #D3D7CF                         
-pub const GREY           :  Color = make_color!(211, 215, 207);
-/// Aluminium - Dark - #BABDB6                            
-pub const DARK_GREY      :  Color = make_color!(186, 189, 182);
+/// Aluminium - Light - #EEEEEC 
+pub const LIGHT_GREY: Color = make_color!(238, 238, 236);
+/// Aluminium - Regular - #D3D7CF
+pub const GREY: Color = make_color!(211, 215, 207);
+/// Aluminium - Dark - #BABDB6
+pub const DARK_GREY: Color = make_color!(186, 189, 182);
 
-/// Charcoal - Light - #888A85                            
-pub const LIGHT_CHARCOAL :  Color = make_color!(136, 138, 133);
-/// Charcoal - Regular - #555753                          
-pub const CHARCOAL       :  Color = make_color!(85, 87, 83);
-/// Charcoal - Dark - #2E3436                             
-pub const DARK_CHARCOAL  :  Color = make_color!(46, 52, 54);
+/// Charcoal - Light - #888A85
+pub const LIGHT_CHARCOAL: Color = make_color!(136, 138, 133);
+/// Charcoal - Regular - #555753
+pub const CHARCOAL: Color = make_color!(85, 87, 83);
+/// Charcoal - Dark - #2E3436
+pub const DARK_CHARCOAL: Color = make_color!(46, 52, 54);
 
 /// Transparent
-pub const TRANSPARENT    :  Color = Color::Rgba(0.0, 0.0, 0.0, 0.0);
+pub const TRANSPARENT: Color = Color::Rgba(0.0, 0.0, 0.0, 0.0);
 
 /// Types that can be colored.
 pub trait Colorable: Sized {
@@ -476,4 +504,3 @@ pub trait Colorable: Sized {
     }
 
 }
-

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -41,4 +41,3 @@ pub trait Frameable: Sized {
     }
 
 }
-

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -97,24 +97,21 @@ pub type LinesWrappedByWhitespace<'a, C> = LinesWrappedBy<'a, C, NextLineBreakFn
 
 
 impl<C> GlyphCache<C> {
-
     /// Construct a new **GlyphCache**.
     pub fn new(cache: C) -> Self {
-        GlyphCache {
-            ref_cell: RefCell::new(cache),
-        }
+        GlyphCache { ref_cell: RefCell::new(cache) }
     }
 
     /// The width of a single character with the given size.
     pub fn char_width(&self, font_size: FontSize, ch: char) -> Scalar
-        where C: CharacterCache,
+        where C: CharacterCache
     {
         self.ref_cell.borrow_mut().character(font_size, ch).width()
     }
 
     /// Converts the given sequence of `char`s into their Scalar widths.
     pub fn char_widths<I>(&self, font_size: FontSize, chars: I) -> CharWidths<C, I::IntoIter>
-        where I: IntoIterator<Item=char>,
+        where I: IntoIterator<Item = char>
     {
         CharWidths {
             font_size: font_size,
@@ -124,9 +121,13 @@ impl<C> GlyphCache<C> {
     }
 
     /// Converts the given sequnce of `char`s into their consecutive positions along the x-axis.
-    pub fn char_xs<I>(&self, font_size: FontSize, start_x: Scalar, chars: I) -> CharXs<C, I::IntoIter>
+    pub fn char_xs<I>(&self,
+                      font_size: FontSize,
+                      start_x: Scalar,
+                      chars: I)
+                      -> CharXs<C, I::IntoIter>
         where C: CharacterCache,
-              I: IntoIterator<Item=char>,
+              I: IntoIterator<Item = char>
     {
         let mut widths = self.char_widths(font_size, chars);
         let maybe_first = widths.next().map(|w| (w / 2.0, start_x));
@@ -138,14 +139,14 @@ impl<C> GlyphCache<C> {
 
     /// Return the width of the given text.
     pub fn width(&self, font_size: FontSize, text: &str) -> Scalar
-        where C: CharacterCache,
+        where C: CharacterCache
     {
         self.ref_cell.borrow_mut().width(font_size, text)
     }
 
     /// Converts the given sequence of `&str`s into their Scalar widths.
     pub fn widths<I>(&self, font_size: FontSize, strs: I) -> Widths<C, I::IntoIter>
-        where for<'a> I: IntoIterator<Item=&'a str>,
+        where for<'a> I: IntoIterator<Item = &'a str>
     {
         Widths {
             font_size: font_size,
@@ -160,8 +161,8 @@ impl<C> GlyphCache<C> {
                                  font_size: FontSize,
                                  text: &'a str,
                                  max_width: Scalar,
-                                 line_break_fn: F) -> LineBreaksBy<'a, C, F>
-    {
+                                 line_break_fn: F)
+                                 -> LineBreaksBy<'a, C, F> {
         LineBreaksBy {
             font_size: font_size,
             cache: self,
@@ -176,8 +177,9 @@ impl<C> GlyphCache<C> {
     pub fn line_breaks_by_character<'a>(&'a self,
                                         font_size: FontSize,
                                         text: &'a str,
-                                        max_width: Scalar) -> LineBreaksByCharacter<'a, C>
-        where C: CharacterCache,
+                                        max_width: Scalar)
+                                        -> LineBreaksByCharacter<'a, C>
+        where C: CharacterCache
     {
         self.line_breaks_by(font_size, text, max_width, LineBreak::next_by_character)
     }
@@ -186,8 +188,9 @@ impl<C> GlyphCache<C> {
     pub fn line_breaks_by_whitespace<'a>(&'a self,
                                          font_size: FontSize,
                                          text: &'a str,
-                                         max_width: Scalar) -> LineBreaksByWhitespace<'a, C>
-        where C: CharacterCache,
+                                         max_width: Scalar)
+                                         -> LineBreaksByWhitespace<'a, C>
+        where C: CharacterCache
     {
         self.line_breaks_by(font_size, text, max_width, LineBreak::next_by_whitespace)
     }
@@ -198,8 +201,8 @@ impl<C> GlyphCache<C> {
                                    font_size: FontSize,
                                    text: &'a str,
                                    max_width: Scalar,
-                                   wrap_fn: F) -> LinesWrappedBy<'a, C, F>
-    {
+                                   wrap_fn: F)
+                                   -> LinesWrappedBy<'a, C, F> {
         let line_breaks = self.line_breaks_by(font_size, text, max_width, wrap_fn);
         Lines::new(text, line_breaks)
     }
@@ -209,8 +212,9 @@ impl<C> GlyphCache<C> {
     pub fn lines_wrapped_by_character<'a>(&'a self,
                                           font_size: FontSize,
                                           text: &'a str,
-                                          max_width: Scalar) -> LinesWrappedByCharacter<'a, C>
-        where C: CharacterCache,
+                                          max_width: Scalar)
+                                          -> LinesWrappedByCharacter<'a, C>
+        where C: CharacterCache
     {
         let line_breaks = self.line_breaks_by_character(font_size, text, max_width);
         Lines::new(text, line_breaks)
@@ -221,13 +225,13 @@ impl<C> GlyphCache<C> {
     pub fn lines_wrapped_by_whitespace<'a>(&'a self,
                                            font_size: FontSize,
                                            text: &'a str,
-                                           max_width: Scalar) -> LinesWrappedByWhitespace<'a, C>
-        where C: CharacterCache,
+                                           max_width: Scalar)
+                                           -> LinesWrappedByWhitespace<'a, C>
+        where C: CharacterCache
     {
         let line_breaks = self.line_breaks_by_character(font_size, text, max_width);
         Lines::new(text, line_breaks)
     }
-
 }
 
 
@@ -247,7 +251,7 @@ impl<C> ::std::ops::DerefMut for GlyphCache<C> {
 
 impl<'a, C, I> Iterator for CharWidths<'a, C, I>
     where C: CharacterCache,
-          I: Iterator<Item=char>,
+          I: Iterator<Item = char>
 {
     type Item = Scalar;
     fn next(&mut self) -> Option<Self::Item> {
@@ -258,7 +262,7 @@ impl<'a, C, I> Iterator for CharWidths<'a, C, I>
 
 impl<'a, C, I> Iterator for Widths<'a, C, I>
     where C: CharacterCache,
-          for<'b> I: Iterator<Item=&'b str>,
+          for<'b> I: Iterator<Item = &'b str>
 {
     type Item = Scalar;
     fn next(&mut self) -> Option<Self::Item> {
@@ -269,7 +273,7 @@ impl<'a, C, I> Iterator for Widths<'a, C, I>
 
 impl<'a, C, I> Iterator for CharXs<'a, C, I>
     where C: CharacterCache,
-          I: Iterator<Item=char>,
+          I: Iterator<Item = char>
 {
     type Item = X;
     fn next(&mut self) -> Option<Self::Item> {
@@ -286,7 +290,7 @@ impl<'a, C, I> Iterator for CharXs<'a, C, I>
 
 impl<'a, C, F> Iterator for LineBreaksBy<'a, C, F>
     where C: CharacterCache,
-          for<'b> F: FnMut(&'b GlyphCache<C>, FontSize, &'b str, Scalar) -> Option<LineBreak>,
+          for<'b> F: FnMut(&'b GlyphCache<C>, FontSize, &'b str, Scalar) -> Option<LineBreak>
 {
     /// The index into the start of the line along with the line's break if it has one.
     type Item = (usize, Option<LineBreak>);
@@ -312,20 +316,21 @@ impl<'a, C, F> Iterator for LineBreaksBy<'a, C, F>
                     LineBreak::Wrap(idx, width) => idx + width,
                 };
                 Some(range)
-            },
-            None => if *start < text.len() {
-                let last = Some((*start, None));
-                *start = text.len();
-                last
-            } else {
-                None
-            },
+            }
+            None => {
+                if *start < text.len() {
+                    let last = Some((*start, None));
+                    *start = text.len();
+                    last
+                } else {
+                    None
+                }
+            }
         }
     }
 }
 
-impl<'a, I> Iterator for Lines<'a, I>
-    where I: Iterator<Item=(usize, Option<LineBreak>)>,
+impl<'a, I> Iterator for Lines<'a, I> where I: Iterator<Item = (usize, Option<LineBreak>)>
 {
     type Item = &'a str;
     fn next(&mut self) -> Option<Self::Item> {
@@ -333,16 +338,17 @@ impl<'a, I> Iterator for Lines<'a, I>
             ref text,
             ref mut line_breaks,
         } = *self;
-        line_breaks.next().map(|(start, maybe_line_break)| match maybe_line_break {
-            Some(line_break) => &text[start..line_break.index()],
-            None => &text[start..],
+        line_breaks.next().map(|(start, maybe_line_break)| {
+            match maybe_line_break {
+                Some(line_break) => &text[start..line_break.index()],
+                None => &text[start..],
+            }
         })
     }
 }
 
 
 impl LineBreak {
-
     /// Extracts the index at which the break occurs within the text (i.e. the index following the
     /// last byte of the line).
     pub fn index(self) -> usize {
@@ -357,8 +363,9 @@ impl LineBreak {
     pub fn next_by_character<C>(cache: &GlyphCache<C>,
                                 font_size: FontSize,
                                 text: &str,
-                                max_width: Scalar) -> Option<Self>
-        where C: CharacterCache,
+                                max_width: Scalar)
+                                -> Option<Self>
+        where C: CharacterCache
     {
         let mut width = 0.0;
         let mut char_indices = text.char_indices().peekable();
@@ -367,7 +374,7 @@ impl LineBreak {
             // Check for a newline.
             if ch == '\r' {
                 if let Some(&(_, '\n')) = char_indices.peek() {
-                    return Some(LineBreak::Newline(i, 2))
+                    return Some(LineBreak::Newline(i, 2));
                 }
             } else if ch == '\n' {
                 return Some(LineBreak::Newline(i, 1));
@@ -391,8 +398,9 @@ impl LineBreak {
     pub fn next_by_whitespace<C>(cache: &GlyphCache<C>,
                                  font_size: FontSize,
                                  text: &str,
-                                 max_width: Scalar) -> Option<Self>
-        where C: CharacterCache,
+                                 max_width: Scalar)
+                                 -> Option<Self>
+        where C: CharacterCache
     {
         let mut width = 0.0;
         let mut last_whitespace_start = 0;
@@ -402,14 +410,11 @@ impl LineBreak {
             // Check for a newline.
             if ch == '\r' {
                 if let Some(&(_, '\n')) = char_indices.peek() {
-                    return Some(LineBreak::Newline(i, 2))
+                    return Some(LineBreak::Newline(i, 2));
                 }
             } else if ch == '\n' {
                 return Some(LineBreak::Newline(i, 1));
-            }
-
-            // Check for a new whitespace.
-            else if ch.is_whitespace() {
+            } else if ch.is_whitespace() {
                 last_whitespace_start = i;
             }
 
@@ -423,7 +428,6 @@ impl LineBreak {
         }
         None
     }
-
 }
 
 

--- a/src/graph/depth_order.rs
+++ b/src/graph/depth_order.rs
@@ -2,12 +2,7 @@
 
 use daggy::Walker;
 use std::collections::HashSet;
-use super::{
-    Graph,
-    GraphIndex,
-    Node,
-    NodeIndex,
-};
+use super::{Graph, GraphIndex, Node, NodeIndex};
 
 
 /// Contains Node indices in order of depth, starting with the deepest.
@@ -34,7 +29,6 @@ pub enum Visitable {
 
 
 impl DepthOrder {
-
     /// Construct a new empty **DepthOrder**.
     pub fn new() -> DepthOrder {
         DepthOrder {
@@ -73,7 +67,7 @@ impl DepthOrder {
                         maybe_captured_mouse: Option<M>,
                         maybe_captured_keyboard: Option<K>)
         where M: GraphIndex,
-              K: GraphIndex,
+              K: GraphIndex
     {
         let DepthOrder { ref mut indices, ref mut floating } = *self;
 
@@ -98,13 +92,15 @@ impl DepthOrder {
                        floating);
 
         // Sort the floating widgets so that the ones clicked last come last.
-        floating.sort_by(|&a, &b| match (&graph[a], &graph[b]) {
-            (&Node::Widget(ref a), &Node::Widget(ref b)) => {
-                let a_floating = a.maybe_floating.expect("Not floating");
-                let b_floating = b.maybe_floating.expect("Not floating");
-                a_floating.time_last_clicked.cmp(&b_floating.time_last_clicked)
-            },
-            _ => ::std::cmp::Ordering::Equal,
+        floating.sort_by(|&a, &b| {
+            match (&graph[a], &graph[b]) {
+                (&Node::Widget(ref a), &Node::Widget(ref b)) => {
+                    let a_floating = a.maybe_floating.expect("Not floating");
+                    let b_floating = b.maybe_floating.expect("Not floating");
+                    a_floating.time_last_clicked.cmp(&b_floating.time_last_clicked)
+                }
+                _ => ::std::cmp::Ordering::Equal,
+            }
         });
 
         // Visit all of the floating widgets last.
@@ -119,7 +115,6 @@ impl DepthOrder {
                            floating);
         }
     }
-
 }
 
 
@@ -130,8 +125,7 @@ fn visit_by_depth(graph: &Graph,
                   maybe_captured_mouse: Option<NodeIndex>,
                   maybe_captured_keyboard: Option<NodeIndex>,
                   depth_order: &mut Vec<Visitable>,
-                  floating_deque: &mut Vec<NodeIndex>)
-{
+                  floating_deque: &mut Vec<NodeIndex>) {
     // First, if the current node is a widget and it was set in the current `set_widgets` stage,
     // store its index.
     match graph.widget(idx).is_some() && updated_widgets.contains(&idx) {
@@ -170,23 +164,22 @@ fn visit_by_depth(graph: &Graph,
         // Store floating widgets int he floating_deque for visiting after the current tree.
         match maybe_is_floating {
             Some(true) => floating_deque.push(child_idx),
-            _          => visit_by_depth(graph,
-                                         child_idx,
-                                         updated_widgets,
-                                         maybe_captured_mouse,
-                                         maybe_captured_keyboard,
-                                         depth_order,
-                                         floating_deque),
+            _ => {
+                visit_by_depth(graph,
+                               child_idx,
+                               updated_widgets,
+                               maybe_captured_mouse,
+                               maybe_captured_keyboard,
+                               depth_order,
+                               floating_deque)
+            }
         }
     }
 
     // If the widget is scrollable, we should add its scrollbar to the visit order also.
     if let Some(widget) = graph.widget(idx) {
-        if widget.maybe_x_scroll_state.is_some()
-        || widget.maybe_y_scroll_state.is_some() {
+        if widget.maybe_x_scroll_state.is_some() || widget.maybe_y_scroll_state.is_some() {
             depth_order.push(Visitable::Scrollbar(idx));
         }
     }
 }
-
-

--- a/src/graph/index_map.rs
+++ b/src/graph/index_map.rs
@@ -15,7 +15,6 @@ pub struct IndexMap {
 
 
 impl IndexMap {
-
     /// Construct an empty **IndexMap**.
     pub fn new() -> Self {
         IndexMap {
@@ -49,7 +48,6 @@ impl IndexMap {
     pub fn get_widget_id(&self, idx: NodeIndex) -> Option<WidgetId> {
         self.widgets.get(&idx).map(|&id| id)
     }
-
 }
 
 impl Index<WidgetId> for IndexMap {
@@ -104,7 +102,6 @@ impl GraphIndex for NodeIndex {
 }
 
 impl GraphIndex for widget::Index {
-
     /// Coerce a widget::Index into an Option<NodeIndex>.
     /// If the Index is the Internal variant, that idx will be used directly.
     /// If the Index is the Public variant, the index_map will be used to find the matching
@@ -131,8 +128,8 @@ impl GraphIndex for widget::Index {
     /// First tries to construct a Public variant by checking the IndexMap for a matching WidgetId.
     /// If not WidgetId is found, then tries to find a matching NodeIndex.
     fn from_idx<I: GraphIndex>(other: I, map: &IndexMap) -> Option<Self> {
-        other.to_widget_id(map).map(|id| widget::Index::Public(id))
-            .or_else(|| other.to_node_index(map).map(|idx| widget::Index::Internal(idx)))
+        other.to_widget_id(map)
+             .map(|id| widget::Index::Public(id))
+             .or_else(|| other.to_node_index(map).map(|idx| widget::Index::Internal(idx)))
     }
-
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -40,8 +40,8 @@ pub type Children = daggy::Children<Node, Edge, u32>;
 pub type PositionParents<I> = iter::Chain<option::IntoIter<I>, option::IntoIter<I>>;
 
 /// An alias for some filtered children walker.
-pub type FilteredChildren =
-    daggy::walker::Filter<Children, fn(&Graph, EdgeIndex, NodeIndex) -> bool>;
+pub type FilteredChildren = daggy::walker::Filter<Children,
+                                                  fn(&Graph, EdgeIndex, NodeIndex) -> bool>;
 /// An alias for a **Walker** over a node's **Depth** children.
 pub type DepthChildren = FilteredChildren;
 /// An alias for a **Walker** over a node's **X Position** children.
@@ -61,9 +61,9 @@ pub type WouldCycle = daggy::WouldCycle<Edge>;
 
 /// The state type that we'll dynamically cast to and from `Any` for storage within the cache.
 #[derive(Debug)]
-pub struct UniqueWidgetState<State, Style> where
-    State: Any + Debug,
-    Style: Any + Debug,
+pub struct UniqueWidgetState<State, Style>
+    where State: Any + Debug,
+          Style: Any + Debug
 {
     /// A **Widget**'s unique "State".
     pub state: State,
@@ -159,11 +159,10 @@ const NO_MATCHING_NODE_INDEX: &'static str = "No matching NodeIndex";
 
 
 impl Container {
-
     /// Borrow the **Container**'s unique widget State and Style if there is any.
     pub fn state_and_style<State, Style>(&self) -> Option<&UniqueWidgetState<State, Style>>
         where State: Any + Debug + 'static,
-              Style: Any + Debug + 'static,
+              Style: Any + Debug + 'static
     {
         self.maybe_state.as_ref().and_then(|boxed_state| boxed_state.downcast_ref())
     }
@@ -173,21 +172,22 @@ impl Container {
     pub fn unique_widget_state<W>(&self) -> Option<&UniqueWidgetState<W::State, W::Style>>
         where W: Widget,
               W::State: Any + 'static,
-              W::Style: Any + 'static,
+              W::Style: Any + 'static
     {
         self.state_and_style::<W::State, W::Style>()
     }
 
     /// A method for taking only the unique state from the container.
     pub fn take_unique_widget_state<W>(&mut self)
-        -> Option<Box<UniqueWidgetState<W::State, W::Style>>>
+                                       -> Option<Box<UniqueWidgetState<W::State, W::Style>>>
         where W: Widget,
               W::State: Any + 'static,
-              W::Style: Any + 'static,
+              W::Style: Any + 'static
     {
         self.maybe_state.take().map(|any_state| {
-            any_state.downcast().ok()
-                .expect("Failed to downcast from `Box<Any>` to the required UniqueWidgetState")
+            any_state.downcast()
+                     .ok()
+                     .expect("Failed to downcast from `Box<Any>` to the required UniqueWidgetState")
         })
     }
 
@@ -195,7 +195,7 @@ impl Container {
     pub fn take_widget_state<W>(&mut self) -> Option<widget::Cached<W>>
         where W: Widget,
               W::State: Any + 'static,
-              W::Style: Any + 'static,
+              W::Style: Any + 'static
     {
         if self.maybe_state.is_some() {
             let boxed_unique_state = self.take_unique_widget_state::<W>().unwrap();
@@ -216,22 +216,22 @@ impl Container {
             None
         }
     }
-
 }
 
 
 impl Node {
-
     /// Whether or not the **Node** is of the **Widget** variant.
     pub fn is_widget(&self) -> bool {
-        if let Node::Widget(_) = *self { true } else { false }
+        if let Node::Widget(_) = *self {
+            true
+        } else {
+            false
+        }
     }
-
 }
 
 
 impl Graph {
-
     /// A new empty **Graph**.
     pub fn new() -> Self {
         Graph {
@@ -286,7 +286,7 @@ impl Graph {
     /// **J**.
     pub fn convert_idx<I, J>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         J::from_idx(idx, &self.index_map)
     }
@@ -305,7 +305,8 @@ impl Graph {
     ///
     /// First attempts to produce a **WidgetId**, then tries to produce a **NodeIndex**.
     pub fn widget_index<I: GraphIndex>(&self, idx: I) -> Option<widget::Index> {
-        self.widget_id(idx).map(|id| widget::Index::Public(id))
+        self.widget_id(idx)
+            .map(|id| widget::Index::Public(id))
             .or_else(|| self.node_index(idx).map(|idx| widget::Index::Internal(idx)))
     }
 
@@ -339,7 +340,7 @@ impl Graph {
     /// **Panics** if the **Graph** is at the maximum number of nodes for its index type.
     fn set_edge<A, B>(&mut self, a: A, b: B, edge: Edge) -> Result<EdgeIndex, WouldCycle>
         where A: GraphIndex,
-              B: GraphIndex,
+              B: GraphIndex
     {
         let a = self.node_index(a).expect(NO_MATCHING_NODE_INDEX);
         let b = self.node_index(b).expect(NO_MATCHING_NODE_INDEX);
@@ -384,13 +385,15 @@ impl Graph {
     ///
     /// Returns `false` if no edges were removed.
     fn remove_parent_edge<I: GraphIndex>(&mut self, idx: I, edge: Edge) -> bool {
-        self.node_index(idx).map(|idx| {
-            if let Some((edge_idx, _)) = self.parents(idx).find(self, |g, e, _| g[e] == edge) {
-                self.remove_edge(edge_idx);
-                return true;
-            }
-            false
-        }).unwrap_or(false)
+        self.node_index(idx)
+            .map(|idx| {
+                if let Some((edge_idx, _)) = self.parents(idx).find(self, |g, e, _| g[e] == edge) {
+                    self.remove_edge(edge_idx);
+                    return true;
+                }
+                false
+            })
+            .unwrap_or(false)
     }
 
     /// Add a new placeholder node and return it's `NodeIndex` into the `Graph`.
@@ -428,17 +431,21 @@ impl Graph {
 
     /// If there is a Widget for the given index, return a reference to it.
     pub fn widget<I: GraphIndex>(&self, idx: I) -> Option<&Container> {
-        self.node(idx).and_then(|node| match *node {
-            Node::Widget(ref container) => Some(container),
-            _ => None,
+        self.node(idx).and_then(|node| {
+            match *node {
+                Node::Widget(ref container) => Some(container),
+                _ => None,
+            }
         })
     }
 
     /// If there is a Widget for the given Id, return a mutable reference to it.
     pub fn widget_mut<I: GraphIndex>(&mut self, idx: I) -> Option<&mut Container> {
-        self.node_mut(idx).and_then(|node| match *node {
-            Node::Widget(ref mut container) => Some(container),
-            _ => None,
+        self.node_mut(idx).and_then(|node| {
+            match *node {
+                Node::Widget(ref mut container) => Some(container),
+                _ => None,
+            }
         })
     }
 
@@ -463,56 +470,57 @@ impl Graph {
     /// return an index to it.
     pub fn edge_parent<I, J>(&self, idx: I, edge: Edge) -> Option<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         self.parents(idx).find(self, |g, e, _| g[e] == edge).and_then(|(_, n)| self.convert_idx(n))
     }
 
     /// Return the index of the parent along the given widget's **Depth** **Edge**.
-    pub fn depth_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn depth_parent<I, J = NodeIndex>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         self.edge_parent(idx, Edge::Depth)
     }
 
     /// Return the index of the parent along the given widget's **Position** **Edge**.
-    pub fn x_position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn x_position_parent<I, J = NodeIndex>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         self.edge_parent(idx, Edge::Position(Axis::X))
     }
 
     /// Return the index of the parent along the given widget's **Position** **Edge**.
-    pub fn y_position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn y_position_parent<I, J = NodeIndex>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         self.edge_parent(idx, Edge::Position(Axis::Y))
     }
 
     /// Produces an iterator yielding the parents along both the **X** and **Y** **Position**
     /// **Edge**s respectively.
-    pub fn position_parents<I, J=NodeIndex>(&self, idx: I) -> PositionParents<J>
+    pub fn position_parents<I, J = NodeIndex>(&self, idx: I) -> PositionParents<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         self.x_position_parent(idx).into_iter().chain(self.y_position_parent(idx))
     }
 
     /// Return the index of the parent along the given widget's **Graphic** **Edge**.
-    pub fn graphic_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn graphic_parent<I, J = NodeIndex>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
-              J: GraphIndex,
+              J: GraphIndex
     {
         self.edge_parent(idx, Edge::Graphic)
     }
 
     /// A **Walker** type that recursively walks **Depth** parents starting from the given node.
-    pub fn depth_parent_recursion<I: GraphIndex>(&self, idx: I)
-        -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>>
-    {
+    pub fn depth_parent_recursion<I: GraphIndex>
+                                                 (&self,
+                                                  idx: I)
+                                                  -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>> {
         fn depth_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
             graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Depth)
         }
@@ -521,9 +529,10 @@ impl Graph {
 
     /// A **Walker** type that recursively walks **X** **Position** parents starting from the given
     /// node.
-    pub fn x_position_parent_recursion<I: GraphIndex>(&self, idx: I)
-        -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>>
-    {
+    pub fn x_position_parent_recursion<I: GraphIndex>
+                                                      (&self,
+                                                       idx: I)
+                                                       -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>> {
         fn x_position_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
             graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Position(Axis::X))
         }
@@ -532,9 +541,10 @@ impl Graph {
 
     /// A **Walker** type that recursively walks **Y** **Position** parents starting from the given
     /// node.
-    pub fn y_position_parent_recursion<I: GraphIndex>(&self, idx: I)
-        -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>>
-    {
+    pub fn y_position_parent_recursion<I: GraphIndex>
+                                                      (&self,
+                                                       idx: I)
+                                                       -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>> {
         fn y_position_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
             graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Position(Axis::Y))
         }
@@ -542,9 +552,10 @@ impl Graph {
     }
 
     /// A **Walker** type that recursively walks **Graphic** parents starting from the given node.
-    pub fn graphic_parent_recursion<I: GraphIndex>(&self, idx: I)
-        -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>>
-    {
+    pub fn graphic_parent_recursion<I: GraphIndex>
+                                                   (&self,
+                                                    idx: I)
+                                                    -> RecursiveWalk<fn(&Graph, NodeIndex) -> Option<IndexPair>> {
         fn graphic_edge_parent(graph: &Graph, idx: NodeIndex) -> Option<IndexPair> {
             graph.parents(idx).find(graph, |g, e, _| g[e] == Edge::Graphic)
         }
@@ -590,11 +601,11 @@ impl Graph {
     pub fn does_edge_exist<P, C, F>(&self, parent: P, child: C, is_edge: F) -> bool
         where P: GraphIndex,
               C: GraphIndex,
-              F: Fn(Edge) -> bool,
+              F: Fn(Edge) -> bool
     {
-        self.node_index(parent).map(|parent| {
-            self.parents(child).any(self, |g, e, n| n == parent && is_edge(g[e]))
-        }).unwrap_or(false)
+        self.node_index(parent)
+            .map(|parent| self.parents(child).any(self, |g, e, n| n == parent && is_edge(g[e])))
+            .unwrap_or(false)
     }
 
     /// Does a **Edge::Depth** exist between the nodes `parent` -> `child`.
@@ -602,7 +613,7 @@ impl Graph {
     /// Returns `false` if either of the given node indices do not exist.
     pub fn does_depth_edge_exist<P, C>(&self, parent: P, child: C) -> bool
         where P: GraphIndex,
-              C: GraphIndex,
+              C: GraphIndex
     {
         self.does_edge_exist(parent, child, |e| e == Edge::Depth)
     }
@@ -612,7 +623,7 @@ impl Graph {
     /// Returns `false` if either of the given node indices do not exist.
     pub fn does_position_edge_exist<P, C>(&self, parent: P, child: C) -> bool
         where P: GraphIndex,
-              C: GraphIndex,
+              C: GraphIndex
     {
         let is_edge = |e| e == Edge::Position(Axis::X) || e == Edge::Position(Axis::Y);
         self.does_edge_exist(parent, child, is_edge)
@@ -623,7 +634,7 @@ impl Graph {
     /// Returns `false` if either of the given node indices do not exist.
     pub fn does_graphic_edge_exist<P, C>(&self, parent: P, child: C) -> bool
         where P: GraphIndex,
-              C: GraphIndex,
+              C: GraphIndex
     {
         self.does_edge_exist(parent, child, |e| e == Edge::Graphic)
     }
@@ -637,12 +648,14 @@ impl Graph {
     pub fn does_recursive_edge_exist<P, C, F>(&self, parent: P, child: C, is_edge: F) -> bool
         where P: GraphIndex,
               C: GraphIndex,
-              F: Fn(Edge) -> bool,
+              F: Fn(Edge) -> bool
     {
-        self.node_index(parent).map(|parent| {
-            self.recursive_walk(child, |g, n| g.parents(n).find(g, |g, e, _| is_edge(g[e])))
-                .any(self, |_, _, n| n == parent)
-        }).unwrap_or(false)
+        self.node_index(parent)
+            .map(|parent| {
+                self.recursive_walk(child, |g, n| g.parents(n).find(g, |g, e, _| is_edge(g[e])))
+                    .any(self, |_, _, n| n == parent)
+            })
+            .unwrap_or(false)
     }
 
     /// Are the given `parent` and `child` nodes connected by a single chain of **Depth** edges?
@@ -652,7 +665,7 @@ impl Graph {
     /// Returns `false` if either of the given node indices do not exist.
     pub fn does_recursive_depth_edge_exist<P, C>(&self, parent: P, child: C) -> bool
         where P: GraphIndex,
-              C: GraphIndex,
+              C: GraphIndex
     {
         self.does_recursive_edge_exist(parent, child, |e| e == Edge::Depth)
     }
@@ -681,7 +694,7 @@ impl Graph {
     /// Returns `false` if either of the given node indices do not exist.
     pub fn does_recursive_graphic_edge_exist<P, C>(&self, parent: P, child: C) -> bool
         where P: GraphIndex,
-              C: GraphIndex,
+              C: GraphIndex
     {
         self.does_recursive_edge_exist(parent, child, |e| e == Edge::Graphic)
     }
@@ -698,8 +711,7 @@ impl Graph {
     pub fn pre_update_cache(&mut self,
                             root: NodeIndex,
                             widget: widget::PreUpdateCache,
-                            instantiation_order_idx: usize)
-    {
+                            instantiation_order_idx: usize) {
         let widget::PreUpdateCache {
             kind, idx, maybe_parent_idx, maybe_x_positioned_relatively_idx,
             maybe_y_positioned_relatively_idx, rect, depth, kid_area, drag_state, maybe_floating,
@@ -707,17 +719,19 @@ impl Graph {
         } = widget;
 
         // Construct a new `Container` to place in the `Graph`.
-        let new_container = || Container {
-            maybe_state: None,
-            kind: kind,
-            rect: rect,
-            depth: depth,
-            drag_state: drag_state,
-            kid_area: kid_area,
-            maybe_floating: maybe_floating,
-            maybe_x_scroll_state: maybe_x_scroll_state,
-            maybe_y_scroll_state: maybe_y_scroll_state,
-            instantiation_order_idx: instantiation_order_idx,
+        let new_container = || {
+            Container {
+                maybe_state: None,
+                kind: kind,
+                rect: rect,
+                depth: depth,
+                drag_state: drag_state,
+                kid_area: kid_area,
+                maybe_floating: maybe_floating,
+                maybe_x_scroll_state: maybe_x_scroll_state,
+                maybe_y_scroll_state: maybe_y_scroll_state,
+                instantiation_order_idx: instantiation_order_idx,
+            }
         };
 
         // Retrieves the widget's parent index.
@@ -728,24 +742,36 @@ impl Graph {
         // it is updated later in the cycle.
         //
         // If no parent index is given, the **Graph**'s `root` index will be used as the parent.
-        let maybe_parent_idx = |graph: &mut Self| match maybe_parent_idx {
-            Some(parent_idx) => match graph.node_index(parent_idx) {
-                Some(idx) => Some(idx),
-                None => {
-                    // Add a temporary node to the graph at the given parent index so that we can
-                    // add the edge even in the parent widget's absense. The temporary node should
-                    // be replaced by the proper widget when it is updated later in the cycle.
-                    let parent_node_idx = graph.add_placeholder();
-                    // If the parent_idx is a **WidgetId**, add the mapping to our index_map.
-                    if let widget::Index::Public(parent_widget_id) = parent_idx {
-                        graph.index_map.insert(parent_widget_id, parent_node_idx);
+        let maybe_parent_idx = |graph: &mut Self| {
+            match maybe_parent_idx {
+                Some(parent_idx) => {
+                    match graph.node_index(parent_idx) {
+                        Some(idx) => Some(idx),
+                        None => {
+                            // Add a temporary node to the graph at the given parent index so that we can
+                            // add the edge even in the parent widget's absense. The temporary node should
+                            // be replaced by the proper widget when it is updated later in the cycle.
+                            let parent_node_idx = graph.add_placeholder();
+                            // If the parent_idx is a **WidgetId**, add the mapping to our index_map.
+                            if let widget::Index::Public(parent_widget_id) = parent_idx {
+                                graph.index_map.insert(parent_widget_id, parent_node_idx);
+                            }
+                            Some(parent_node_idx)
+                        }
                     }
-                    Some(parent_node_idx)
-                },
-            },
-            // Check that this node is not the root node before using the root node as the parent.
-            None => graph.node_index(idx)
-                .and_then(|idx| if idx == root { None } else { Some(root) }),
+                }
+                // Check that this node is not the root node before using the root node as the parent.
+                None => {
+                    graph.node_index(idx)
+                         .and_then(|idx| {
+                             if idx == root {
+                                 None
+                             } else {
+                                 Some(root)
+                             }
+                         })
+                }
+            }
         };
 
         // If we already have a `Node` in the graph for the given `idx`, we need to update it.
@@ -770,9 +796,11 @@ impl Graph {
                     // TODO: It might be overkill to panic here.
                     if container.kind != kind && container.kind != "EMPTY" {
                         panic!("A widget of a different kind already exists at the given idx \
-                                ({:?}). You tried to insert a {:?}, however the existing \
-                                widget is a {:?}. Check your `WidgetId`s for errors.",
-                                idx, &kind, container.kind);
+                                ({:?}). You tried to insert a {:?}, however the existing widget \
+                                is a {:?}. Check your `WidgetId`s for errors.",
+                               idx,
+                               &kind,
+                               container.kind);
                     }
 
                     container.kind = kind;
@@ -784,15 +812,15 @@ impl Graph {
                     container.maybe_x_scroll_state = maybe_x_scroll_state;
                     container.maybe_y_scroll_state = maybe_y_scroll_state;
                     container.instantiation_order_idx = instantiation_order_idx;
-                },
+                }
 
             }
 
-        // Otherwise if there is no Widget for the given index we need to add one.
-        //
-        // If there is no widget for the given index we can assume that the index is a
-        // `widget::Id`, as the only way to procure a NodeIndex is by adding a Widget to the
-        // Graph.
+            // Otherwise if there is no Widget for the given index we need to add one.
+            //
+            // If there is no widget for the given index we can assume that the index is a
+            // `widget::Id`, as the only way to procure a NodeIndex is by adding a Widget to the
+            // Graph.
         } else if let Some(widget_id) = self.widget_id(idx) {
             let node_idx = self.add_node(Node::Widget(new_container()));
             self.index_map.insert(widget_id, node_idx);
@@ -824,7 +852,7 @@ impl Graph {
         // Check whether or not the widget is a graphics element for some other widget.
         if let Some(graphic_parent_idx) = maybe_graphics_for {
             self.set_edge(graphic_parent_idx, idx, Edge::Graphic).unwrap();
-        // If not, ensure that there is no parent **Graphic** edge from the widget.
+            // If not, ensure that there is no parent **Graphic** edge from the widget.
         } else {
             self.remove_parent_edge(idx, Edge::Graphic);
         }
@@ -835,10 +863,10 @@ impl Graph {
     ///
     /// This is called (via the `ui` module) from within the `widget::set_widget` function after
     /// the `Widget::update` method is called and some new state is returned.
-    pub fn post_update_cache<W>(&mut self, widget: widget::PostUpdateCache<W>) where
-        W: Widget,
-        W::State: 'static,
-        W::Style: 'static,
+    pub fn post_update_cache<W>(&mut self, widget: widget::PostUpdateCache<W>)
+        where W: Widget,
+              W::State: 'static,
+              W::Style: 'static
     {
         let widget::PostUpdateCache { idx, state, style, .. } = widget;
 
@@ -855,7 +883,6 @@ impl Graph {
             container.maybe_state = Some(Box::new(unique_state));
         }
     }
-
 }
 
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -346,8 +346,9 @@ impl Graph {
         let b = self.node_index(b).expect(NO_MATCHING_NODE_INDEX);
 
         // Check to see if the node already has some matching incoming edge.
-        // Keep it if it's the one we want. Otherwise, remove any incoming edge that matches the given
-        // edge kind but isn't coming from the node that we desire.
+        // Keep it if it's the one we want. Otherwise, remove any incoming edge
+        // that matches the given edge kind but isn't coming from the node
+        // that we desire.
         let mut parents = self.parents(b);
         let mut already_set = None;
 

--- a/src/label.rs
+++ b/src/label.rs
@@ -53,4 +53,3 @@ pub trait Labelable<'a>: Sized {
     }
 
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub use theme::Theme;
 pub use ui::{Ui, UserInput};
 pub use widget::{default_x_dimension, default_y_dimension};
 pub use widget::{drag, scroll};
-pub use widget::{CommonBuilder, CommonState, CommonStyle, Floating, IndexSlot, MaybeParent, UiCell,
-                 UpdateArgs, Widget};
+pub use widget::{CommonBuilder, CommonState, CommonStyle, Floating, IndexSlot, MaybeParent,
+                 UiCell, UpdateArgs, Widget};
 pub use widget::{KidArea, KidAreaArgs};
 pub use widget::CommonState as WidgetCommonState;
 pub use widget::Id as WidgetId;
@@ -108,10 +108,10 @@ mod widget;
 /// This is the recommended way of generating `WidgetId`s as it greatly lessens the chances of
 /// making errors when adding or removing widget ids.
 ///
-/// Each Widget must have its own unique identifier so that the `Ui` can keep track of its state 
+/// Each Widget must have its own unique identifier so that the `Ui` can keep track of its state
 /// between updates.
 ///
-/// To make this easier, we provide the `widget_ids` macro, which generates a unique `WidgetId` for 
+/// To make this easier, we provide the `widget_ids` macro, which generates a unique `WidgetId` for
 /// each identifier given in the list.
 ///
 /// The `with n` syntax reserves `n` number of `WidgetId`s for that identifier rather than just one.

--- a/src/log.txt
+++ b/src/log.txt
@@ -1,0 +1,8 @@
+line 399 in color.rs - what is the proper form for shortening this?
+
+line 271 in drop_down_list.rs - what is the proper form for shortening this line?
+
+lines 249, 523, 535, 547, 558, 677, 751, 752, 753, 755, 763 in graph/mod.rs are all too long.
+
+lines 185 and 1049 in mod.rs are too long
+

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! A module for describing Mouse state.
 //!
 //! The `Ui` will continuously maintain the latest Mouse state, necessary for widget logic.
@@ -54,7 +54,6 @@ pub struct Scroll {
 
 
 impl ButtonState {
-
     /// Constructor for a default ButtonState.
     pub fn new() -> ButtonState {
         ButtonState {
@@ -69,12 +68,10 @@ impl ButtonState {
         self.was_just_released = false;
         self.was_just_pressed = false;
     }
-
 }
 
 
 impl Mouse {
-
     /// Constructor for a default Mouse struct.
     pub fn new() -> Mouse {
         Mouse {
@@ -91,6 +88,4 @@ impl Mouse {
     pub fn relative_to(self, xy: Point) -> Mouse {
         Mouse { xy: ::vecmath::vec2_sub(self.xy, xy), ..self }
     }
-
 }
-

--- a/src/position/matrix.rs
+++ b/src/position/matrix.rs
@@ -25,7 +25,6 @@ pub struct Matrix {
 }
 
 impl Matrix {
-
     /// Start building a new position **Matrix**.
     pub fn new(cols: usize, rows: usize) -> Matrix {
         Matrix {
@@ -48,9 +47,9 @@ impl Matrix {
     }
 
     /// Call the given function for every element in the Matrix.
-    pub fn each_widget<C, F>(self, ui: &mut Ui<C>, mut f: F) where
-        C: CharacterCache,
-        F: FnMut(&mut Ui<C>, WidgetNum, ColNum, RowNum, Point, Dimensions),
+    pub fn each_widget<C, F>(self, ui: &mut Ui<C>, mut f: F)
+        where C: CharacterCache,
+              F: FnMut(&mut Ui<C>, WidgetNum, ColNum, RowNum, Point, Dimensions)
     {
         use utils::map_range;
 
@@ -83,7 +82,6 @@ impl Matrix {
             }
         }
     }
-
 }
 
 impl Positionable for Matrix {
@@ -129,18 +127,23 @@ impl Sizeable for Matrix {
     #[inline]
     fn get_x_dimension<C: CharacterCache>(&self, ui: &Ui<C>) -> Dimension {
         const DEFAULT_WIDTH: Dimension = Dimension::Absolute(256.0);
-        self.maybe_x_dimension.or_else(|| {
-            ui.theme.widget_style::<widget::matrix::Style>(widget::matrix::KIND)
-                .map(|default| default.common.maybe_x_dimension.unwrap_or(DEFAULT_WIDTH))
-        }).unwrap_or(DEFAULT_WIDTH)
+        self.maybe_x_dimension
+            .or_else(|| {
+                ui.theme
+                  .widget_style::<widget::matrix::Style>(widget::matrix::KIND)
+                  .map(|default| default.common.maybe_x_dimension.unwrap_or(DEFAULT_WIDTH))
+            })
+            .unwrap_or(DEFAULT_WIDTH)
     }
     #[inline]
     fn get_y_dimension<C: CharacterCache>(&self, ui: &Ui<C>) -> Dimension {
         const DEFAULT_HEIGHT: Dimension = Dimension::Absolute(256.0);
-        self.maybe_y_dimension.or_else(|| {
-            ui.theme.widget_style::<widget::matrix::Style>(widget::matrix::KIND)
-                .map(|default| default.common.maybe_y_dimension.unwrap_or(DEFAULT_HEIGHT))
-        }).unwrap_or(DEFAULT_HEIGHT)
+        self.maybe_y_dimension
+            .or_else(|| {
+                ui.theme
+                  .widget_style::<widget::matrix::Style>(widget::matrix::KIND)
+                  .map(|default| default.common.maybe_y_dimension.unwrap_or(DEFAULT_HEIGHT))
+            })
+            .unwrap_or(DEFAULT_HEIGHT)
     }
 }
-

--- a/src/position/mod.rs
+++ b/src/position/mod.rs
@@ -203,7 +203,11 @@ pub trait Positionable: Sized {
     }
 
     /// Set the position relative to the widget with the given widget::Index.
-    fn x_y_relative_to<I: Into<widget::Index> + Copy>(self, other: I, x: Scalar, y: Scalar) -> Self {
+    fn x_y_relative_to<I: Into<widget::Index> + Copy>(self,
+                                                      other: I,
+                                                      x: Scalar,
+                                                      y: Scalar)
+                                                      -> Self {
         self.xy_relative_to(other, [x, y])
     }
 
@@ -241,14 +245,14 @@ pub trait Positionable: Sized {
 
     /// Build with the **Position** along the *x* axis as some distance from the given widget.
     fn x_direction_from<I>(self, other: I, direction: Direction, x: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_position(Position::Direction(direction, x, Some(other.into())))
     }
 
     /// Build with the **Position** along the *y* axis as some distance from the given widget.
     fn y_direction_from<I>(self, other: I, direction: Direction, y: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.y_position(Position::Direction(direction, y, Some(other.into())))
     }
@@ -355,7 +359,7 @@ pub trait Positionable: Sized {
         self.y_align_to(other, Align::Start)
     }
 
-    ///// `Place` methods. /////
+    /// // `Place` methods. /////
 
     /// Place the widget at some position on the `other` Widget along the *x* axis.
     fn x_place_on<I: Into<widget::Index>>(self, other: I, place: Place) -> Self {
@@ -380,7 +384,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the top left corner of the given Widget with the given margin between
     /// both edges.
     fn top_left_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::Start(Some(mgn))).y_place_on(other, Place::End(Some(mgn)))
     }
@@ -388,7 +392,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the top left corner of the given Widget with the given margins between
     /// each respective edge.
     fn top_left_with_margins_on<I>(self, other: I, top: Scalar, left: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::Start(Some(left))).y_place_on(other, Place::End(Some(top)))
     }
@@ -401,7 +405,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the top right corner of the given Widget with the given margin
     /// between both edges.
     fn top_right_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::End(Some(mgn))).y_place_on(other, Place::End(Some(mgn)))
     }
@@ -409,7 +413,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the top right corner of the given Widget with the given margins between
     /// each respective edge.
     fn top_right_with_margins_on<I>(self, other: I, top: Scalar, right: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::End(Some(right))).y_place_on(other, Place::End(Some(top)))
     }
@@ -422,7 +426,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the bottom left corner of the given Widget with the given margin
     /// between both edges.
     fn bottom_left_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::Start(Some(mgn))).y_place_on(other, Place::Start(Some(mgn)))
     }
@@ -430,9 +434,10 @@ pub trait Positionable: Sized {
     /// Place the widget in the bottom left corner of the given Widget with the given margins
     /// between each respective edge.
     fn bottom_left_with_margins_on<I>(self, other: I, bottom: Scalar, left: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
-        self.x_place_on(other, Place::Start(Some(left))).y_place_on(other, Place::Start(Some(bottom)))
+        self.x_place_on(other, Place::Start(Some(left)))
+            .y_place_on(other, Place::Start(Some(bottom)))
     }
 
     /// Place the widget in the bottom right corner of the given Widget.
@@ -443,7 +448,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the bottom right corner of the given Widget with the given margin
     /// between both edges.
     fn bottom_right_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::End(Some(mgn))).y_place_on(other, Place::Start(Some(mgn)))
     }
@@ -451,9 +456,10 @@ pub trait Positionable: Sized {
     /// Place the widget in the bottom right corner of the given Widget with the given margins
     /// between each respective edge.
     fn bottom_right_with_margins_on<I>(self, other: I, bottom: Scalar, right: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
-        self.x_place_on(other, Place::End(Some(right))).y_place_on(other, Place::Start(Some(bottom)))
+        self.x_place_on(other, Place::End(Some(right)))
+            .y_place_on(other, Place::Start(Some(bottom)))
     }
 
     /// Place the widget in the middle of the top edge of the given Widget.
@@ -464,7 +470,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the middle of the top edge of the given Widget with the given margin
     /// between the edges.
     fn mid_top_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::Middle).y_place_on(other, Place::End(Some(mgn)))
     }
@@ -477,7 +483,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the middle of the bottom edge of the given Widget with the given margin
     /// between the edges.
     fn mid_bottom_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::Middle).y_place_on(other, Place::Start(Some(mgn)))
     }
@@ -490,7 +496,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the middle of the left edge of the given Widget with the given margin
     /// between the edges.
     fn mid_left_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::Start(Some(mgn))).y_place_on(other, Place::Middle)
     }
@@ -503,7 +509,7 @@ pub trait Positionable: Sized {
     /// Place the widget in the middle of the right edge of the given Widget with the given margin
     /// between the edges.
     fn mid_right_with_margin_on<I>(self, other: I, mgn: Scalar) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         self.x_place_on(other, Place::End(Some(mgn))).y_place_on(other, Place::Middle)
     }
@@ -635,7 +641,7 @@ pub trait Positionable: Sized {
         self.x_place(Place::End(Some(mgn))).y_place(Place::Middle)
     }
 
-    ///// Rendering Depth (aka Z axis) /////
+    /// // Rendering Depth (aka Z axis) /////
 
     /// The depth at which the widget should be rendered relatively to its sibling widgets.
     fn depth(self, depth: Depth) -> Self;

--- a/src/position/range.rs
+++ b/src/position/range.rs
@@ -27,7 +27,6 @@ pub enum Edge {
 
 
 impl Range {
-
     /// Construct a new `Range` from a given range, i.e. `Range::new(start, end)`.
     ///
     /// # Examples
@@ -122,7 +121,10 @@ impl Range {
     /// assert_eq!(Range::new(5.0, 1.0).invert(), Range::new(1.0, 5.0));
     /// ```
     pub fn invert(self) -> Range {
-        Range { start: self.end, end: self.start }
+        Range {
+            start: self.end,
+            end: self.start,
+        }
     }
 
     /// Map the given Scalar from `Self` to some other given `Range`.
@@ -164,7 +166,10 @@ impl Range {
     /// assert_eq!(Range::new(5.0, -5.0).shift(-5.0), Range::new(0.0, -10.0));
     /// ```
     pub fn shift(self, amount: Scalar) -> Range {
-        Range { start: self.start + amount, end: self.end + amount }
+        Range {
+            start: self.start + amount,
+            end: self.end + amount,
+        }
     }
 
     /// The direction of the Range represented as a normalised scalar.
@@ -179,9 +184,13 @@ impl Range {
     /// assert_eq!(Range::new(0.0, -5.0).direction(), -1.0);
     /// ```
     pub fn direction(&self) -> Scalar {
-        if      self.start < self.end { 1.0 }
-        else if self.start > self.end { -1.0 }
-        else                          { 0.0 }
+        if self.start < self.end {
+            1.0
+        } else if self.start > self.end {
+            -1.0
+        } else {
+            0.0
+        }
     }
 
     /// Converts the Range to an undirected Range. By ensuring that `start` <= `end`.
@@ -198,7 +207,11 @@ impl Range {
     /// assert_eq!(Range::new(10.0, -10.0).undirected(), Range::new(-10.0, 10.0));
     /// ```
     pub fn undirected(self) -> Range {
-        if self.start > self.end { self.invert() } else { self }
+        if self.start > self.end {
+            self.invert()
+        } else {
+            self
+        }
     }
 
     /// The Range that encompasses both self and the given Range.
@@ -245,7 +258,7 @@ impl Range {
     /// let c = Range::new(10.0, -30.0);
     /// let d = Range::new(-5.0, 20.0);
     /// assert_eq!(c.overlap(d), Some(Range::new(-5.0, 10.0)));
-    /// 
+    ///
     /// let e = Range::new(0.0, 2.5);
     /// let f = Range::new(50.0, 100.0);
     /// assert_eq!(e.overlap(f), None);
@@ -282,8 +295,11 @@ impl Range {
     /// assert_eq!(c.max_directed(d), Range::new(5.0, -30.0));
     /// ```
     pub fn max_directed(self, other: Self) -> Range {
-        if self.start <= self.end { self.max(other) }
-        else                      { self.max(other).invert() }
+        if self.start <= self.end {
+            self.max(other)
+        } else {
+            self.max(other).invert()
+        }
     }
 
     /// Is the given scalar within our range.
@@ -344,7 +360,11 @@ impl Range {
     /// assert_eq!(Range::new(10.0, 0.0).pad_start(2.0), Range::new(8.0, 0.0));
     /// ```
     pub fn pad_start(mut self, pad: Scalar) -> Range {
-        self.start += if self.start <= self.end { pad } else { -pad };
+        self.start += if self.start <= self.end {
+            pad
+        } else {
+            -pad
+        };
         self
     }
 
@@ -359,7 +379,11 @@ impl Range {
     /// assert_eq!(Range::new(10.0, 0.0).pad_end(2.0), Range::new(10.0, 2.0));
     /// ```
     pub fn pad_end(mut self, pad: Scalar) -> Range {
-        self.end += if self.start <= self.end { -pad } else { pad };
+        self.end += if self.start <= self.end {
+            -pad
+        } else {
+            pad
+        };
         self
     }
 
@@ -427,17 +451,29 @@ impl Range {
         let Range { start, end } = self;
         if start <= end {
             if value < start {
-                Range { start: value, end: end }
+                Range {
+                    start: value,
+                    end: end,
+                }
             } else if value > end {
-                Range { start: start, end: value }
+                Range {
+                    start: start,
+                    end: value,
+                }
             } else {
                 self
             }
         } else {
             if value < end {
-                Range { start: start, end: value }
+                Range {
+                    start: start,
+                    end: value,
+                }
             } else if value > start {
-                Range { start: value, end: end }
+                Range {
+                    start: value,
+                    end: end,
+                }
             } else {
                 self
             }
@@ -612,11 +648,20 @@ impl Range {
     /// ```
     pub fn closest_edge(&self, scalar: Scalar) -> Edge {
         let Range { start, end } = *self;
-        let start_diff = if scalar < start { start - scalar } else { scalar - start };
-        let end_diff = if scalar < end { end - scalar } else { scalar - end };
-        if start_diff <= end_diff { Edge::Start } else { Edge::End }
+        let start_diff = if scalar < start {
+            start - scalar
+        } else {
+            scalar - start
+        };
+        let end_diff = if scalar < end {
+            end - scalar
+        } else {
+            scalar - end
+        };
+        if start_diff <= end_diff {
+            Edge::Start
+        } else {
+            Edge::End
+        }
     }
-
 }
-
-

--- a/src/position/rect.rs
+++ b/src/position/rect.rs
@@ -28,7 +28,6 @@ pub enum Corner {
 
 
 impl Rect {
-
     /// Construct a Rect from a given `Point` and `Dimensions`.
     pub fn from_xy_dim(xy: Point, dim: Dimensions) -> Self {
         Rect {
@@ -39,11 +38,25 @@ impl Rect {
 
     /// Construct a Rect from the coordinates of two points.
     pub fn from_corners(a: Point, b: Point) -> Self {
-        let (left, right) = if a[0] < b[0] { (a[0], b[0]) } else { (b[0], a[0]) };
-        let (bottom, top) = if a[1] < b[1] { (a[1], b[1]) } else { (b[1], a[1]) };
+        let (left, right) = if a[0] < b[0] {
+            (a[0], b[0])
+        } else {
+            (b[0], a[0])
+        };
+        let (bottom, top) = if a[1] < b[1] {
+            (a[1], b[1])
+        } else {
+            (b[1], a[1])
+        };
         Rect {
-            x: Range { start: left, end: right },
-            y: Range { start: bottom, end: top },
+            x: Range {
+                start: left,
+                end: right,
+            },
+            y: Range {
+                start: bottom,
+                end: top,
+            },
         }
     }
 
@@ -216,7 +229,10 @@ impl Rect {
     /// The Rect with some padding amount applied to each edge.
     pub fn pad(self, pad: Scalar) -> Self {
         let Rect { x, y } = self;
-        Rect { x: x.pad(pad), y: y.pad(pad) }
+        Rect {
+            x: x.pad(pad),
+            y: y.pad(pad),
+        }
     }
 
     /// The Rect with some padding applied.
@@ -373,7 +389,6 @@ impl Rect {
             (Edge::End, Edge::End) => Corner::TopRight,
         }
     }
-
 }
 
 /// A function to simplify determining whether or not a point `xy` is over a rectangle.
@@ -381,4 +396,3 @@ impl Rect {
 pub fn is_over(rect_xy: Point, rect_dim: Dimensions, xy: Point) -> bool {
     Rect::from_xy_dim(rect_xy, rect_dim).is_over(xy)
 }
-

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -71,7 +71,6 @@ impl WidgetDefault {
 
 
 impl Theme {
-
     /// The default theme if not loading from file.
     pub fn default() -> Theme {
         Theme {
@@ -96,7 +95,7 @@ impl Theme {
     ///
     /// Attempts to cast the `Box<WidgetStyle>` to the **Widget**'s unique associated style **T**.
     pub fn widget_style<T>(&self, kind: &'static str) -> Option<UniqueDefault<T>>
-        where T: widget::Style,
+        where T: widget::Style
     {
         self.widget_styling.get(kind).and_then(|boxed_default| {
             boxed_default.style.downcast_ref().map(|style| {
@@ -108,6 +107,4 @@ impl Theme {
             })
         })
     }
-
 }
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! Various utility functions used throughout Conrod.
 //!
 
@@ -11,20 +11,40 @@ use std::iter::{Chain, once, Once};
 
 /// Compare to PartialOrd values and return the min.
 pub fn partial_min<T: PartialOrd>(a: T, b: T) -> T {
-    if a <= b { a } else { b }
+    if a <= b {
+        a
+    } else {
+        b
+    }
 }
 
 /// Compare to PartialOrd values and return the min.
 pub fn partial_max<T: PartialOrd>(a: T, b: T) -> T {
-    if a >= b { a } else { b }
+    if a >= b {
+        a
+    } else {
+        b
+    }
 }
 
 /// Clamp a value between some range.
 pub fn clamp<T: PartialOrd>(n: T, start: T, end: T) -> T {
     if start <= end {
-        if n < start { start } else if n > end { end } else { n }
+        if n < start {
+            start
+        } else if n > end {
+            end
+        } else {
+            n
+        }
     } else {
-        if n < end { end } else if n > start { start } else { n }
+        if n < end {
+            end
+        } else if n > start {
+            start
+        } else {
+            n
+        }
     }
 }
 
@@ -44,25 +64,23 @@ pub fn fmod(f: f32, n: i32) -> f32 {
 #[inline]
 pub fn modulo<I: PrimInt>(a: I, b: I) -> I {
     match a % b {
-        r if (r > I::zero() && b < I::zero())
-          || (r < I::zero() && b > I::zero()) => r + b,
-        r                                     => r,
+        r if (r > I::zero() && b < I::zero()) || (r < I::zero() && b > I::zero()) => r + b,
+        r => r,
     }
 }
 
 /// Map a value from a given range to a new given range.
 pub fn map_range<X, Y>(val: X, in_min: X, in_max: X, out_min: Y, out_max: Y) -> Y
     where X: NumCast,
-          Y: NumCast,
+          Y: NumCast
 {
     let val_f: f64 = NumCast::from(val).unwrap();
     let in_min_f: f64 = NumCast::from(in_min).unwrap();
     let in_max_f: f64 = NumCast::from(in_max).unwrap();
     let out_min_f: f64 = NumCast::from(out_min).unwrap();
     let out_max_f: f64 = NumCast::from(out_max).unwrap();
-    NumCast::from(
-        (val_f - in_min_f) / (in_max_f - in_min_f) * (out_max_f - out_min_f) + out_min_f
-    ).unwrap()
+    NumCast::from((val_f - in_min_f) / (in_max_f - in_min_f) * (out_max_f - out_min_f) + out_min_f)
+        .unwrap()
 }
 
 /// Get value percentage between max and min.
@@ -87,8 +105,11 @@ pub fn value_from_perc<T: Float + NumCast + ToPrimitive>(perc: f32, min: T, max:
 }
 
 /// Get a suitable string from the value, its max and the pixel range.
-pub fn val_to_string<T: ToString + NumCast>
-(val: T, max: T, val_rng: T, pixel_range: usize) -> String {
+pub fn val_to_string<T: ToString + NumCast>(val: T,
+                                            max: T,
+                                            val_rng: T,
+                                            pixel_range: usize)
+                                            -> String {
     let mut s = val.to_string();
     let decimal = s.chars().position(|ch| ch == '.');
     match decimal {
@@ -109,15 +130,21 @@ pub fn val_to_string<T: ToString + NumCast>
             // Find out how many pixels there are to actually use
             // and judge a reasonable precision from this.
             let mut n = 1;
-            while 10.pow(n) < pixel_range { n += 1 }
+            while 10.pow(n) < pixel_range {
+                n += 1
+            }
             let precision = n as usize;
 
             // Truncate the length to the pixel precision as
             // long as this doesn't cause it to be smaller
             // than the necessary decimal place.
             let mut truncate_len = min_string_len + (precision - 1);
-            if idx + precision < truncate_len { truncate_len = idx + precision }
-            if s.len() > truncate_len { s.truncate(truncate_len) }
+            if idx + precision < truncate_len {
+                truncate_len = idx + precision
+            }
+            if s.len() > truncate_len {
+                s.truncate(truncate_len)
+            }
             s
         }
     }
@@ -125,15 +152,23 @@ pub fn val_to_string<T: ToString + NumCast>
 
 /// Find the bounding rect for the given series of points.
 pub fn bounding_box_for_points<I>(mut points: I) -> Rect
-    where I: Iterator<Item=Point>,
+    where I: Iterator<Item = Point>
 {
-    points.next().map(|first| {
-        let start_rect = Rect {
-            x: Range { start: first[0], end: first[0] },
-            y: Range { start: first[1], end: first[1] },
-        };
-        points.fold(start_rect, Rect::stretch_to_point)
-    }).unwrap_or_else(|| Rect::from_xy_dim([0.0, 0.0], [0.0, 0.0]))
+    points.next()
+          .map(|first| {
+              let start_rect = Rect {
+                  x: Range {
+                      start: first[0],
+                      end: first[0],
+                  },
+                  y: Range {
+                      start: first[1],
+                      end: first[1],
+                  },
+              };
+              points.fold(start_rect, Rect::stretch_to_point)
+          })
+          .unwrap_or_else(|| Rect::from_xy_dim([0.0, 0.0], [0.0, 0.0]))
 }
 
 /// A type returned by the `iter_diff` function.
@@ -168,7 +203,7 @@ pub enum IterDiff<E, I> {
 /// of the collection, a suitable `IterDiff` is returned so that the existing collection may be
 /// updated with the difference using elements from the very same iterator.
 pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
-    where A: IntoIterator<Item=&'a B::Item>,
+    where A: IntoIterator<Item = &'a B::Item>,
           B: IntoIterator,
           B::Item: PartialEq + 'a
 {
@@ -176,9 +211,11 @@ pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
     for (i, a_elem) in a.into_iter().enumerate() {
         match b.next() {
             None => return Some(IterDiff::Shorter(i)),
-            Some(b_elem) => if *a_elem != b_elem {
-                return Some(IterDiff::FirstMismatch(i, once(b_elem).chain(b)));
-            },
+            Some(b_elem) => {
+                if *a_elem != b_elem {
+                    return Some(IterDiff::FirstMismatch(i, once(b_elem).chain(b)));
+                }
+            }
         }
     }
     b.next().map(|elem| IterDiff::Longer(once(elem).chain(b)))
@@ -190,15 +227,18 @@ pub fn iter_diff<'a, A, B>(a: A, b: B) -> Option<IterDiff<B::Item, B::IntoIter>>
 /// themselves differ.
 pub fn write_if_different<T, I>(elems: &[T], new_elems: I) -> Cow<[T]>
     where T: PartialEq + Clone,
-          I: IntoIterator<Item=T>,
+          I: IntoIterator<Item = T>
 {
     match iter_diff(elems.iter(), new_elems.into_iter()) {
-        Some(IterDiff::FirstMismatch(i, mismatch)) =>
-            Cow::Owned(elems[0..i].iter().cloned().chain(mismatch).collect()),
-        Some(IterDiff::Longer(remaining)) =>
-            Cow::Owned(elems.iter().cloned().chain(remaining).collect()),
-        Some(IterDiff::Shorter(num_new_elems)) =>
-            Cow::Owned(elems.iter().cloned().take(num_new_elems).collect()),
+        Some(IterDiff::FirstMismatch(i, mismatch)) => {
+            Cow::Owned(elems[0..i].iter().cloned().chain(mismatch).collect())
+        }
+        Some(IterDiff::Longer(remaining)) => {
+            Cow::Owned(elems.iter().cloned().chain(remaining).collect())
+        }
+        Some(IterDiff::Shorter(num_new_elems)) => {
+            Cow::Owned(elems.iter().cloned().take(num_new_elems).collect())
+        }
         None => Cow::Borrowed(elems),
     }
 }
@@ -206,15 +246,17 @@ pub fn write_if_different<T, I>(elems: &[T], new_elems: I) -> Cow<[T]>
 /// Compares two iterators to see if they yield the same thing.
 pub fn iter_eq<A, B>(mut a: A, mut b: B) -> bool
     where A: Iterator,
-          B: Iterator<Item=A::Item>,
-          A::Item: PartialEq,
+          B: Iterator<Item = A::Item>,
+          A::Item: PartialEq
 {
     loop {
         match (a.next(), b.next()) {
             (None, None) => return true,
-            (maybe_a, maybe_b) => if maybe_a != maybe_b {
-                return false
-            },
+            (maybe_a, maybe_b) => {
+                if maybe_a != maybe_b {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/src/widget/builder.rs
+++ b/src/widget/builder.rs
@@ -77,7 +77,7 @@ macro_rules! builder_method {
 ///     pub fn new() -> Self {
 ///         Button { color: None }
 ///     }
-///     
+///
 ///     /// A Color "builder method".
 ///     ///
 ///     /// Builds the Button with the given Color.
@@ -173,7 +173,7 @@ macro_rules! builder_methods {
         builder_method!($fn_name { $($assignee).+ = Some($Type) });
         builder_methods!($($rest)*);
     };
-    
+
     (pub $fn_name:ident { $($assignee:ident).+ = $Type:ty } $($rest:tt)*) => {
         builder_method!(pub $fn_name { $($assignee).+ = $Type });
         builder_methods!($($rest)*);

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -1,19 +1,6 @@
 
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    FontSize,
-    Frameable,
-    FramedRectangle,
-    IndexSlot,
-    Labelable,
-    Mouse,
-    Positionable,
-    Scalar,
-    Text,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, FontSize, Frameable, FramedRectangle, IndexSlot, Labelable,
+     Mouse, Positionable, Scalar, Text, Widget};
 use widget;
 
 
@@ -83,17 +70,16 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
-        (true,  _,       Up)   => Highlighted,
+        (true, Normal, Down) => Normal,
+        (true, _, Down) => Clicked,
+        (true, _, Up) => Highlighted,
         (false, Clicked, Down) => Clicked,
-        _                      => Normal,
+        _ => Normal,
     }
 }
 
 
 impl<'a, F> Button<'a, F> {
-
     /// Create a button context to be built upon.
     pub fn new() -> Self {
         Button {
@@ -109,12 +95,10 @@ impl<'a, F> Button<'a, F> {
         pub react { maybe_react = Some(F) }
         pub enabled { enabled = bool }
     }
-
 }
 
 
-impl<'a, F> Widget for Button<'a, F>
-    where F: FnOnce(),
+impl<'a, F> Widget for Button<'a, F> where F: FnOnce()
 {
     type State = State;
     type Style = Style;
@@ -155,20 +139,24 @@ impl<'a, F> Widget for Button<'a, F>
             (true, Some(mouse)) => {
                 let is_over = rect.is_over(mouse.xy);
                 get_new_interaction(is_over, state.view().interaction, mouse)
-            },
+            }
         };
 
         // Capture the mouse if it was clicked, uncapture if it was released.
         match (state.view().interaction, new_interaction) {
-            (Interaction::Highlighted, Interaction::Clicked) => { ui.capture_mouse(); },
+            (Interaction::Highlighted, Interaction::Clicked) => {
+                ui.capture_mouse();
+            }
             (Interaction::Clicked, Interaction::Highlighted) |
-            (Interaction::Clicked, Interaction::Normal)      => { ui.uncapture_mouse(); },
+            (Interaction::Clicked, Interaction::Normal) => {
+                ui.uncapture_mouse();
+            }
             _ => (),
         }
 
         // If the mouse was released over button, react.
-        if let (Interaction::Clicked, Interaction::Highlighted) =
-            (state.view().interaction, new_interaction) {
+        if let (Interaction::Clicked, Interaction::Highlighted) = (state.view().interaction,
+                                                                   new_interaction) {
             if let Some(react) = maybe_react {
                 react()
             }
@@ -207,7 +195,6 @@ impl<'a, F> Widget for Button<'a, F>
         }
 
     }
-
 }
 
 

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -1,29 +1,6 @@
-use {
-    Align,
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimensions,
-    FontSize,
-    Frameable,
-    FramedRectangle,
-    IndexSlot,
-    Labelable,
-    Padding,
-    Place,
-    Position,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Sizeable,
-    TextWrap,
-    Theme,
-    TitleBar,
-    Ui,
-    UiCell,
-    Widget,
-};
+use {Align, CharacterCache, Color, Colorable, Dimensions, FontSize, Frameable, FramedRectangle,
+     IndexSlot, Labelable, Padding, Place, Position, Positionable, Range, Rect, Scalar, Sizeable,
+     TextWrap, Theme, TitleBar, Ui, UiCell, Widget};
 use position;
 use position::Direction::{Forwards, Backwards};
 use widget::{self, title_bar};
@@ -50,7 +27,7 @@ pub struct Canvas<'a> {
     /// The builder data related to the style of the Canvas.
     pub style: Style,
     /// The label for the **Canvas**' **TitleBar** if there is one.
-    pub maybe_title_bar_label: Option<&'a str>, 
+    pub maybe_title_bar_label: Option<&'a str>,
     /// A list of child **Canvas**ses as splits of this **Canvas** flowing in the given direction.
     pub maybe_splits: Option<FlowOfSplits<'a>>,
 }
@@ -130,7 +107,6 @@ enum Direction {
 
 
 impl<'a> Canvas<'a> {
-
     /// Construct a new Canvas builder.
     pub fn new() -> Self {
         Canvas {
@@ -204,7 +180,6 @@ impl<'a> Canvas<'a> {
             .pad_bottom(pad.y.start)
             .pad_top(pad.y.end)
     }
-
 }
 
 
@@ -305,29 +280,28 @@ impl<'a> Widget for Canvas<'a> {
             let mut title_bar = TitleBar::new(label, rectangle_idx);
             title_bar.style.maybe_wrap = Some(maybe_wrap);
             title_bar.style.text_align = Some(text_align);
-            title_bar
-                .color(color)
-                .frame(frame)
-                .frame_color(frame_color)
-                .label_font_size(font_size)
-                .label_color(label_color)
-                .line_spacing(line_spacing)
-                .graphics_for(idx)
-                .place_on_kid_area(false)
-                .react(|_interaction| ())
-                .set(title_bar_idx, &mut ui);
+            title_bar.color(color)
+                     .frame(frame)
+                     .frame_color(frame_color)
+                     .label_font_size(font_size)
+                     .label_color(label_color)
+                     .line_spacing(line_spacing)
+                     .graphics_for(idx)
+                     .place_on_kid_area(false)
+                     .react(|_interaction| ())
+                     .set(title_bar_idx, &mut ui);
         }
 
         // If we were given some child canvas splits, we should instantiate them.
         if let Some((direction, splits)) = maybe_splits {
 
-            let (total_abs, total_weight) =
-                splits.iter().fold((0.0, 0.0), |(abs, weight), &(_, split)| {
-                    match split.style.length(ui.theme()) {
-                        Length::Absolute(a) => (abs + a, weight),
-                        Length::Weight(w) => (abs, weight + w),
-                    }
-                });
+            let (total_abs, total_weight) = splits.iter()
+                                                  .fold((0.0, 0.0), |(abs, weight), &(_, split)| {
+                                                      match split.style.length(ui.theme()) {
+                                                          Length::Absolute(a) => (abs + a, weight),
+                                                          Length::Weight(w) => (abs, weight + w),
+                                                      }
+                                                  });
 
             // No need to calculate kid_area again, we'll just get it from the graph.
             let kid_area = ui.kid_area_of(idx).expect("No KidArea found");
@@ -354,48 +328,63 @@ impl<'a> Widget for Canvas<'a> {
             // Instantiate each of the splits, matching on the direction first for efficiency.
             match direction {
 
-                Direction::X(direction) => match direction {
-                    Forwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
-                        let w = length(&split, &ui);
-                        let split = match i {
-                            0 => split.h(kid_area.h()).mid_left_of(idx),
-                            _ => split.right(0.0),
-                        }.w(w);
-                        set_split(split_id, split, &mut ui);
-                    },
-                    Backwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
-                        let w = length(&split, &ui);
-                        let split = match i {
-                            0 => split.h(kid_area.h()).mid_right_of(idx),
-                            _ => split.left(0.0),
-                        }.w(w);
-                        set_split(split_id, split, &mut ui);
-                    },
-                },
+                Direction::X(direction) => {
+                    match direction {
+                        Forwards => {
+                            for (i, &(split_id, split)) in splits.iter().enumerate() {
+                                let w = length(&split, &ui);
+                                let split = match i {
+                                                0 => split.h(kid_area.h()).mid_left_of(idx),
+                                                _ => split.right(0.0),
+                                            }
+                                            .w(w);
+                                set_split(split_id, split, &mut ui);
+                            }
+                        }
+                        Backwards => {
+                            for (i, &(split_id, split)) in splits.iter().enumerate() {
+                                let w = length(&split, &ui);
+                                let split = match i {
+                                                0 => split.h(kid_area.h()).mid_right_of(idx),
+                                                _ => split.left(0.0),
+                                            }
+                                            .w(w);
+                                set_split(split_id, split, &mut ui);
+                            }
+                        }
+                    }
+                }
 
-                Direction::Y(direction) => match direction {
-                    Forwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
-                        let h = length(&split, &ui);
-                        let split = match i {
-                            0 => split.w(kid_area.w()).mid_bottom_of(idx),
-                            _ => split.up(0.0),
-                        }.h(h);
-                        set_split(split_id, split, &mut ui);
-                    },
-                    Backwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
-                        let h = length(&split, &ui);
-                        let split = match i {
-                            0 => split.w(kid_area.w()).mid_top_of(idx),
-                            _ => split.down(0.0),
-                        }.h(h);
-                        set_split(split_id, split, &mut ui);
-                    },
-                },
+                Direction::Y(direction) => {
+                    match direction {
+                        Forwards => {
+                            for (i, &(split_id, split)) in splits.iter().enumerate() {
+                                let h = length(&split, &ui);
+                                let split = match i {
+                                                0 => split.w(kid_area.w()).mid_bottom_of(idx),
+                                                _ => split.up(0.0),
+                                            }
+                                            .h(h);
+                                set_split(split_id, split, &mut ui);
+                            }
+                        }
+                        Backwards => {
+                            for (i, &(split_id, split)) in splits.iter().enumerate() {
+                                let h = length(&split, &ui);
+                                let split = match i {
+                                                0 => split.w(kid_area.w()).mid_top_of(idx),
+                                                _ => split.down(0.0),
+                                            }
+                                            .h(h);
+                                set_split(split_id, split, &mut ui);
+                            }
+                        }
+                    }
+                }
             }
 
         }
     }
-
 }
 
 
@@ -446,4 +435,3 @@ impl<'a> ::label::Labelable<'a> for Canvas<'a> {
         label_font_size { style.title_bar_font_size = Some(FontSize) }
     }
 }
-

--- a/src/widget/drag.rs
+++ b/src/widget/drag.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! Types and functionality related to the dragging behaviour of Widgets.
 //!
 
@@ -32,22 +32,19 @@ pub fn drag_widget(xy: Point, rel_rect: Rect, state: State, mouse: Mouse) -> (Po
 
     // Determine the new drag state.
     let new_state = match (is_over, state, mouse.left.position) {
-        (true,  Normal,     Down) => Normal,
-        (true,  _,          Up)   => Highlighted,
-        (true,  _,          Down) |
+        (true, Normal, Down) => Normal,
+        (true, _, Up) => Highlighted,
+        (true, _, Down) |
         (false, Clicked(_), Down) => Clicked(mouse.xy),
-        _                         => Normal,
+        _ => Normal,
     };
 
     // Drag the Canvas if the TitleBar remains clicked.
     let new_xy = match (state, new_state) {
-        //(Clicked(ax, ay), Clicked(bx, by)) => ::vecmath::vec2_add(xy, [bx - ax, by - ay]),
+        // (Clicked(ax, ay), Clicked(bx, by)) => ::vecmath::vec2_add(xy, [bx - ax, by - ay]),
         (Clicked(a), Clicked(b)) => ::vecmath::vec2_add(xy, ::vecmath::vec2_sub(b, a)),
-        _                        => xy,
+        _ => xy,
     };
 
     (new_xy, new_state)
 }
-
-
-

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -268,7 +268,8 @@ impl<'a, F> Widget for DropDownList<'a, F> where F: FnMut(&mut Option<Idx>, Idx,
 
                     MenuState::Closed
                     // Otherwise if the mouse was released somewhere else we should close the menu.
-                } else if global_mouse.left.was_just_pressed && !canvas_rect.is_over(global_mouse.xy) {
+                } else if global_mouse.left.was_just_pressed &&
+                    !canvas_rect.is_over(global_mouse.xy) {
                     MenuState::Closed
                 } else {
                     MenuState::Open

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -1,21 +1,6 @@
 
-use ::{
-    Button,
-    ButtonStyle,
-    CharacterCache,
-    Color,
-    Colorable,
-    FontSize,
-    Frameable,
-    IndexSlot,
-    Labelable,
-    NodeIndex,
-    Positionable,
-    Rect,
-    Rectangle,
-    Scalar,
-    Sizeable,
-};
+use {Button, ButtonStyle, CharacterCache, Color, Colorable, FontSize, Frameable, IndexSlot,
+     Labelable, NodeIndex, Positionable, Rect, Rectangle, Scalar, Sizeable};
 use widget::{self, Widget};
 
 
@@ -82,7 +67,6 @@ pub enum MenuState {
 }
 
 impl<'a, F> DropDownList<'a, F> {
-
     /// Construct a new DropDownList.
     pub fn new(strings: &'a mut Vec<String>, selected: &'a mut Option<Idx>) -> Self {
         DropDownList {
@@ -114,12 +98,10 @@ impl<'a, F> DropDownList<'a, F> {
         self.style.maybe_max_visible_height = Some(Some(MaxHeight::Scalar(height)));
         self
     }
-
 }
 
 
-impl<'a, F> Widget for DropDownList<'a, F> where
-    F: FnMut(&mut Option<Idx>, Idx, &str),
+impl<'a, F> Widget for DropDownList<'a, F> where F: FnMut(&mut Option<Idx>, Idx, &str)
 {
     type State = State;
     type Style = Style;
@@ -163,18 +145,26 @@ impl<'a, F> Widget for DropDownList<'a, F> where
         let canvas_idx = state.view().canvas_idx.get(&mut ui);
 
         // Check that the selected index, if given, is not greater than the number of strings.
-        let selected = self.selected.and_then(|idx| if idx < num_strings { Some(idx) }
-                                                    else { None });
+        let selected = self.selected.and_then(|idx| {
+            if idx < num_strings {
+                Some(idx)
+            } else {
+                None
+            }
+        });
 
         // If the number of buttons that we have in our previous state doesn't match the number of
         // strings we've just been given, we need to resize our buttons Vec.
         let num_buttons = state.view().buttons.len();
         let maybe_new_buttons = if num_buttons < num_strings {
-            let new_buttons = (num_buttons..num_strings)
-                .map(|i| (ui.new_unique_node_index(), self.strings[i].to_owned()));
-            let total_new_buttons = state.view().buttons.iter()
-                .map(|&(idx, ref string)| (idx, string.clone()))
-                .chain(new_buttons);
+            let new_buttons = (num_buttons..num_strings).map(|i| {
+                (ui.new_unique_node_index(), self.strings[i].to_owned())
+            });
+            let total_new_buttons = state.view()
+                                         .buttons
+                                         .iter()
+                                         .map(|&(idx, ref string)| (idx, string.clone()))
+                                         .chain(new_buttons);
             Some(total_new_buttons.collect())
         } else {
             None
@@ -193,27 +183,32 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                 let buttons = &state.view().buttons;
 
                 // Get the button index and the label for the closed menu's button.
-                let (button_idx, label) = selected
-                    .map(|i| (buttons[i].0, &self.strings[i][..]))
-                    .unwrap_or_else(|| (buttons[0].0, self.maybe_label.unwrap_or("")));
+                let (button_idx, label) = selected.map(|i| (buttons[i].0, &self.strings[i][..]))
+                                                  .unwrap_or_else(|| {
+                                                      (buttons[0].0, self.maybe_label.unwrap_or(""))
+                                                  });
 
                 // Use the pre-existing button widget to act as our button.
                 let mut was_clicked = false;
                 {
                     let mut button = Button::new()
-                        .xy(rect.xy())
-                        .wh(rect.dim())
-                        .label(label)
-                        .parent(idx)
-                        .react(|| was_clicked = true);
+                                         .xy(rect.xy())
+                                         .wh(rect.dim())
+                                         .label(label)
+                                         .parent(idx)
+                                         .react(|| was_clicked = true);
                     let is_selected = false;
                     button.style = style.button_style(is_selected);
                     button.set(button_idx, &mut ui);
                 }
 
                 // If the closed menu was clicked, we want to open it.
-                if was_clicked { MenuState::Open } else { MenuState::Closed }
-            },
+                if was_clicked {
+                    MenuState::Open
+                } else {
+                    MenuState::Closed
+                }
+            }
 
             // Otherwise if open, we want to set all the buttons that would be currently visible.
             MenuState::Open => {
@@ -223,13 +218,15 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                     let bottom_win_y = (-window_dim[1]) / 2.0;
                     const WINDOW_PADDING: Scalar = 20.0;
                     let max = xy[1] + dim[1] / 2.0 - bottom_win_y - WINDOW_PADDING;
-                    style.maybe_max_visible_height(ui.theme()).map(|max_height| {
-                        let height = match max_height {
-                            MaxHeight::Items(num) => (dim[1] - frame) * num as Scalar + frame,
-                            MaxHeight::Scalar(height) => height,
-                        };
-                        ::utils::partial_min(height, max)
-                    }).unwrap_or(max)
+                    style.maybe_max_visible_height(ui.theme())
+                         .map(|max_height| {
+                             let height = match max_height {
+                                 MaxHeight::Items(num) => (dim[1] - frame) * num as Scalar + frame,
+                                 MaxHeight::Scalar(height) => height,
+                             };
+                             ::utils::partial_min(height, max)
+                         })
+                         .unwrap_or(max)
                 };
                 let canvas_dim = [dim[0], max_visible_height];
                 let canvas_shift_y = dim[1] / 2.0 - canvas_dim[1] / 2.0;
@@ -251,11 +248,11 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                 let mut was_clicked = None;
                 for (i, ((label, button_node_idx), button_xy)) in iter {
                     let mut button = Button::new()
-                        .wh(dim)
-                        .label(label)
-                        .parent(canvas_idx)
-                        .xy(button_xy)
-                        .react(|| was_clicked = Some(i));
+                                         .wh(dim)
+                                         .label(label)
+                                         .parent(canvas_idx)
+                                         .xy(button_xy)
+                                         .react(|| was_clicked = Some(i));
                     button.style = style.button_style(Some(i) == selected);
                     button.set(button_node_idx, &mut ui);
                 }
@@ -270,14 +267,13 @@ impl<'a, F> Widget for DropDownList<'a, F> where
                     }
 
                     MenuState::Closed
-                // Otherwise if the mouse was released somewhere else we should close the menu.
-                } else if global_mouse.left.was_just_pressed
-                && !canvas_rect.is_over(global_mouse.xy) {
+                    // Otherwise if the mouse was released somewhere else we should close the menu.
+                } else if global_mouse.left.was_just_pressed && !canvas_rect.is_over(global_mouse.xy) {
                     MenuState::Closed
                 } else {
                     MenuState::Open
                 }
-            },
+            }
 
         };
 
@@ -289,23 +285,26 @@ impl<'a, F> Widget for DropDownList<'a, F> where
             state.update(|state| state.maybe_selected = *self.selected);
         }
     }
-
 }
 
 
 impl Style {
-
     /// Style for a `Button` given this `Style`'s current state.
     pub fn button_style(&self, is_selected: bool) -> ButtonStyle {
         ButtonStyle {
-            color: self.color.map(|c| if is_selected { c.highlighted() } else { c }),
+            color: self.color.map(|c| {
+                if is_selected {
+                    c.highlighted()
+                } else {
+                    c
+                }
+            }),
             frame: self.frame,
             frame_color: self.frame_color,
             label_color: self.label_color,
             label_font_size: self.label_font_size,
         }
     }
-
 }
 
 

--- a/src/widget/id.rs
+++ b/src/widget/id.rs
@@ -9,7 +9,9 @@ pub struct Id(pub usize);
 
 impl From<usize> for Id {
     #[inline]
-    fn from(u: usize) -> Id { Id(u) }
+    fn from(u: usize) -> Id {
+        Id(u)
+    }
 }
 
 
@@ -21,6 +23,7 @@ impl From<usize> for Id {
 ///
 impl ::std::ops::Add<usize> for Id {
     type Output = Id;
-    fn add(self, rhs: usize) -> Id { Id(self.0 + rhs) }
+    fn add(self, rhs: usize) -> Id {
+        Id(self.0 + rhs)
+    }
 }
-

--- a/src/widget/index.rs
+++ b/src/widget/index.rs
@@ -1,5 +1,5 @@
 
-use ::{NodeIndex, WidgetId};
+use {NodeIndex, WidgetId};
 
 
 /// An index either given in the form of a publicly instantiated `Widget`'s `WidgetId`, or an

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -48,7 +48,6 @@ widget_style!{
 }
 
 impl<F> Matrix<F> {
-
     /// Create a widget matrix context.
     pub fn new(cols: usize, rows: usize) -> Matrix<F> {
         Matrix {
@@ -76,13 +75,12 @@ impl<F> Matrix<F> {
         self.style.cell_pad_h = Some(h);
         self
     }
-
 }
 
 
-impl<'a, F, W> Widget for Matrix<F> where
-    W: Widget,
-    F: FnMut(WidgetNum, ColNum, RowNum) -> W
+impl<'a, F, W> Widget for Matrix<F>
+    where W: Widget,
+          F: FnMut(WidgetNum, ColNum, RowNum) -> W
 {
     type State = State;
     type Style = Style;
@@ -116,10 +114,13 @@ impl<'a, F, W> Widget for Matrix<F> where
         let num_cols = state.view().indices.len();
         let num_rows = state.view().indices.get(0).map(|col| col.len()).unwrap_or(0);
         let maybe_new_indices = if num_cols < cols || num_rows < rows {
-            let mut total_cols: Vec<_> = state.view().indices.iter()
-                .map(|col| col.clone())
-                .chain((num_cols..cols).map(|_| Vec::with_capacity(rows)))
-                .collect();
+            let mut total_cols: Vec<_> = state.view()
+                                              .indices
+                                              .iter()
+                                              .map(|col| col.clone())
+                                              .chain((num_cols..cols)
+                                                         .map(|_| Vec::with_capacity(rows)))
+                                              .collect();
             for col in total_cols.iter_mut() {
                 let rows_in_col = col.len();
                 if rows_in_col < rows {
@@ -133,7 +134,8 @@ impl<'a, F, W> Widget for Matrix<F> where
 
         // A function to simplify getting the current slice of indices.
         fn get_indices<'a>(maybe_new: &'a Option<Vec<Vec<NodeIndex>>>,
-                           state: &'a widget::State<State>) -> &'a [Vec<NodeIndex>] {
+                           state: &'a widget::State<State>)
+                           -> &'a [Vec<NodeIndex>] {
             maybe_new.as_ref().map(|is| &is[..]).unwrap_or_else(|| &state.view().indices[..])
         }
 
@@ -178,5 +180,4 @@ impl<'a, F, W> Widget for Matrix<F> where
             state.update(|state| state.indices = new_indices);
         }
     }
-
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -11,8 +11,8 @@ pub use self::id::Id;
 pub use self::index::Index;
 
 // Macro providing modules.
-#[macro_use] mod builder;
-#[macro_use] mod style;
+#[macro_use]mod builder;
+#[macro_use]mod style;
 
 // Widget functionality modules.
 pub mod drag;
@@ -40,7 +40,9 @@ pub mod xy_pad;
 
 /// Arguments for the [**Widget::update**](./trait.Widget#method.update) method in a struct to
 /// simplify the method signature.
-pub struct UpdateArgs<'a, 'b: 'a, W, C: 'a> where W: Widget {
+pub struct UpdateArgs<'a, 'b: 'a, W, C: 'a>
+    where W: Widget
+{
     /// The **Widget**'s unique index.
     pub idx: Index,
     /// The **Widget**'s parent unique index, if there is one.
@@ -104,7 +106,9 @@ pub struct IndexSlot {
 
 /// Arguments to the [**Widget::kid_area**](./trait.Widget#method.kid_area) method in a struct to
 /// simplify the method signature.
-pub struct KidAreaArgs<'a, W, C: 'a> where W: Widget {
+pub struct KidAreaArgs<'a, W, C: 'a>
+    where W: Widget
+{
     /// The **Rect** describing the **Widget**'s position and dimensions.
     pub rect: Rect,
     /// Current **Widget::Style** of the **Widget**.
@@ -155,9 +159,12 @@ impl MaybeParent {
 
     /// The same as `get_unchecked`, but checks whether or not the widget that we're inferring the
     /// parent for is the `Ui`'s window (which cannot have a parent, without creating a cycle).
-    pub fn get<C>(&self, idx: Index, ui: &Ui<C>, x_pos: Position, y_pos: Position)
-        -> Option<Index>
-    {
+    pub fn get<C>(&self,
+                  idx: Index,
+                  ui: &Ui<C>,
+                  x_pos: Position,
+                  y_pos: Position)
+                  -> Option<Index> {
         if idx == ui.window.into() {
             None
         } else {
@@ -263,7 +270,9 @@ pub struct CommonState {
 }
 
 /// A **Widget**'s state in a form that is retrievable from the **Ui**'s widget cache.
-pub struct Cached<W> where W: Widget {
+pub struct Cached<W>
+    where W: Widget
+{
     /// State that is unique to the Widget.
     pub state: W::State,
     /// Unique styling state for the Widget.
@@ -333,7 +342,9 @@ pub struct PreUpdateCache {
 /// We do this so that if this **Widget** were to internally **Widget::set** some other
 /// **Widget**s, this **Widget**'s positioning and dimension data will already exist within the
 /// widget **Graph** for reference.
-pub struct PostUpdateCache<W> where W: Widget {
+pub struct PostUpdateCache<W>
+    where W: Widget
+{
     /// The **Widget**'s unique **Index**.
     pub idx: Index,
     /// The **Widget**'s parent's unique **Index** (if it has a parent).
@@ -352,14 +363,20 @@ trait UiRefMut {
     fn ui_ref_mut(&mut self) -> &mut Ui<Self::CharacterCache>;
 }
 
-impl<C> UiRefMut for Ui<C> where C: CharacterCache {
+impl<C> UiRefMut for Ui<C> where C: CharacterCache
+{
     type CharacterCache = C;
-    fn ui_ref_mut(&mut self) -> &mut Ui<C> { self }
+    fn ui_ref_mut(&mut self) -> &mut Ui<C> {
+        self
+    }
 }
 
-impl<'a, C> UiRefMut for UiCell<'a, C> where C: CharacterCache {
+impl<'a, C> UiRefMut for UiCell<'a, C> where C: CharacterCache
+{
     type CharacterCache = C;
-    fn ui_ref_mut(&mut self) -> &mut Ui<C> { self.ui }
+    fn ui_ref_mut(&mut self) -> &mut Ui<C> {
+        self.ui
+    }
 }
 
 
@@ -367,7 +384,8 @@ impl<'a, C> UiRefMut for UiCell<'a, C> where C: CharacterCache {
 pub trait Style: Any + Debug + PartialEq + Sized {}
 
 /// Auto-implement the **Style** trait for all applicable types.
-impl<T> Style for T where T: Any + Debug + PartialEq + Sized {}
+impl<T> Style for T where T: Any + Debug + PartialEq + Sized
+{}
 
 
 /// Determines the default **Dimension** for a **Widget**.
@@ -380,17 +398,18 @@ impl<T> Style for T where T: Any + Debug + PartialEq + Sized {}
 fn default_dimension<W, C, F>(widget: &W, ui: &Ui<C>, f: F) -> Dimension
     where W: Widget,
           C: CharacterCache,
-          F: FnOnce(theme::UniqueDefault<W::Style>) -> Option<Dimension>,
+          F: FnOnce(theme::UniqueDefault<W::Style>) -> Option<Dimension>
 {
-    ui.theme.widget_style::<W::Style>(widget.unique_kind())
-        .and_then(f)
-        .or_else(|| ui.maybe_prev_widget().map(|idx| Dimension::Of(idx, None)))
-        .unwrap_or_else(|| {
-            let x_pos = widget.get_x_position(ui);
-            let y_pos = widget.get_y_position(ui);
-            let parent_idx = widget.common().maybe_parent_idx.get_unchecked(ui, x_pos, y_pos);
-            Dimension::Of(parent_idx, None)
-        })
+    ui.theme
+      .widget_style::<W::Style>(widget.unique_kind())
+      .and_then(f)
+      .or_else(|| ui.maybe_prev_widget().map(|idx| Dimension::Of(idx, None)))
+      .unwrap_or_else(|| {
+          let x_pos = widget.get_x_position(ui);
+          let y_pos = widget.get_y_position(ui);
+          let parent_idx = widget.common().maybe_parent_idx.get_unchecked(ui, x_pos, y_pos);
+          Dimension::Of(parent_idx, None)
+      })
 }
 
 /// Determines the default **Dimension** for a **Widget**.
@@ -407,7 +426,7 @@ fn default_dimension<W, C, F>(widget: &W, ui: &Ui<C>, f: F) -> Dimension
 /// internally if you partly require the bahaviour of the default implementations.
 pub fn default_x_dimension<W, C>(widget: &W, ui: &Ui<C>) -> Dimension
     where W: Widget,
-          C: CharacterCache,
+          C: CharacterCache
 {
     default_dimension(widget, ui, |default| default.common.maybe_x_dimension)
 }
@@ -426,7 +445,7 @@ pub fn default_x_dimension<W, C>(widget: &W, ui: &Ui<C>) -> Dimension
 /// internally if you partly require the bahaviour of the default implementations.
 pub fn default_y_dimension<W, C>(widget: &W, ui: &Ui<C>) -> Dimension
     where W: Widget,
-          C: CharacterCache,
+          C: CharacterCache
 {
     default_dimension(widget, ui, |default| default.common.maybe_y_dimension)
 }
@@ -592,18 +611,20 @@ pub trait Widget: Sized {
     ///
     /// This is used when no **Position** is explicitly given when instantiating the Widget.
     fn default_x_position<C: CharacterCache>(&self, ui: &Ui<C>) -> Position {
-        ui.theme.widget_style::<Self::Style>(self.unique_kind())
-            .and_then(|style| style.common.maybe_x_position)
-            .unwrap_or(ui.theme.x_position)
+        ui.theme
+          .widget_style::<Self::Style>(self.unique_kind())
+          .and_then(|style| style.common.maybe_x_position)
+          .unwrap_or(ui.theme.x_position)
     }
 
     /// The default **Position** for the widget along the *y* axis.
     ///
     /// This is used when no **Position** is explicitly given when instantiating the Widget.
     fn default_y_position<C: CharacterCache>(&self, ui: &Ui<C>) -> Position {
-        ui.theme.widget_style::<Self::Style>(self.unique_kind())
-            .and_then(|style| style.common.maybe_y_position)
-            .unwrap_or(ui.theme.y_position)
+        ui.theme
+          .widget_style::<Self::Style>(self.unique_kind())
+          .and_then(|style| style.common.maybe_y_position)
+          .unwrap_or(ui.theme.y_position)
     }
 
     /// The default width for the **Widget**.
@@ -626,11 +647,7 @@ pub trait Widget: Sized {
 
     /// If the widget is draggable, implement this method and return the position an dimensions
     /// of the draggable space. The position should be relative to the center of the widget.
-    fn drag_area(&self,
-                 _dim: Dimensions,
-                 _style: &Self::Style,
-                 _theme: &Theme) -> Option<Rect>
-    {
+    fn drag_area(&self, _dim: Dimensions, _style: &Self::Style, _theme: &Theme) -> Option<Rect> {
         None
     }
 
@@ -746,9 +763,9 @@ pub trait Widget: Sized {
     /// - If the widget's state or style has changed, the **Ui** will be notified that the widget
     /// needs to be re-drawn.
     /// - The new State and Style will be cached within the `Ui`.
-    fn set<I, U>(self, idx: I, ui: &mut U) where
-        I: Into<Index>,
-        U: UiRefMut,
+    fn set<I, U>(self, idx: I, ui: &mut U)
+        where I: Into<Index>,
+              U: UiRefMut
     {
         set_widget(self, idx.into(), ui.ui_ref_mut());
     }
@@ -763,13 +780,13 @@ pub trait Widget: Sized {
 /// For all following occasions, the pre-existing cached state will be compared and updated.
 ///
 /// Note that this is a very imperative, mutation oriented segment of code. We try to move as much
-/// imperativeness and mutation out of the users hands and into this function as possible, so that 
+/// imperativeness and mutation out of the users hands and into this function as possible, so that
 /// users have a clear, consise, purely functional `Widget` API. As a result, we try to keep this
 /// as verbosely annotated as possible. If anything is unclear, feel free to post an issue or PR
 /// with concerns/improvements to the github repo.
-fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
-    C: CharacterCache,
-    W: Widget,
+fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>)
+    where C: CharacterCache,
+          W: Widget
 {
     let kind = widget.unique_kind();
 
@@ -782,9 +799,12 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
             if container.kind != kind {
                 writeln!(::std::io::stderr(),
                          "A widget of a different kind already exists at the given WidgetId \
-                         ({:?}). You tried to insert a {:?}, however the existing widget is a \
-                         {:?}. Check your widgets' `WidgetId`s for errors.",
-                          idx, kind, container.kind).unwrap();
+                          ({:?}). You tried to insert a {:?}, however the existing widget is a \
+                          {:?}. Check your widgets' `WidgetId`s for errors.",
+                         idx,
+                         kind,
+                         container.kind)
+                    .unwrap();
                 return None;
             } else {
                 container.take_widget_state()
@@ -802,7 +822,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
          maybe_prev_y_scroll_state) =
         maybe_widget_state.map(|prev| {
 
-            // Destructure the cached state.
+    // Destructure the cached state.
             let Cached {
                 state,
                 style,
@@ -816,7 +836,7 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
                 ..
             } = prev;
 
-            // Use the cached state to construct the prev_state (to be fed to Widget::update).
+    // Use the cached state to construct the prev_state (to be fed to Widget::update).
             let prev_common = CommonState {
                 rect: rect,
                 depth: depth,
@@ -868,19 +888,21 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
                     // track of whether or not a widget `has_been_dragged` to see if we should
                     // leave it at its previous xy or use calc_xy.
                     None => (calc_xy(), drag::State::Normal),
-                    Some(drag_area) => match maybe_mouse {
-                        // If there is some draggable area and mouse, drag the xy.
-                        Some(mouse) => {
-                            let drag_state = prev.drag_state;
+                    Some(drag_area) => {
+                        match maybe_mouse {
+                            // If there is some draggable area and mouse, drag the xy.
+                            Some(mouse) => {
+                                let drag_state = prev.drag_state;
 
-                            // Drag the xy of the widget and return the new xy.
-                            drag::drag_widget(prev.rect.xy(), drag_area, drag_state, mouse)
-                        },
-                        // Otherwise just return the regular xy and drag state.
-                        None => (prev.rect.xy(), drag::State::Normal),
-                    },
+                                // Drag the xy of the widget and return the new xy.
+                                drag::drag_widget(prev.rect.xy(), drag_area, drag_state, mouse)
+                            }
+                            // Otherwise just return the regular xy and drag state.
+                            None => (prev.rect.xy(), drag::State::Normal),
+                        }
+                    }
                 }
-            },
+            }
         }
     };
 
@@ -889,14 +911,15 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
     // Check whether we have stopped / started dragging the widget and in turn whether or not
     // we need to capture the mouse.
-    match (maybe_prev_common.as_ref().map(|prev| prev.drag_state), drag_state) {
+    match (maybe_prev_common.as_ref().map(|prev| prev.drag_state),
+           drag_state) {
         (Some(drag::State::Highlighted), drag::State::Clicked(_)) => {
             ui::mouse_captured_by(ui, idx);
-        },
+        }
         (Some(drag::State::Clicked(_)), drag::State::Highlighted) |
-        (Some(drag::State::Clicked(_)), drag::State::Normal)      => {
+        (Some(drag::State::Clicked(_)), drag::State::Normal) => {
             ui::mouse_uncaptured_by(ui, idx);
-        },
+        }
         _ => (),
     }
 
@@ -918,11 +941,11 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
                         } else {
                             Some(prev_floating)
                         }
-                    },
+                    }
                     (Some(prev_floating), None) => Some(prev_floating),
                     _ => Some(new_floating()),
                 }
-            },
+            }
             None => Some(new_floating()),
         }
     } else {
@@ -945,12 +968,20 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
     // We must step the scrolling using the previous `kid_area` state so that the bounding box
     // around our kid widgets is in sync with the position of the `kid_area`.
     let prev_kid_area = maybe_prev_common.map(|common| common.kid_area)
-        .unwrap_or_else(|| kid_area);
+                                         .unwrap_or_else(|| kid_area);
     let maybe_x_scroll_state = widget.common().maybe_x_scroll.map(|scroll_args| {
-        scroll::State::update(ui, idx, scroll_args, &prev_kid_area, maybe_prev_x_scroll_state)
+        scroll::State::update(ui,
+                              idx,
+                              scroll_args,
+                              &prev_kid_area,
+                              maybe_prev_x_scroll_state)
     });
     let maybe_y_scroll_state = widget.common().maybe_y_scroll.map(|scroll_args| {
-        scroll::State::update(ui, idx, scroll_args, &prev_kid_area, maybe_prev_y_scroll_state)
+        scroll::State::update(ui,
+                              idx,
+                              scroll_args,
+                              &prev_kid_area,
+                              maybe_prev_y_scroll_state)
     });
 
     // Determine whether or not this is the first time set has been called.
@@ -964,11 +995,14 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
         use Position::{Place, Relative, Direction, Align, Absolute};
 
         // Some widget to which this widget is relatively positioned (if there is one).
-        let maybe_positioned_relatively_idx = |pos: Position| match pos {
-            Place(_, maybe_idx) | Relative(_, maybe_idx) |
-            Direction(_, _, maybe_idx) | Align(_, maybe_idx) =>
-                maybe_idx.or(maybe_prev_widget_idx),
-            Absolute(_) => None,
+        let maybe_positioned_relatively_idx = |pos: Position| {
+            match pos {
+                Place(_, maybe_idx) |
+                Relative(_, maybe_idx) |
+                Direction(_, _, maybe_idx) |
+                Align(_, maybe_idx) => maybe_idx.or(maybe_prev_widget_idx),
+                Absolute(_) => None,
+            }
         };
 
         let maybe_x_positioned_relatively_idx = maybe_positioned_relatively_idx(x_pos);
@@ -994,12 +1028,14 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
     // Unwrap the widget's previous common state. If there is no previous common state, we'll
     // use the new state in it's place.
-    let prev_common = maybe_prev_common.unwrap_or_else(|| CommonState {
-        rect: rect,
-        depth: depth,
-        drag_state: drag_state,
-        maybe_floating: maybe_floating,
-        kid_area: kid_area,
+    let prev_common = maybe_prev_common.unwrap_or_else(|| {
+        CommonState {
+            rect: rect,
+            depth: depth,
+            drag_state: drag_state,
+            maybe_floating: maybe_floating,
+            kid_area: kid_area,
+        }
     });
 
     // Retrieve the widget's unique state and update it via `Widget::update`.
@@ -1034,17 +1070,15 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
     };
 
     // Determine whether or not the `State` has changed.
-    let state_has_changed = has_state_updated
-        || rect != prev_common.rect
-        || depth != prev_common.depth
-        || is_first_set;
+    let state_has_changed = has_state_updated || rect != prev_common.rect ||
+                            depth != prev_common.depth || is_first_set;
 
     // Determine whether or not the widget's `Style` has changed.
     let style_has_changed = maybe_prev_style.map(|style| style != new_style).unwrap_or(false);
 
     // We need to know if the scroll state has changed to see if we need to redraw.
-    let scroll_has_changed = maybe_x_scroll_state != maybe_prev_x_scroll_state
-        || maybe_y_scroll_state != maybe_prev_y_scroll_state;
+    let scroll_has_changed = maybe_x_scroll_state != maybe_prev_x_scroll_state ||
+                             maybe_y_scroll_state != maybe_prev_y_scroll_state;
 
     // We only need to redraw if some visible part of our widget has changed.
     let requires_redraw = style_has_changed || state_has_changed || scroll_has_changed;
@@ -1056,22 +1090,26 @@ fn set_widget<'a, C, W>(widget: W, idx: Index, ui: &mut Ui<C>) where
 
     // Finally, cache the `Widget`'s newly updated `State` and `Style` within the `ui`'s
     // `widget_graph`.
-    ui::post_update_cache::<C, W>(ui, PostUpdateCache {
-        idx: idx,
-        maybe_parent_idx: maybe_parent_idx,
-        state: unique_state,
-        style: new_style,
-    });
+    ui::post_update_cache::<C, W>(ui,
+                                  PostUpdateCache {
+                                      idx: idx,
+                                      maybe_parent_idx: maybe_parent_idx,
+                                      state: unique_state,
+                                      style: new_style,
+                                  });
 }
 
 
 impl<'a, C> UiCell<'a, C> {
-
     /// A reference to the `Theme` that is currently active within the `Ui`.
-    pub fn theme(&self) -> &Theme { &self.ui.theme }
+    pub fn theme(&self) -> &Theme {
+        &self.ui.theme
+    }
 
     /// A reference to the `Ui`'s `GlyphCache`.
-    pub fn glyph_cache(&self) -> &GlyphCache<C> { &self.ui.glyph_cache }
+    pub fn glyph_cache(&self) -> &GlyphCache<C> {
+        &self.ui.glyph_cache
+    }
 
     /// A struct representing the user input that has occurred since the last update.
     pub fn input(&self) -> UserInput {
@@ -1140,7 +1178,6 @@ impl<'a, C> UiCell<'a, C> {
     pub fn kids_bounding_box<I: Into<Index>>(&self, idx: I) -> Option<Rect> {
         self.ui.kids_bounding_box(idx)
     }
-
 }
 
 impl<'a, C> ::std::ops::Deref for UiCell<'a, C> {
@@ -1158,12 +1195,9 @@ impl<'a, C> AsRef<Ui<C>> for UiCell<'a, C> {
 
 
 impl IndexSlot {
-
     /// Construct a new empty **IndexSlot**.
     pub fn new() -> Self {
-        IndexSlot {
-            maybe_idx: ::std::cell::Cell::new(None),
-        }
+        IndexSlot { maybe_idx: ::std::cell::Cell::new(None) }
     }
 
     /// Returns the **NodeIndex** held by the **IndexSlot**.
@@ -1177,15 +1211,15 @@ impl IndexSlot {
         }
         self.maybe_idx.get().unwrap()
     }
-
 }
 
 
 impl<'a, T> State<'a, T> {
-
     /// Immutably borrow the internal widget state.
     #[inline]
-    pub fn view(&self) -> &T { &self.state }
+    pub fn view(&self) -> &T {
+        &self.state
+    }
 
     /// Mutate the internal widget state and set a flag notifying us that there has been a mutation.
     ///
@@ -1195,11 +1229,12 @@ impl<'a, T> State<'a, T> {
     /// If this method *is* called, we assume that there has been some mutation and in turn will
     /// need to re-draw the Widget. Thus, it is recommended that you *only* call this method if you
     /// need to update the unique state in some way.
-    pub fn update<F>(&mut self, f: F) where F: FnOnce(&mut T) {
+    pub fn update<F>(&mut self, f: F)
+        where F: FnOnce(&mut T)
+    {
         self.has_updated = true;
         f(self.state);
     }
-
 }
 
 
@@ -1232,7 +1267,8 @@ impl CommonStyle {
 }
 
 
-impl<W> Positionable for W where W: Widget {
+impl<W> Positionable for W where W: Widget
+{
     #[inline]
     fn x_position(mut self, x: Position) -> Self {
         self.common_mut().style.maybe_x_position = Some(x);
@@ -1246,17 +1282,29 @@ impl<W> Positionable for W where W: Widget {
     #[inline]
     fn get_x_position<C: CharacterCache>(&self, ui: &Ui<C>) -> Position {
 
-        let from_y_position = || self.common().style.maybe_y_position
-            .and_then(|y_pos| infer_position_from_other_position(y_pos, Align::Start));
-        self.common().style.maybe_x_position
+        let from_y_position = || {
+            self.common()
+                .style
+                .maybe_y_position
+                .and_then(|y_pos| infer_position_from_other_position(y_pos, Align::Start))
+        };
+        self.common()
+            .style
+            .maybe_x_position
             .or_else(from_y_position)
             .unwrap_or(self.default_x_position(ui))
     }
     #[inline]
     fn get_y_position<C: CharacterCache>(&self, ui: &Ui<C>) -> Position {
-        let from_x_position = || self.common().style.maybe_x_position
-            .and_then(|x_pos| infer_position_from_other_position(x_pos, Align::End));
-        self.common().style.maybe_y_position
+        let from_x_position = || {
+            self.common()
+                .style
+                .maybe_x_position
+                .and_then(|x_pos| infer_position_from_other_position(x_pos, Align::End))
+        };
+        self.common()
+            .style
+            .maybe_y_position
             .or_else(from_x_position)
             .unwrap_or(self.default_y_position(ui))
     }
@@ -1287,7 +1335,8 @@ fn infer_position_from_other_position(other_pos: Position, dir_align: Align) -> 
 }
 
 
-impl<W> Sizeable for W where W: Widget {
+impl<W> Sizeable for W where W: Widget
+{
     #[inline]
     fn x_dimension(mut self, w: Dimension) -> Self {
         self.common_mut().style.maybe_x_dimension = Some(w);
@@ -1325,7 +1374,7 @@ impl<W> Sizeable for W where W: Widget {
 //         }
 //     };
 // }
-// 
+//
 // style_retrieval! {
 //     fn_name: color,
 //     member: maybe_color,

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -1,24 +1,7 @@
 
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimensions,
-    FontSize,
-    Frameable,
-    FramedRectangle,
-    IndexSlot,
-    Labelable,
-    Mouse,
-    NodeIndex,
-    Point,
-    Positionable,
-    Rectangle,
-    Scalar,
-    Sizeable,
-    Text,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, Dimensions, FontSize, Frameable, FramedRectangle,
+     IndexSlot, Labelable, Mouse, NodeIndex, Point, Positionable, Rectangle, Scalar, Sizeable,
+     Text, Widget};
 use num::{Float, NumCast};
 use std::any::Any;
 use std::cmp::Ordering;
@@ -76,7 +59,7 @@ pub enum Elem {
     LabelGlyphs,
     /// Represents a value glyph slot at `usize` index as well as the last mouse.xy.y for
     /// comparison in determining new value.
-    ValueGlyph(usize, f64)
+    ValueGlyph(usize, f64),
 }
 
 /// The current interaction with the NumberDialer.
@@ -121,10 +104,10 @@ fn create_val_string<T: ToString>(val: T, len: usize, precision: u8) -> String {
         (None, _) => {
             val_string.push('.');
             val_string.extend(repeat('0').take(precision as usize));
-        },
+        }
         (Some(idx), 0) => {
             val_string.truncate(idx);
-        },
+        }
         (Some(idx), _) => {
             let (len, desired_len) = (val_string.len(), idx + precision as usize + 1);
             match len.cmp(&desired_len) {
@@ -132,7 +115,7 @@ fn create_val_string<T: ToString>(val: T, len: usize, precision: u8) -> String {
                 Ordering::Equal => (),
                 Ordering::Less => val_string.extend(repeat('0').take(desired_len - len)),
             }
-        },
+        }
     }
     // Now check that the total length matches. We already know that the decimal end of the string
     // is correct, so if the lengths don't match we know we must prepend the difference as '0's.
@@ -162,8 +145,8 @@ fn is_over(mouse_xy: Point,
            label_x: f64,
            label_dim: Dimensions,
            val_string_dim: Point,
-           val_string_len: usize) -> Option<Elem>
-{
+           val_string_len: usize)
+           -> Option<Elem> {
     use position::is_over_rect;
     if is_over_rect([0.0, 0.0], dim, mouse_xy) {
         if is_over_rect([label_x, 0.0], label_dim, mouse_xy) {
@@ -176,7 +159,7 @@ fn is_over(mouse_xy: Point,
                 let mut slot_xy = slot_rect_xy;
                 for i in 0..val_string_len {
                     if is_over_rect(slot_xy, [slot_w, pad_dim[1]], mouse_xy) {
-                        return Some(Elem::ValueGlyph(i, mouse_xy[1]))
+                        return Some(Elem::ValueGlyph(i, mouse_xy[1]));
                     }
                     slot_xy[0] += slot_w;
                 }
@@ -196,28 +179,28 @@ fn get_new_interaction(is_over_elem: Option<Elem>, prev: Interaction, mouse: Mou
     use self::Elem::ValueGlyph;
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over_elem, prev, mouse.left.position) {
-        (Some(_),    Normal,          Down) => Normal,
-        (Some(elem), _,               Up)   => Highlighted(elem),
-        (Some(elem), Highlighted(_),  Down) => Clicked(elem),
-        (Some(_),    Clicked(p_elem), Down) => {
+        (Some(_), Normal, Down) => Normal,
+        (Some(elem), _, Up) => Highlighted(elem),
+        (Some(elem), Highlighted(_), Down) => Clicked(elem),
+        (Some(_), Clicked(p_elem), Down) => {
             match p_elem {
                 ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.xy[1])),
-                _                  => Clicked(p_elem),
+                _ => Clicked(p_elem),
             }
-        },
-        (None,       Clicked(p_elem), Down) => {
+        }
+        (None, Clicked(p_elem), Down) => {
             match p_elem {
                 ValueGlyph(idx, _) => Clicked(ValueGlyph(idx, mouse.xy[1])),
-                _                  => Clicked(p_elem),
+                _ => Clicked(p_elem),
             }
-        },
-        _                                   => Normal,
+        }
+        _ => Normal,
     }
 }
 
 
-impl<'a, T, F> NumberDialer<'a, T, F> where T: Float {
-
+impl<'a, T, F> NumberDialer<'a, T, F> where T: Float
+{
     /// Construct a new NumberDialer widget.
     pub fn new(value: T, min: T, max: T, precision: u8) -> Self {
         NumberDialer {
@@ -237,12 +220,11 @@ impl<'a, T, F> NumberDialer<'a, T, F> where T: Float {
         pub react { maybe_react = Some(F) }
         pub enabled { enabled = bool }
     }
-
 }
 
-impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
-    F: FnOnce(T),
-    T: Any + ::std::fmt::Debug + Float + NumCast + ToString,
+impl<'a, T, F> Widget for NumberDialer<'a, T, F>
+    where F: FnOnce(T),
+          T: Any + ::std::fmt::Debug + Float + NumCast + ToString
 {
     type State = State<T>;
     type Style = Style;
@@ -291,7 +273,11 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
         let font_size = style.label_font_size(ui.theme());
         let label_string = maybe_label.map_or_else(|| String::new(), |text| format!("{}: ", text));
         let label_dim = [ui.glyph_cache().width(font_size, &label_string), font_size as f64];
-        let precision_len = if precision == 0 { 0 } else { precision as usize + 1 };
+        let precision_len = if precision == 0 {
+            0
+        } else {
+            precision as usize + 1
+        };
         let val_string_len = max.to_string().len() + precision_len;
         let val_string = create_val_string(value, val_string_len, precision);
         let val_string_dim = [val_string_width(font_size, &val_string), font_size as f64];
@@ -300,17 +286,26 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
         let new_interaction = match (enabled, maybe_mouse) {
             (false, _) | (true, None) => Normal,
             (true, Some(mouse)) => {
-                let is_over_elem = is_over(mouse.xy, rect.dim(), inner_rect.dim(), label_rel_x,
-                                           label_dim, val_string_dim, val_string_len);
+                let is_over_elem = is_over(mouse.xy,
+                                           rect.dim(),
+                                           inner_rect.dim(),
+                                           label_rel_x,
+                                           label_dim,
+                                           val_string_dim,
+                                           val_string_len);
                 get_new_interaction(is_over_elem, interaction, mouse)
-            },
+            }
         };
 
         // Capture the mouse if clicked, uncapture if released.
         match (interaction, new_interaction) {
-            (Highlighted(_), Clicked(_)) => { ui.capture_mouse(); },
+            (Highlighted(_), Clicked(_)) => {
+                ui.capture_mouse();
+            }
             (Clicked(_), Highlighted(_)) |
-            (Clicked(_), Normal)         => { ui.uncapture_mouse(); },
+            (Clicked(_), Normal) => {
+                ui.uncapture_mouse();
+            }
             _ => (),
         }
 
@@ -330,26 +325,28 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
                             match ord {
                                 Ordering::Greater => {
                                     clamp(val_f + (10.0).powf(power as f32) as f64, min_f, max_f)
-                                },
+                                }
                                 Ordering::Less => {
                                     clamp(val_f - (10.0).powf(power as f32) as f64, min_f, max_f)
-                                },
+                                }
                                 _ => val_f,
                             }
-                        },
+                        }
                         Some(dec_idx) => {
                             let mut power = dec_idx as isize - idx as isize - 1;
-                            if power < -1 { power += 1; }
+                            if power < -1 {
+                                power += 1;
+                            }
                             match ord {
                                 Ordering::Greater => {
                                     clamp(val_f + (10.0).powf(power as f32) as f64, min_f, max_f)
-                                },
+                                }
                                 Ordering::Less => {
                                     clamp(val_f - (10.0).powf(power as f32) as f64, min_f, max_f)
-                                },
+                                }
                                 _ => val_f,
                             }
-                        },
+                        }
                     };
                     new_val = NumCast::from(new_val_f).unwrap()
                 };
@@ -359,11 +356,11 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
         // Call the `react` with the new value if the mouse is pressed/released on the widget or if
         // the value has changed.
         if let Some(react) = maybe_react {
-            let should_react = value != new_val
-                || match (interaction, new_interaction) {
-                    (Highlighted(_), Clicked(_)) | (Clicked(_), Highlighted(_)) => true,
-                    _ => false,
-                };
+            let should_react = value != new_val ||
+                               match (interaction, new_interaction) {
+                (Highlighted(_), Clicked(_)) | (Clicked(_), Highlighted(_)) => true,
+                _ => false,
+            };
             if should_react {
                 react(new_val);
             }
@@ -420,9 +417,11 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
         if state.view().glyph_slot_indices.len() < val_string.chars().count() {
             state.update(|state| {
                 let range = state.glyph_slot_indices.len()..val_string.chars().count();
-                let extension = range.map(|_| GlyphSlot {
-                    rectangle_idx: ui.new_unique_node_index(),
-                    text_idx: ui.new_unique_node_index(),
+                let extension = range.map(|_| {
+                    GlyphSlot {
+                        rectangle_idx: ui.new_unique_node_index(),
+                        text_idx: ui.new_unique_node_index(),
+                    }
                 });
                 state.glyph_slot_indices.extend(extension);
             })
@@ -434,25 +433,37 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
         let val_string_pos = [label_rel_x + label_dim[0] / 2.0, 0.0];
         let mut rel_slot_x = slot_w / 2.0 + val_string_pos[0];
         for (i, _) in val_string.char_indices() {
-            let glyph_string = &val_string[i..i+1];
+            let glyph_string = &val_string[i..i + 1];
             let slot = state.view().glyph_slot_indices[i];
 
             // We only want to draw the slot if **Rectangle** if its highlighted or selected.
             let maybe_slot_color = match new_interaction {
-                Interaction::Highlighted(elem) => match elem {
-                    Elem::ValueGlyph(idx, _) =>
-                        if idx == i { Some(color.highlighted()) }
-                        else { None },
-                        //else { Some(color) },
-                    _ => None
-                },
-                Interaction::Clicked(elem) => match elem {
-                    Elem::ValueGlyph(idx, _) =>
-                        if idx == i { Some(color.clicked()) }
-                        else { None },
-                        //else { Some(color) },
-                    _ => None,
-                },
+                Interaction::Highlighted(elem) => {
+                    match elem {
+                        Elem::ValueGlyph(idx, _) => {
+                            if idx == i {
+                                Some(color.highlighted())
+                            } else {
+                                None
+                            }
+                        }
+                        // else { Some(color) },
+                        _ => None,
+                    }
+                }
+                Interaction::Clicked(elem) => {
+                    match elem {
+                        Elem::ValueGlyph(idx, _) => {
+                            if idx == i {
+                                Some(color.clicked())
+                            } else {
+                                None
+                            }
+                        }
+                        // else { Some(color) },
+                        _ => None,
+                    }
+                }
                 _ => None,
             };
             if let Some(slot_color) = maybe_slot_color {
@@ -478,7 +489,6 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F> where
             rel_slot_x += slot_w;
         }
     }
-
 }
 
 
@@ -500,4 +510,3 @@ impl<'a, T, F> Labelable<'a> for NumberDialer<'a, T, F> {
         label_font_size { style.label_font_size = Some(FontSize) }
     }
 }
-

--- a/src/widget/primitive/line.rs
+++ b/src/widget/primitive/line.rs
@@ -1,16 +1,5 @@
 
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Point,
-    Positionable,
-    Rect,
-    Scalar,
-    Sizeable,
-    Theme,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, Point, Positionable, Rect, Scalar, Sizeable, Theme, Widget};
 use vecmath::{vec2_add, vec2_sub};
 use widget;
 
@@ -73,7 +62,6 @@ pub enum Cap {
 
 
 impl Line {
-
     /// Build a new **Line** widget with the given style.
     pub fn styled(start: Point, end: Point, style: Style) -> Self {
         Line {
@@ -152,12 +140,10 @@ impl Line {
         self.style.set_pattern(Pattern::Dotted);
         self
     }
-
 }
 
 
 impl Style {
-
     /// Constructor for a default Line Style.
     pub fn new() -> Self {
         Style {
@@ -230,34 +216,45 @@ impl Style {
     /// The Pattern for the Line.
     pub fn get_pattern(&self, theme: &Theme) -> Pattern {
         const DEFAULT_PATTERN: Pattern = Pattern::Solid;
-        self.maybe_pattern.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-            default.style.maybe_pattern.unwrap_or(DEFAULT_PATTERN)
-        })).unwrap_or(DEFAULT_PATTERN)
+        self.maybe_pattern
+            .or_else(|| {
+                theme.widget_style::<Style>(KIND)
+                     .map(|default| default.style.maybe_pattern.unwrap_or(DEFAULT_PATTERN))
+            })
+            .unwrap_or(DEFAULT_PATTERN)
     }
 
     /// The Color for the Line.
     pub fn get_color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-            default.style.maybe_color.unwrap_or(theme.shape_color)
-        })).unwrap_or(theme.shape_color)
+        self.maybe_color
+            .or_else(|| {
+                theme.widget_style::<Style>(KIND)
+                     .map(|default| default.style.maybe_color.unwrap_or(theme.shape_color))
+            })
+            .unwrap_or(theme.shape_color)
     }
 
     /// The width or thickness of the Line.
     pub fn get_thickness(&self, theme: &Theme) -> Scalar {
         const DEFAULT_THICKNESS: Scalar = 1.0;
-        self.maybe_thickness.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-            default.style.maybe_thickness.unwrap_or(DEFAULT_THICKNESS)
-        })).unwrap_or(DEFAULT_THICKNESS)
+        self.maybe_thickness
+            .or_else(|| {
+                theme.widget_style::<Style>(KIND)
+                     .map(|default| default.style.maybe_thickness.unwrap_or(DEFAULT_THICKNESS))
+            })
+            .unwrap_or(DEFAULT_THICKNESS)
     }
 
     /// The styling for the ends of the Line.
     pub fn get_cap(&self, theme: &Theme) -> Cap {
         const DEFAULT_CAP: Cap = Cap::Flat;
-        self.maybe_cap.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
-            default.style.maybe_cap.unwrap_or(DEFAULT_CAP)
-        })).unwrap_or(DEFAULT_CAP)
+        self.maybe_cap
+            .or_else(|| {
+                theme.widget_style::<Style>(KIND)
+                     .map(|default| default.style.maybe_cap.unwrap_or(DEFAULT_CAP))
+            })
+            .unwrap_or(DEFAULT_CAP)
     }
-
 }
 
 
@@ -310,7 +307,6 @@ impl Widget for Line {
             state.update(|state| state.end = end);
         }
     }
-
 }
 
 

--- a/src/widget/primitive/point_path.rs
+++ b/src/widget/primitive/point_path.rs
@@ -1,15 +1,4 @@
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Point,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Sizeable,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, Point, Positionable, Range, Rect, Scalar, Sizeable, Widget};
 use vecmath::{vec2_add, vec2_sub};
 use widget;
 
@@ -43,20 +32,27 @@ pub const KIND: widget::Kind = "PointPath";
 
 /// Find the bounding rect for the given series of points.
 fn bounding_box_for_points<I>(mut points: I) -> Rect
-    where I: Iterator<Item=Point>,
+    where I: Iterator<Item = Point>
 {
-    points.next().map(|first| {
-        let start_rect = Rect {
-            x: Range { start: first[0], end: first[0] },
-            y: Range { start: first[1], end: first[1] },
-        };
-        points.fold(start_rect, Rect::stretch_to_point)
-    }).unwrap_or_else(|| Rect::from_xy_dim([0.0, 0.0], [0.0, 0.0]))
+    points.next()
+          .map(|first| {
+              let start_rect = Rect {
+                  x: Range {
+                      start: first[0],
+                      end: first[0],
+                  },
+                  y: Range {
+                      start: first[1],
+                      end: first[1],
+                  },
+              };
+              points.fold(start_rect, Rect::stretch_to_point)
+          })
+          .unwrap_or_else(|| Rect::from_xy_dim([0.0, 0.0], [0.0, 0.0]))
 }
 
 
 impl<I> PointPath<I> {
-
     /// The same as [**PointPath::new**](./struct.PointPath#method.new) but with th given style.
     pub fn styled(points: I, style: Style) -> Self {
         PointPath {
@@ -83,7 +79,7 @@ impl<I> PointPath<I> {
     /// If you would rather centre the points to the middle of the bounding box, use
     /// [**PointPath::centred**](./struct.PointPath#method.centred) instead.
     pub fn abs(points: I) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         PointPath::abs_styled(points, Style::new())
     }
@@ -91,7 +87,7 @@ impl<I> PointPath<I> {
     /// The same as [**PointPath::abs**](./struct.PointPath#method.abs) but constructs the
     /// **PointPath** with the given style.
     pub fn abs_styled(points: I, style: Style) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
@@ -107,7 +103,7 @@ impl<I> PointPath<I> {
     /// If you would rather centre the bounding box to the points, use
     /// [**PointPath::abs**](./struct.PointPath#method.abs) instead.
     pub fn centred(points: I) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         PointPath::centred_styled(points, Style::new())
     }
@@ -115,7 +111,7 @@ impl<I> PointPath<I> {
     /// The same as [**PointPath::centred**](./struct.PointPath#method.centred) but constructs the
     /// **PointPath** with the given style.
     pub fn centred_styled(points: I, style: Style) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
@@ -150,12 +146,10 @@ impl<I> PointPath<I> {
         self.style.set_pattern(Pattern::Dotted);
         self
     }
-
 }
 
 
-impl<I> Widget for PointPath<I>
-    where I: IntoIterator<Item=Point>,
+impl<I> Widget for PointPath<I> where I: IntoIterator<Item = Point>
 {
     type State = State;
     type Style = Style;
@@ -173,9 +167,7 @@ impl<I> Widget for PointPath<I>
     }
 
     fn init_state(&self) -> State {
-        State {
-            points: Vec::new(),
-        }
+        State { points: Vec::new() }
     }
 
     fn style(&self) -> Self::Style {
@@ -191,17 +183,21 @@ impl<I> Widget for PointPath<I>
         // A function that compares the given points iterator to the points currently owned by
         // `State` and updates only if necessary.
         fn update_points<I>(state: &mut widget::State<State>, points: I)
-            where I: IntoIterator<Item=Point>,
+            where I: IntoIterator<Item = Point>
         {
             match iter_diff(&state.view().points, points) {
-                Some(IterDiff::FirstMismatch(i, mismatch)) => state.update(|state| {
-                    state.points.truncate(i);
-                    state.points.extend(mismatch);
-                }),
-                Some(IterDiff::Longer(remaining)) =>
-                    state.update(|state| state.points.extend(remaining)),
-                Some(IterDiff::Shorter(total)) =>
-                    state.update(|state| state.points.truncate(total)),
+                Some(IterDiff::FirstMismatch(i, mismatch)) => {
+                    state.update(|state| {
+                        state.points.truncate(i);
+                        state.points.extend(mismatch);
+                    })
+                }
+                Some(IterDiff::Longer(remaining)) => {
+                    state.update(|state| state.points.extend(remaining))
+                }
+                Some(IterDiff::Shorter(total)) => {
+                    state.update(|state| state.points.truncate(total))
+                }
                 None => (),
             }
         }
@@ -210,12 +206,12 @@ impl<I> Widget for PointPath<I>
             Some(original) => {
                 let xy = rect.xy();
                 let difference = vec2_sub(xy, original);
-                update_points(state, points.into_iter().map(|point| vec2_add(point, difference)))
-            },
+                update_points(state,
+                              points.into_iter().map(|point| vec2_add(point, difference)))
+            }
             None => update_points(state, points),
         }
     }
-
 }
 
 impl<I> Colorable for PointPath<I> {

--- a/src/widget/primitive/shape/circle.rs
+++ b/src/widget/primitive/shape/circle.rs
@@ -1,7 +1,7 @@
 
 use {Color, Dimensions, LineStyle, Scalar};
 use super::oval::Oval;
-use super::Style as Style;
+use super::Style;
 
 /// A tiny wrapper around the **Oval** widget type.
 #[derive(Copy, Clone, Debug)]
@@ -15,7 +15,6 @@ fn rad_to_dim(radius: Scalar) -> Dimensions {
 
 
 impl Circle {
-
     /// Build a circular **Oval** with the given dimensions and style.
     pub fn styled(radius: Scalar, style: Style) -> Oval {
         Oval::styled(rad_to_dim(radius), style)
@@ -40,6 +39,4 @@ impl Circle {
     pub fn outline_styled(radius: Scalar, line_style: LineStyle) -> Oval {
         Oval::outline_styled(rad_to_dim(radius), line_style)
     }
-
 }
-

--- a/src/widget/primitive/shape/framed_rectangle.rs
+++ b/src/widget/primitive/shape/framed_rectangle.rs
@@ -1,13 +1,4 @@
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimensions,
-    Frameable,
-    Scalar,
-    Sizeable,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, Dimensions, Frameable, Scalar, Sizeable, Widget};
 use widget;
 
 
@@ -37,17 +28,16 @@ widget_style!{
 }
 
 impl FramedRectangle {
-
     /// Build a new **FramedRectangle**.
     pub fn new(dim: Dimensions) -> Self {
         FramedRectangle {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
-        }.wh(dim)
+        }
+        .wh(dim)
     }
 
     builder_method!(pub with_style { style = Style });
-
 }
 
 
@@ -79,7 +69,6 @@ impl Widget for FramedRectangle {
     fn update<C: CharacterCache>(self, _args: widget::UpdateArgs<Self, C>) {
         // Nothing to update here!
     }
-
 }
 
 

--- a/src/widget/primitive/shape/mod.rs
+++ b/src/widget/primitive/shape/mod.rs
@@ -22,7 +22,6 @@ pub enum Style {
 
 
 impl Style {
-
     /// A default `Fill` style.
     pub fn fill() -> Self {
         Style::Fill(None)
@@ -64,5 +63,4 @@ impl Style {
             Style::Outline(style) => style.get_color(theme),
         }
     }
-
 }

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -1,13 +1,5 @@
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimensions,
-    LineStyle,
-    Sizeable,
-    Widget,
-};
-use super::Style as Style;
+use {CharacterCache, Color, Colorable, Dimensions, LineStyle, Sizeable, Widget};
+use super::Style;
 use widget;
 
 
@@ -41,13 +33,13 @@ pub const KIND: widget::Kind = "Oval";
 
 
 impl Oval {
-
     /// Build an **Oval** with the given dimensions and style.
     pub fn styled(dim: Dimensions, style: Style) -> Self {
         Oval {
             common: widget::CommonBuilder::new(),
             style: style,
-        }.wh(dim)
+        }
+        .wh(dim)
     }
 
     /// Build a new **Fill**ed **Oval**.
@@ -69,7 +61,6 @@ impl Oval {
     pub fn outline_styled(dim: Dimensions, line_style: LineStyle) -> Self {
         Oval::styled(dim, Style::outline_styled(line_style))
     }
-
 }
 
 
@@ -90,9 +81,7 @@ impl Widget for Oval {
     }
 
     fn init_state(&self) -> State {
-        State {
-            kind: Kind::Fill,
-        }
+        State { kind: Kind::Fill }
     }
 
     fn style(&self) -> Style {
@@ -112,7 +101,6 @@ impl Widget for Oval {
             state.update(|state| state.kind = kind);
         }
     }
-
 }
 
 

--- a/src/widget/primitive/shape/polygon.rs
+++ b/src/widget/primitive/shape/polygon.rs
@@ -1,14 +1,5 @@
 
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    LineStyle,
-    Point,
-    Positionable,
-    Sizeable,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, LineStyle, Point, Positionable, Sizeable, Widget};
 use super::Style;
 use widget;
 use utils::bounding_box_for_points;
@@ -56,7 +47,6 @@ pub const KIND: widget::Kind = "Polygon";
 
 
 impl<I> Polygon<I> {
-
     /// Build a polygon with the given points and style.
     pub fn styled(points: I, style: Style) -> Self {
         Polygon {
@@ -96,7 +86,7 @@ impl<I> Polygon<I> {
     /// If you would rather centre the points to the middle of the bounding box, use
     /// the [**Polygon::centred**](./struct.Polygon#method.centred) methods instead.
     pub fn abs_styled(points: I, style: Style) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
@@ -106,7 +96,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::abs_styled**](./struct.Polygon#method.abs_styled) but builds the
     /// **Polygon** with the default **Fill** style.
     pub fn abs_fill(points: I) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::abs_styled(points, Style::fill())
     }
@@ -114,7 +104,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::abs_styled**](./struct.Polygon#method.abs_styled) but builds the
     /// **Polygon** **Fill**ed with the given **Color**.
     pub fn abs_fill_with(points: I, color: Color) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::abs_styled(points, Style::fill_with(color))
     }
@@ -122,7 +112,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::abs_styled**](./struct.Polygon#method.abs_styled) but builds the
     /// **Polygon** with the default **Outline** style.
     pub fn abs_outline(points: I) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::abs_styled(points, Style::outline())
     }
@@ -130,7 +120,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::abs_styled**](./struct.Polygon#method.abs_styled) but builds the
     /// **Polygon** with the given **Outline** styling.
     pub fn abs_outline_styled(points: I, style: LineStyle) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::abs_styled(points, Style::outline_styled(style))
     }
@@ -144,7 +134,7 @@ impl<I> Polygon<I> {
     /// If you would rather centre the bounding box to the points, use the
     /// [**Polygon::abs**](./struct.Polygon#method.abs) constructor method instead.
     pub fn centred_styled(points: I, style: Style) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         let points_clone = points.clone().into_iter();
         let (xy, dim) = bounding_box_for_points(points_clone).xy_dim();
@@ -156,7 +146,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::centred_styled**](./struct.Polygon#method.centred_styled) but
     /// constructs the **Polygon** with the default **Fill** style.
     pub fn centred_fill(points: I) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::centred_styled(points, Style::fill())
     }
@@ -164,7 +154,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::centred_styled**](./struct.Polygon#method.centred_styled) but
     /// constructs the **Polygon** **Fill**ed with the given color.
     pub fn centred_fill_with(points: I, color: Color) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::centred_styled(points, Style::fill_with(color))
     }
@@ -172,7 +162,7 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::centred_styled**](./struct.Polygon#method.centred_styled) but
     /// constructs the **Polygon** with the default **Outline** style.
     pub fn centred_outline(points: I) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::centred_styled(points, Style::outline())
     }
@@ -180,16 +170,14 @@ impl<I> Polygon<I> {
     /// The same as [**Polygon::centred_styled**](./struct.Polygon#method.centred_styled) but
     /// constructs the **Polygon** **Outline**d with the given styling.
     pub fn centred_outline_styled(points: I, style: LineStyle) -> Self
-        where I: IntoIterator<Item=Point> + Clone,
+        where I: IntoIterator<Item = Point> + Clone
     {
         Polygon::centred_styled(points, Style::outline_styled(style))
     }
-
 }
 
 
-impl<I> Widget for Polygon<I>
-    where I: IntoIterator<Item=Point>,
+impl<I> Widget for Polygon<I> where I: IntoIterator<Item = Point>
 {
     type State = State;
     type Style = Style;
@@ -226,17 +214,21 @@ impl<I> Widget for Polygon<I>
         // A function that compares the given points iterator to the points currently owned by
         // `State` and updates only if necessary.
         fn update_points<I>(state: &mut widget::State<State>, points: I)
-            where I: IntoIterator<Item=Point>,
+            where I: IntoIterator<Item = Point>
         {
             match iter_diff(&state.view().points, points) {
-                Some(IterDiff::FirstMismatch(i, mismatch)) => state.update(|state| {
-                    state.points.truncate(i);
-                    state.points.extend(mismatch);
-                }),
-                Some(IterDiff::Longer(remaining)) =>
-                    state.update(|state| state.points.extend(remaining)),
-                Some(IterDiff::Shorter(total)) =>
-                    state.update(|state| state.points.truncate(total)),
+                Some(IterDiff::FirstMismatch(i, mismatch)) => {
+                    state.update(|state| {
+                        state.points.truncate(i);
+                        state.points.extend(mismatch);
+                    })
+                }
+                Some(IterDiff::Longer(remaining)) => {
+                    state.update(|state| state.points.extend(remaining))
+                }
+                Some(IterDiff::Shorter(total)) => {
+                    state.update(|state| state.points.truncate(total))
+                }
                 None => (),
             }
         }
@@ -246,8 +238,9 @@ impl<I> Widget for Polygon<I>
             Some(original) => {
                 let xy = rect.xy();
                 let difference = vec2_sub(xy, original);
-                update_points(state, points.into_iter().map(|point| vec2_add(point, difference)))
-            },
+                update_points(state,
+                              points.into_iter().map(|point| vec2_add(point, difference)))
+            }
             None => update_points(state, points),
         }
 
@@ -260,7 +253,6 @@ impl<I> Widget for Polygon<I>
             state.update(|state| state.kind = kind);
         }
     }
-
 }
 
 

--- a/src/widget/primitive/shape/rectangle.rs
+++ b/src/widget/primitive/shape/rectangle.rs
@@ -1,13 +1,5 @@
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimensions,
-    LineStyle,
-    Sizeable,
-    Widget,
-};
-use super::Style as Style;
+use {CharacterCache, Color, Colorable, Dimensions, LineStyle, Sizeable, Widget};
+use super::Style;
 use widget;
 
 
@@ -40,13 +32,13 @@ pub const KIND: widget::Kind = "Rectangle";
 
 
 impl Rectangle {
-
     /// Build a rectangle with the dimensions and style.
     pub fn styled(dim: Dimensions, style: Style) -> Self {
         Rectangle {
             common: widget::CommonBuilder::new(),
             style: style,
-        }.wh(dim)
+        }
+        .wh(dim)
     }
 
     /// Build a new filled rectangle.
@@ -68,7 +60,6 @@ impl Rectangle {
     pub fn outline_styled(dim: Dimensions, line_style: LineStyle) -> Self {
         Rectangle::styled(dim, Style::outline_styled(line_style))
     }
-
 }
 
 
@@ -89,9 +80,7 @@ impl Widget for Rectangle {
     }
 
     fn init_state(&self) -> State {
-        State {
-            kind: Kind::Fill,
-        }
+        State { kind: Kind::Fill }
     }
 
     fn style(&self) -> Style {
@@ -111,7 +100,6 @@ impl Widget for Rectangle {
             state.update(|state| state.kind = kind);
         }
     }
-
 }
 
 

--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -1,18 +1,6 @@
 use std::cmp;
-use {
-    Align,
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimension,
-    FontSize,
-    LineBreak,
-    Range,
-    Rect,
-    Scalar,
-    Ui,
-    Widget,
-};
+use {Align, CharacterCache, Color, Colorable, Dimension, FontSize, LineBreak, Range, Rect, Scalar,
+     Ui, Widget};
 use widget;
 
 
@@ -85,7 +73,6 @@ pub struct State {
 
 
 impl<'a> Text<'a> {
-
     /// Build a new **Text** widget.
     pub fn new(text: &'a str) -> Self {
         Text {
@@ -148,7 +135,6 @@ impl<'a> Text<'a> {
         self.style.line_spacing = Some(height);
         self
     }
-
 }
 
 
@@ -197,15 +183,25 @@ impl<'a> Widget for Text<'a> {
         let font_size = self.style.font_size(&ui.theme);
         let num_lines = match self.style.maybe_wrap(&ui.theme) {
             None => text.lines().count(),
-            Some(wrap) => match self.get_w(ui) {
-                None => text.lines().count(),
-                Some(max_w) => match wrap {
-                    Wrap::Character =>
-                        ui.glyph_cache.line_breaks_by_character(font_size, text, max_w).count(),
-                    Wrap::Whitespace =>
-                        ui.glyph_cache.line_breaks_by_whitespace(font_size, text, max_w).count(),
-                },
-            },
+            Some(wrap) => {
+                match self.get_w(ui) {
+                    None => text.lines().count(),
+                    Some(max_w) => {
+                        match wrap {
+                            Wrap::Character => {
+                                ui.glyph_cache
+                                  .line_breaks_by_character(font_size, text, max_w)
+                                  .count()
+                            }
+                            Wrap::Whitespace => {
+                                ui.glyph_cache
+                                  .line_breaks_by_whitespace(font_size, text, max_w)
+                                  .count()
+                            }
+                        }
+                    }
+                }
+            }
         };
         let line_spacing = self.style.line_spacing(&ui.theme);
         let height = total_height(cmp::max(num_lines, 1), font_size, line_spacing);
@@ -221,14 +217,16 @@ impl<'a> Widget for Text<'a> {
         let font_size = style.font_size(ui.theme());
 
         // Produces an iterator yielding the line breaks for the `text`.
-        let new_line_breaks = || match maybe_wrap {
-            None =>
-                // This branch could be faster if we just used `.lines()` somehow.
-                ui.glyph_cache().line_breaks_by_character(font_size, text, ::std::f64::MAX),
-            Some(Wrap::Character) =>
-                ui.glyph_cache().line_breaks_by_character(font_size, text, rect.w()),
-            Some(Wrap::Whitespace) =>
-                ui.glyph_cache().line_breaks_by_whitespace(font_size, text, rect.w()),
+        let new_line_breaks = || {
+            match maybe_wrap {
+                None => ui.glyph_cache().line_breaks_by_character(font_size, text, ::std::f64::MAX),
+                Some(Wrap::Character) => {
+                    ui.glyph_cache().line_breaks_by_character(font_size, text, rect.w())
+                }
+                Some(Wrap::Whitespace) => {
+                    ui.glyph_cache().line_breaks_by_whitespace(font_size, text, rect.w())
+                }
+            }
         };
 
         // If the string is different, we must update both the string and the line breaks.
@@ -238,7 +236,7 @@ impl<'a> Widget for Text<'a> {
                 state.line_breaks = new_line_breaks().collect();
             });
 
-        // Otherwise, we'll check to see if we have to update the line breaks.
+            // Otherwise, we'll check to see if we have to update the line breaks.
         } else {
             use utils::write_if_different;
             use std::borrow::Cow;
@@ -257,7 +255,6 @@ impl<'a> Widget for Text<'a> {
             }
         }
     }
-
 }
 
 
@@ -270,7 +267,6 @@ impl<'a> Colorable for Text<'a> {
 
 
 impl State {
-
     /// Iterator that yields a new line at both "newline"s (i.e. `\n`) and `line_wrap_indices`.
     pub fn lines(&self) -> Lines {
         ::glyph_cache::Lines::new(&self.string, self.line_breaks.iter().cloned())
@@ -288,8 +284,8 @@ impl State {
                           container: Rect,
                           h_align: Align,
                           font_size: FontSize,
-                          line_spacing: Scalar) -> LineRects<'a, Lines<'a>>
-    {
+                          line_spacing: Scalar)
+                          -> LineRects<'a, Lines<'a>> {
         let lines = self.lines();
         LineRects::new(lines, container, h_align, font_size, line_spacing)
     }
@@ -319,7 +315,6 @@ impl State {
     //         maybe_current_line: maybe_first_line,
     //     }
     // }
-
 }
 
 
@@ -332,7 +327,9 @@ pub fn total_height(num_lines: usize, font_size: FontSize, line_spacing: Scalar)
 
 /// Shorthand for the **Lines** iterator yielded by **State::lines**.
 pub type Lines<'a> =
-    ::glyph_cache::Lines<'a, ::std::iter::Cloned<::std::slice::Iter<'a, (usize, Option<LineBreak>)>>>;
+    ::glyph_cache::Lines<'a,
+                           ::std::iter::Cloned<::std::slice::Iter<'a,
+                                                                      (usize, Option<LineBreak>)>>>;
 
 
 /// An walker yielding a **Rect** (representing the absolute position and dimensions) for
@@ -349,14 +346,14 @@ pub struct LineRects<'a, I: 'a> {
 
 
 impl<'a, I> LineRects<'a, I> {
-
     /// Construct a new **LineRects**.
     pub fn new(lines: I,
                container: Rect,
                h_align: Align,
                font_size: FontSize,
-               line_spacing: Scalar) -> LineRects<'a, I>
-        where I: Iterator<Item=&'a str>,
+               line_spacing: Scalar)
+               -> LineRects<'a, I>
+        where I: Iterator<Item = &'a str>
     {
         let height = font_size as Scalar;
         LineRects {
@@ -389,19 +386,21 @@ impl<'a, I> LineRects<'a, I> {
     /// The same as [**LineRects::next**](./struct.LineRects@method.next) but also yields the
     /// line's `&'a str` alongside the **Rect**.
     pub fn next_with_line<C>(&mut self, cache: &mut C) -> Option<(Rect, &'a str)>
-        where I: Iterator<Item=&'a str>,
-              C: CharacterCache,
+        where I: Iterator<Item = &'a str>,
+              C: CharacterCache
     {
-        let LineRects { ref mut lines, font_size, y_step, h_align, container_x, ref mut y, .. } = *self;
+        let LineRects { ref mut lines, font_size, y_step, h_align, container_x, ref mut y, .. } =
+            *self;
         lines.next().map(|line| {
             let w = cache.width(font_size, line);
             let h = font_size as Scalar;
             let w_range = Range::new(0.0, w);
             let x = match h_align {
-                Align::Start => w_range.align_start_of(container_x),
-                Align::Middle => w_range.align_middle_of(container_x),
-                Align::End => w_range.align_end_of(container_x),
-            }.middle();
+                        Align::Start => w_range.align_start_of(container_x),
+                        Align::Middle => w_range.align_middle_of(container_x),
+                        Align::End => w_range.align_end_of(container_x),
+                    }
+                    .middle();
             let xy = [x, *y];
             let wh = [w, h];
             let rect = Rect::from_xy_dim(xy, wh);
@@ -409,24 +408,23 @@ impl<'a, I> LineRects<'a, I> {
             (rect, line)
         })
     }
-
 }
 
 
 // /// Shorthand for the `CharWidths` iterator used within the `CharRects` iterator.
 // pub type CharWidths<'a, C> = ::glyph_cache::CharWidths<'a, C, ::std::str::Chars<'a>>;
-// 
+//
 // /// Shorthand for the `CharXs` iterator used within the `CharRects` iterator.
 // pub type CharXs<'a, C> = ::glyph_cache::CharXs<'a, C, ::std::str::Chars<'a>>;
-// 
+//
 // /// Shorthand for the `Zip`ped `CharWidths` and `CharXs` iterators used within the `CharRects`
 // /// iterator.
 // pub type CharWidthsAndXs<'a, C> = ::std::iter::Zip<CharWidths<'a, C>, CharXs<'a, C>>;
-// 
+//
 // /// Shorthand for the `Zip`ped `Lines` and `LineRects` iterators used within the `CharRects`
 // /// iterator.
 // pub type LinesWithRects<'a, C> = ::std::iter::Zip<Lines<'a>, LineRects<'a, C>>;
-// 
+//
 // type Y = Scalar;
 // type CurrentLine<'a, C> = (CharWidthsAndXs<'a, C>, Y);
 
@@ -439,8 +437,8 @@ impl<'a, I> LineRects<'a, I> {
 //     lines_with_rects: LinesWithRects<'a, C>,
 //     maybe_current_line: Option<CurrentLine<'a, C>>,
 // }
-// 
-// 
+//
+//
 // impl<'a, C> Iterator for CharRects<'a, C>
 //     where C: CharacterCache,
 // {
@@ -452,7 +450,7 @@ impl<'a, I> LineRects<'a, I> {
 //             ref mut lines_with_rects,
 //             ref mut maybe_current_line,
 //         } = *self;
-// 
+//
 //         // Continue trying each line until we find one with characters.
 //         loop {
 //             match *maybe_current_line {
@@ -468,7 +466,7 @@ impl<'a, I> LineRects<'a, I> {
 //                 // If we have no more lines, we're done.
 //                 None => return None,
 //             }
-// 
+//
 //             // If our line had no more characters, make the next line the current line.
 //             *maybe_current_line = lines_with_rects.next().and_then(|(line, line_rect)| {
 //                 char_widths_and_xs_for_line(cache, font_size, line, line_rect)
@@ -477,8 +475,8 @@ impl<'a, I> LineRects<'a, I> {
 //         }
 //     }
 // }
-// 
-// 
+//
+//
 // /// Returns a `CharWidthsAndXs` iterator for the given `line`.
 // ///
 // /// Rturns `None` if there are no characters within the `line`.

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -1,23 +1,6 @@
 
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    FontSize,
-    Frameable,
-    Labelable,
-    IndexSlot,
-    KidArea,
-    Mouse,
-    Padding,
-    Positionable,
-    Range,
-    Rect,
-    Rectangle,
-    Scalar,
-    Text,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, FontSize, Frameable, Labelable, IndexSlot, KidArea, Mouse,
+     Padding, Positionable, Range, Rect, Rectangle, Scalar, Text, Widget};
 use num::{Float, NumCast, ToPrimitive};
 use widget;
 
@@ -108,16 +91,15 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
-        (true,  _,       Up)   => Highlighted,
+        (true, Normal, Down) => Normal,
+        (true, _, Down) => Clicked,
+        (true, _, Up) => Highlighted,
         (false, Clicked, Down) => Clicked,
         _ => Normal,
     }
 }
 
 impl<'a, T, F> Slider<'a, T, F> {
-
     /// Construct a new Slider widget.
     pub fn new(value: T, min: T, max: T) -> Self {
         Slider {
@@ -138,12 +120,11 @@ impl<'a, T, F> Slider<'a, T, F> {
         pub react { maybe_react = Some(F) }
         pub enabled { enabled = bool }
     }
-
 }
 
-impl<'a, T, F> Widget for Slider<'a, T, F> where
-    F: FnOnce(T),
-    T: ::std::any::Any + ::std::fmt::Debug + Float + NumCast + ToPrimitive,
+impl<'a, T, F> Widget for Slider<'a, T, F>
+    where F: FnOnce(T),
+          T: ::std::any::Any + ::std::fmt::Debug + Float + NumCast + ToPrimitive
 {
     type State = State<T>;
     type Style = Style;
@@ -203,13 +184,17 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
             (true, Some(mouse)) => {
                 let is_over = rect.is_over(mouse.xy);
                 get_new_interaction(is_over, interaction, mouse)
-            },
+            }
         };
 
         match (interaction, new_interaction) {
-            (Highlighted, Clicked) => { ui.capture_mouse(); },
+            (Highlighted, Clicked) => {
+                ui.capture_mouse();
+            }
             (Clicked, Highlighted) |
-            (Clicked, Normal)      => { ui.uncapture_mouse(); },
+            (Clicked, Normal) => {
+                ui.uncapture_mouse();
+            }
             _ => (),
         }
 
@@ -226,13 +211,13 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
                         let perc = clamp(slider_w, 0.0, inner_w) / inner_w;
                         let skewed_perc = (perc).powf(skew as f64);
                         skewed_perc
-                    },
+                    }
                     _ => {
                         let value_percentage = percentage(value, min, max);
                         let slider_w = clamp(value_percentage as f64 * inner_w, 0.0, inner_w);
                         let perc = slider_w / inner_w;
                         perc
-                    },
+                    }
                 };
                 value_from_perc(w_perc as f32, min, max)
             } else {
@@ -244,13 +229,13 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
                         let perc = clamp(slider_h, 0.0, inner_h) / inner_h;
                         let skewed_perc = (perc).powf(skew as f64);
                         skewed_perc
-                    },
+                    }
                     _ => {
                         let value_percentage = percentage(value, min, max);
                         let slider_h = clamp(value_percentage as f64 * inner_h, 0.0, inner_h);
                         let perc = slider_h / inner_h;
                         perc
-                    },
+                    }
                 };
                 value_from_perc(h_perc as f32, min, max)
             }
@@ -261,9 +246,9 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
         // If the value has just changed, or if the slider has been clicked/released, call the
         // reaction function.
         if let Some(react) = maybe_react {
-            let should_react = value != new_value
-                || (interaction == Highlighted && new_interaction == Clicked)
-                || (interaction == Clicked && new_interaction == Highlighted);
+            let should_react = value != new_value ||
+                               (interaction == Highlighted && new_interaction == Clicked) ||
+                               (interaction == Clicked && new_interaction == Highlighted);
             if should_react {
                 react(new_value)
             }
@@ -326,17 +311,19 @@ impl<'a, T, F> Widget for Slider<'a, T, F> where
         if let Some(label) = maybe_label {
             let label_color = style.label_color(ui.theme());
             let font_size = style.label_font_size(ui.theme());
-            //const TEXT_PADDING: f64 = 10.0;
+            // const TEXT_PADDING: f64 = 10.0;
             let label_idx = state.view().label_idx.get(&mut ui);
-            if is_horizontal { Text::new(label).mid_left_of(idx) }
-            else             { Text::new(label).mid_bottom_of(idx) }
-                .graphics_for(idx)
-                .color(label_color)
-                .font_size(font_size)
-                .set(label_idx, &mut ui);
+            if is_horizontal {
+                Text::new(label).mid_left_of(idx)
+            } else {
+                Text::new(label).mid_bottom_of(idx)
+            }
+            .graphics_for(idx)
+            .color(label_color)
+            .font_size(font_size)
+            .set(label_idx, &mut ui);
         }
     }
-
 }
 
 

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -1,19 +1,6 @@
 
-use {
-    Button,
-    Canvas,
-    CharacterCache,
-    Color,
-    Dimensions,
-    FontSize,
-    GlyphCache,
-    NodeIndex,
-    Point,
-    Rect,
-    Scalar,
-    Theme,
-    Widget,
-};
+use {Button, Canvas, CharacterCache, Color, Dimensions, FontSize, GlyphCache, NodeIndex, Point,
+     Rect, Scalar, Theme, Widget};
 use super::canvas;
 use widget;
 
@@ -82,7 +69,6 @@ pub enum Layout {
 
 
 impl<'a> Tabs<'a> {
-
     /// Construct some new Canvas Tabs.
     pub fn new(tabs: &'a [(widget::Id, &'a str)]) -> Tabs<'a> {
         Tabs {
@@ -95,9 +81,11 @@ impl<'a> Tabs<'a> {
 
     /// Set the initially selected tab with a Canvas via its widget::Id.
     pub fn starting_canvas(mut self, canvas_id: widget::Id) -> Self {
-        let maybe_idx = self.tabs.iter().enumerate()
-            .find(|&(_, &(id, _))| canvas_id == id)
-            .map(|(idx, &(_, _))| idx);
+        let maybe_idx = self.tabs
+                            .iter()
+                            .enumerate()
+                            .find(|&(_, &(id, _))| canvas_id == id)
+                            .map(|(idx, &(_, _))| idx);
         self.maybe_starting_tab_idx = maybe_idx;
         self
     }
@@ -130,7 +118,6 @@ impl<'a> Tabs<'a> {
         pub pad_bottom { style.canvas.pad_bottom = Some(Scalar) }
         pub pad_top { style.canvas.pad_top = Some(Scalar) }
     }
-
 }
 
 
@@ -173,7 +160,7 @@ impl<'a> Widget for Tabs<'a> {
                     rect: rect.pad_top(tab_bar_h),
                     pad: style.canvas.padding(theme),
                 }
-            },
+            }
             Layout::Vertical => {
                 let max_text_width = max_text_width(self.tabs.iter(), font_size, glyph_cache);
                 let tab_bar_w = vertical_tab_bar_w(style.maybe_bar_width, max_text_width as Scalar);
@@ -181,7 +168,7 @@ impl<'a> Widget for Tabs<'a> {
                     rect: rect.pad_left(tab_bar_w),
                     pad: style.canvas.padding(theme),
                 }
-            },
+            }
         }
     }
 
@@ -197,13 +184,19 @@ impl<'a> Widget for Tabs<'a> {
         let font_height = font_size as Scalar;
         let maybe_bar_width = style.maybe_bar_width;
         let dim = rect.dim();
-        let rel_tab_bar_rect =
-            rel_tab_bar_area(dim, layout, maybe_bar_width, font_height, max_text_width);
+        let rel_tab_bar_rect = rel_tab_bar_area(dim,
+                                                layout,
+                                                maybe_bar_width,
+                                                font_height,
+                                                max_text_width);
 
         // Update the `tabs` **Vec** stored within our **State**, only if there have been changes.
-        let tabs_have_changed = state.view().tabs.len() != tabs.len()
-            || state.view().tabs.iter().zip(tabs.iter())
-                .any(|(tab, &(id, _))| tab.id != id);
+        let tabs_have_changed = state.view().tabs.len() != tabs.len() ||
+                                state.view()
+                                     .tabs
+                                     .iter()
+                                     .zip(tabs.iter())
+                                     .any(|(tab, &(id, _))| tab.id != id);
         if tabs_have_changed {
             state.update(|state| {
                 let num_tabs = state.tabs.len();
@@ -216,9 +209,11 @@ impl<'a> Widget for Tabs<'a> {
 
                 // If we have less tabs than we need, extend our `tabs` Vec.
                 if num_tabs < num_new_tabs {
-                    let extension = tabs[num_tabs..].iter().map(|&(id, _)| Tab {
-                        id: id,
-                        button_idx: ui.new_unique_node_index(),
+                    let extension = tabs[num_tabs..].iter().map(|&(id, _)| {
+                        Tab {
+                            id: id,
+                            button_idx: ui.new_unique_node_index(),
+                        }
                     });
                     state.tabs.extend(extension);
                 }
@@ -232,9 +227,16 @@ impl<'a> Widget for Tabs<'a> {
             let frame = style.canvas.frame(ui.theme());
             let frame_color = style.canvas.frame_color(ui.theme());
             let label_color = style.label_color(ui.theme());
-            let mut maybe_selected_tab_idx = state.view().maybe_selected_tab_idx
-                .or(maybe_starting_tab_idx)
-                .or_else(|| if tabs.len() > 0 { Some(0) } else { None });
+            let mut maybe_selected_tab_idx = state.view()
+                                                  .maybe_selected_tab_idx
+                                                  .or(maybe_starting_tab_idx)
+                                                  .or_else(|| {
+                                                      if tabs.len() > 0 {
+                                                          Some(0)
+                                                      } else {
+                                                          None
+                                                      }
+                                                  });
             let mut tab_rects = TabRects::new(tabs, layout, rel_tab_bar_rect);
             let mut i = 0;
             while let Some((tab_rect, _, label)) = tab_rects.next_with_id_and_label() {
@@ -278,18 +280,21 @@ impl<'a> Widget for Tabs<'a> {
         }
 
     }
-
 }
 
 
 /// Calculate the max text width yielded by a string in the tabs slice.
 fn max_text_width<'a, I, C>(tabs: I, font_size: FontSize, glyph_cache: &GlyphCache<C>) -> Scalar
-    where I: Iterator<Item=&'a (widget::Id, &'a str)>,
-          C: CharacterCache,
+    where I: Iterator<Item = &'a (widget::Id, &'a str)>,
+          C: CharacterCache
 {
     tabs.fold(0.0, |max_w, &(_, string)| {
         let w = glyph_cache.width(font_size, &string);
-        if w > max_w { w } else { max_w }
+        if w > max_w {
+            w
+        } else {
+            max_w
+        }
     })
 }
 
@@ -299,8 +304,8 @@ fn rel_tab_bar_area(dim: Dimensions,
                     layout: Layout,
                     maybe_bar_width: Option<Scalar>,
                     font_size: f64,
-                    max_text_width: f64) -> Rect
-{
+                    max_text_width: f64)
+                    -> Rect {
     match layout {
         Layout::Horizontal => {
             let w = dim[0];
@@ -308,14 +313,14 @@ fn rel_tab_bar_area(dim: Dimensions,
             let x = 0.0;
             let y = dim[1] / 2.0 - h / 2.0;
             Rect::from_xy_dim([x, y], [w, h])
-        },
+        }
         Layout::Vertical => {
             let w = vertical_tab_bar_w(maybe_bar_width, max_text_width);
             let h = dim[1];
             let x = -dim[0] / 2.0 + w / 2.0;
             let y = 0.0;
             Rect::from_xy_dim([x, y], [w, h])
-        },
+        }
     }
 }
 
@@ -332,16 +337,13 @@ fn vertical_tab_bar_w(maybe_bar_width: Option<Scalar>, max_text_width: Scalar) -
 fn tab_dim(num_tabs: usize, tab_bar_dim: Dimensions, layout: Layout) -> Dimensions {
     let width_multi = 1.0 / num_tabs as Scalar;
     match layout {
-        Layout::Horizontal =>
-            [width_multi * tab_bar_dim[0], tab_bar_dim[1]],
-        Layout::Vertical =>
-            [tab_bar_dim[0], width_multi * tab_bar_dim[1]],
+        Layout::Horizontal => [width_multi * tab_bar_dim[0], tab_bar_dim[1]],
+        Layout::Vertical => [tab_bar_dim[0], width_multi * tab_bar_dim[1]],
     }
 }
 
 
 impl Style {
-
     /// Construct the default `Tabs` style.
     pub fn new() -> Style {
         Style {
@@ -356,25 +358,28 @@ impl Style {
     /// Get the layout of the tabs for the `Tabs` widget.
     pub fn layout(&self, theme: &Theme) -> Layout {
         const DEFAULT_LAYOUT: Layout = Layout::Horizontal;
-        self.maybe_layout.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_layout.unwrap_or(DEFAULT_LAYOUT)
-        })).unwrap_or(DEFAULT_LAYOUT)
+        self.maybe_layout
+            .or(theme.widget_style::<Self>(KIND)
+                     .map(|default| default.style.maybe_layout.unwrap_or(DEFAULT_LAYOUT)))
+            .unwrap_or(DEFAULT_LAYOUT)
     }
 
     /// Get the color for the tab labels.
     pub fn label_color(&self, theme: &Theme) -> Color {
-        self.maybe_label_color.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_color.unwrap_or(theme.label_color)
-        })).unwrap_or(theme.label_color)
+        self.maybe_label_color
+            .or(theme.widget_style::<Self>(KIND)
+                     .map(|default| default.style.maybe_label_color.unwrap_or(theme.label_color)))
+            .unwrap_or(theme.label_color)
     }
 
     /// Get the font size for the tab labels.
     pub fn font_size(&self, theme: &Theme) -> FontSize {
-        self.maybe_label_font_size.or(theme.widget_style::<Self>(KIND).map(|default| {
-            default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
-        })).unwrap_or(theme.font_size_medium)
+        self.maybe_label_font_size
+            .or(theme.widget_style::<Self>(KIND).map(|default| {
+                default.style.maybe_label_font_size.unwrap_or(theme.font_size_medium)
+            }))
+            .unwrap_or(theme.font_size_medium)
     }
-
 }
 
 
@@ -405,12 +410,8 @@ pub struct TabRects<'a> {
 }
 
 impl<'a> TabRects<'a> {
-
     /// Construct a new **TabRects** iterator.
-    pub fn new(tabs: &'a [(widget::Id, &'a str)],
-               layout: Layout,
-               rel_tab_bar_rect: Rect) -> Self
-    {
+    pub fn new(tabs: &'a [(widget::Id, &'a str)], layout: Layout, rel_tab_bar_rect: Rect) -> Self {
         let num_tabs = tabs.len();
         let tab_bar_dim = rel_tab_bar_rect.dim();
         let tab_dim = tab_dim(num_tabs, tab_bar_dim, layout);
@@ -439,5 +440,4 @@ impl<'a> TabRects<'a> {
             (rect, id, label)
         })
     }
-
 }

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -1,24 +1,6 @@
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimensions,
-    FontSize,
-    Frameable,
-    FramedRectangle,
-    GlyphCache,
-    IndexSlot,
-    Line,
-    Mouse,
-    Padding,
-    Point,
-    Positionable,
-    Range,
-    Rectangle,
-    Scalar,
-    Text,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, Dimensions, FontSize, Frameable, FramedRectangle,
+     GlyphCache, IndexSlot, Line, Mouse, Padding, Point, Positionable, Range, Rectangle, Scalar,
+     Text, Widget};
 use input::keyboard::Key::{Backspace, Left, Right, Return, A, E, LCtrl, RCtrl};
 use vecmath::vec2_sub;
 use widget::{self, KidArea};
@@ -72,7 +54,7 @@ pub struct State {
     text_idx: IndexSlot,
     cursor_idx: IndexSlot,
     highlight_idx: IndexSlot,
-    control_pressed: bool
+    control_pressed: bool,
 }
 
 /// Represents the state of the text_box widget.
@@ -124,9 +106,11 @@ impl Interaction {
     fn color(&self, color: Color) -> Color {
         match *self {
             Interaction::Captured(_) => color,
-            Interaction::Uncaptured(state) => match state {
-                Uncaptured::Highlighted => color.highlighted(),
-                Uncaptured::Normal => color,
+            Interaction::Uncaptured(state) => {
+                match state {
+                    Uncaptured::Highlighted => color.highlighted(),
+                    Uncaptured::Normal => color,
+                }
             }
         }
     }
@@ -134,18 +118,29 @@ impl Interaction {
 
 
 impl Cursor {
-
     /// Construct a Cursor from a String index.
     fn from_index(idx: Idx) -> Cursor {
-        Cursor { anchor: Anchor::Start, start: idx, end: idx }
+        Cursor {
+            anchor: Anchor::Start,
+            start: idx,
+            end: idx,
+        }
     }
 
     /// Construct a Cursor from an index range.
     fn from_range(start: Idx, end: Idx) -> Cursor {
         if start < end {
-            Cursor { anchor: Anchor::Start, start: start, end: end }
+            Cursor {
+                anchor: Anchor::Start,
+                start: start,
+                end: end,
+            }
         } else {
-            Cursor { anchor: Anchor::End, start: end, end: start }
+            Cursor {
+                anchor: Anchor::End,
+                start: end,
+                end: start,
+            }
         }
     }
 
@@ -156,10 +151,9 @@ impl Cursor {
             self.start = end_limit;
             self.end = end_limit;
             return true;
-        }
-        else if self.end > end_limit {
+        } else if self.end > end_limit {
             self.end = end_limit;
-            return true
+            return true;
         }
         false
     }
@@ -167,7 +161,7 @@ impl Cursor {
     /// Shift the curosr by the given number of indices.
     fn shift(&mut self, by: i32) {
         if by == 0 {
-             return;
+            return;
         }
         let mut new_idx = self.start as i32 + by;
         if new_idx < 0 {
@@ -189,15 +183,18 @@ fn cursor_position<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
                                       idx: usize,
                                       mut text_start_x: f64,
                                       font_size: FontSize,
-                                      text: &str) -> CursorX {
+                                      text: &str)
+                                      -> CursorX {
     assert!(idx <= text.chars().count());
 
     if idx == 0 {
-         return text_start_x;
+        return text_start_x;
     }
 
     for (i, ch) in text.chars().enumerate() {
-        if i >= idx { break; }
+        if i >= idx {
+            break;
+        }
         text_start_x += glyph_cache.char_width(font_size, ch);
     }
     text_start_x
@@ -211,11 +208,17 @@ fn over_elem<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
                                 text_start_x: f64,
                                 text_w: f64,
                                 font_size: FontSize,
-                                text: &str) -> Elem {
+                                text: &str)
+                                -> Elem {
     use position::is_over_rect;
     if is_over_rect([0.0, 0.0], dim, mouse_xy) {
         if is_over_rect([0.0, 0.0], pad_dim, mouse_xy) {
-            let (idx, _) = closest_idx(glyph_cache, mouse_xy, text_start_x, text_w, font_size, text);
+            let (idx, _) = closest_idx(glyph_cache,
+                                       mouse_xy,
+                                       text_start_x,
+                                       text_w,
+                                       font_size,
+                                       text);
             Elem::Char(idx)
         } else {
             Elem::Rect
@@ -231,8 +234,11 @@ fn closest_idx<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
                                   text_start_x: f64,
                                   text_w: f64,
                                   font_size: FontSize,
-                                  text: &str) -> (Idx, f64) {
-    if mouse_xy[0] <= text_start_x { return (0, text_start_x) }
+                                  text: &str)
+                                  -> (Idx, f64) {
+    if mouse_xy[0] <= text_start_x {
+        return (0, text_start_x);
+    }
     let mut left_x = text_start_x;
     let mut x = left_x;
     let mut prev_x = x;
@@ -240,7 +246,9 @@ fn closest_idx<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
         let char_w = glyph_cache.char_width(font_size, ch);
         x += char_w;
         let right_x = prev_x + char_w / 2.0;
-        if mouse_xy[0] > left_x && mouse_xy[0] <= right_x { return (i, prev_x) }
+        if mouse_xy[0] > left_x && mouse_xy[0] <= right_x {
+            return (i, prev_x);
+        }
         prev_x = x;
         left_x = right_x;
     }
@@ -248,71 +256,101 @@ fn closest_idx<C: CharacterCache>(glyph_cache: &GlyphCache<C>,
 }
 
 /// Check and return the current state of the TextBox.
-fn get_new_interaction(over_elem: Elem, prev_interaction: Interaction, mouse: Mouse) -> Interaction {
+fn get_new_interaction(over_elem: Elem,
+                       prev_interaction: Interaction,
+                       mouse: Mouse)
+                       -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Captured, Uncaptured};
     use self::Uncaptured::{Normal, Highlighted};
 
     match prev_interaction {
-        Interaction::Captured(mut prev) => match mouse.left.position {
-            Down => match over_elem {
-                Elem::Nill => if prev.cursor.anchor == Anchor::None {
-                    Uncaptured(Normal)
-                } else {
-                    prev_interaction
-                },
-                Elem::Rect =>  if prev.cursor.anchor == Anchor::None {
-                    prev.cursor = Cursor::from_index(0);
-                    Captured(prev)
-                } else {
-                    prev_interaction
-                },
-                Elem::Char(idx) => {
-                    match prev.cursor.anchor {
-                        Anchor::None  => prev.cursor = Cursor::from_index(idx),
-                        Anchor::Start => prev.cursor = Cursor::from_range(prev.cursor.start, idx),
-                        Anchor::End   => prev.cursor = Cursor::from_range(prev.cursor.end, idx),
+        Interaction::Captured(mut prev) => {
+            match mouse.left.position {
+                Down => {
+                    match over_elem {
+                        Elem::Nill => {
+                            if prev.cursor.anchor == Anchor::None {
+                                Uncaptured(Normal)
+                            } else {
+                                prev_interaction
+                            }
+                        }
+                        Elem::Rect => {
+                            if prev.cursor.anchor == Anchor::None {
+                                prev.cursor = Cursor::from_index(0);
+                                Captured(prev)
+                            } else {
+                                prev_interaction
+                            }
+                        }
+                        Elem::Char(idx) => {
+                            match prev.cursor.anchor {
+                                Anchor::None => prev.cursor = Cursor::from_index(idx),
+                                Anchor::Start => {
+                                    prev.cursor = Cursor::from_range(prev.cursor.start, idx)
+                                }
+                                Anchor::End => {
+                                    prev.cursor = Cursor::from_range(prev.cursor.end, idx)
+                                }
+                            }
+                            Captured(prev)
+                        }
                     }
+                }
+                Up => {
+                    prev.cursor.anchor = Anchor::None;
                     Captured(prev)
-                },
-            },
-            Up => {
-                prev.cursor.anchor = Anchor::None;
-                Captured(prev)
-            },
-        },
+                }
+            }
+        }
 
-        Interaction::Uncaptured(prev) => match mouse.left.position {
-            Down => match over_elem {
-                Elem::Nill => Uncaptured(Normal),
-                Elem::Rect => match prev {
-                    Normal => prev_interaction,
-                    Highlighted => Captured(View {
-                         cursor: Cursor::from_index(0),
-                         offset: 0.0,
-                    })
-                },
-                Elem::Char(idx) =>  match prev {
-                    Normal => prev_interaction,
-                    Highlighted => Captured(View {
-                        cursor: Cursor::from_index(idx),
-                        offset: 0.0,
-                    })
-                },
-            },
-            Up => match over_elem {
-                Elem::Nill => Uncaptured(Normal),
-                Elem::Char(_) | Elem::Rect => match prev {
-                    Normal => Uncaptured(Highlighted),
-                    Highlighted => prev_interaction,
-                },
-            },
-        },
+        Interaction::Uncaptured(prev) => {
+            match mouse.left.position {
+                Down => {
+                    match over_elem {
+                        Elem::Nill => Uncaptured(Normal),
+                        Elem::Rect => {
+                            match prev {
+                                Normal => prev_interaction,
+                                Highlighted => {
+                                    Captured(View {
+                                        cursor: Cursor::from_index(0),
+                                        offset: 0.0,
+                                    })
+                                }
+                            }
+                        }
+                        Elem::Char(idx) => {
+                            match prev {
+                                Normal => prev_interaction,
+                                Highlighted => {
+                                    Captured(View {
+                                        cursor: Cursor::from_index(idx),
+                                        offset: 0.0,
+                                    })
+                                }
+                            }
+                        }
+                    }
+                }
+                Up => {
+                    match over_elem {
+                        Elem::Nill => Uncaptured(Normal),
+                        Elem::Char(_) | Elem::Rect => {
+                            match prev {
+                                Normal => Uncaptured(Highlighted),
+                                Highlighted => prev_interaction,
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
 impl<'a, F> TextBox<'a, F> {
-
     /// Construct a TextBox widget.
     pub fn new(text: &'a mut String) -> TextBox<'a, F> {
         TextBox {
@@ -329,10 +367,10 @@ impl<'a, F> TextBox<'a, F> {
         pub react { maybe_react = Some(F) }
         pub enabled { enabled = bool }
     }
-
 }
 
-impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
+impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String)
+{
     type State = State;
     type Style = Style;
 
@@ -390,10 +428,16 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
         let mut new_interaction = match (self.enabled, maybe_mouse) {
             (false, _) | (true, None) => Interaction::Uncaptured(Uncaptured::Normal),
             (true, Some(mouse)) => {
-                let over_elem = over_elem(ui.glyph_cache(), mouse.xy, dim, pad_dim, text_start_x,
-                                          text_w, font_size, &self.text);
+                let over_elem = over_elem(ui.glyph_cache(),
+                                          mouse.xy,
+                                          dim,
+                                          pad_dim,
+                                          text_start_x,
+                                          text_w,
+                                          font_size,
+                                          &self.text);
                 get_new_interaction(over_elem, state.view().interaction, mouse)
-            },
+            }
         };
 
         // Check cursor validity (and update new_interaction if necessary).
@@ -409,7 +453,10 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
                 Anchor::End => cursor.start,
                 Anchor::Start | Anchor::None => cursor.end,
             };
-            let cursor_x = cursor_position(ui.glyph_cache(), cursor_idx, text_start_x, font_size,
+            let cursor_x = cursor_position(ui.glyph_cache(),
+                                           cursor_idx,
+                                           text_start_x,
+                                           font_size,
                                            &self.text);
 
             if cursor.is_cursor() || cursor.anchor != Anchor::None {
@@ -424,7 +471,10 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
             }
 
             // Set the updated state.
-            new_interaction = Interaction::Captured(View { cursor: cursor, offset: v_offset });
+            new_interaction = Interaction::Captured(View {
+                cursor: cursor,
+                offset: v_offset,
+            });
         }
 
         // If TextBox is captured, check for recent input and update the text accordingly.
@@ -434,11 +484,17 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
 
             // Check for entered text.
             for text in input.entered_text {
-                if new_control_pressed { break; }
-                if text.chars().count() == 0 { continue; }
+                if new_control_pressed {
+                    break;
+                }
+                if text.chars().count() == 0 {
+                    continue;
+                }
 
                 let max_w = pad_dim[0] - TEXT_PADDING * 2.0;
-                if text_w + ui.glyph_cache().width(font_size, &text) > max_w { continue; }
+                if text_w + ui.glyph_cache().width(font_size, &text) > max_w {
+                    continue;
+                }
 
                 let end: String = self.text.chars().skip(cursor.end).collect();
                 let start: String = self.text.chars().take(cursor.start).collect();
@@ -452,50 +508,61 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
             // Check for control keys.
             for key in input.pressed_keys.iter() {
                 match *key {
-                    Backspace => if cursor.is_cursor() {
-                        if cursor.start > 0 {
-                            let start: String = self.text.chars().take(cursor.start-1).collect();
+                    Backspace => {
+                        if cursor.is_cursor() {
+                            if cursor.start > 0 {
+                                let start: String = self.text
+                                                        .chars()
+                                                        .take(cursor.start - 1)
+                                                        .collect();
+                                let end: String = self.text.chars().skip(cursor.end).collect();
+                                self.text.clear();
+                                self.text.push_str(&start);
+                                self.text.push_str(&end);
+                                cursor.shift(-1);
+                            }
+                        } else {
+                            let start: String = self.text.chars().take(cursor.start).collect();
                             let end: String = self.text.chars().skip(cursor.end).collect();
                             self.text.clear();
                             self.text.push_str(&start);
                             self.text.push_str(&end);
+                            cursor.end = cursor.start;
+                        }
+                    }
+                    Left => {
+                        if cursor.is_cursor() {
                             cursor.shift(-1);
                         }
-                    } else {
-                        let start: String = self.text.chars().take(cursor.start).collect();
-                        let end: String = self.text.chars().skip(cursor.end).collect();
-                        self.text.clear();
-                        self.text.push_str(&start);
-                        self.text.push_str(&end);
-                        cursor.end = cursor.start;
-                    },
-                    Left => if cursor.is_cursor() {
-                        cursor.shift(-1);
-                    },
-                    Right => if cursor.is_cursor() && self.text.chars().count() > cursor.end {
-                        cursor.shift(1);
-                    },
-                    Return => if self.text.chars().count() > 0 {
-                        let TextBox { ref mut maybe_react, ref mut text, .. } = self;
-                        if let Some(ref mut react) = *maybe_react {
-                            react(*text);
+                    }
+                    Right => {
+                        if cursor.is_cursor() && self.text.chars().count() > cursor.end {
+                            cursor.shift(1);
                         }
-                    },
+                    }
+                    Return => {
+                        if self.text.chars().count() > 0 {
+                            let TextBox { ref mut maybe_react, ref mut text, .. } = self;
+                            if let Some(ref mut react) = *maybe_react {
+                                react(*text);
+                            }
+                        }
+                    }
                     LCtrl | RCtrl if !new_control_pressed => {
                         new_control_pressed = true;
-                    },
+                    }
                     A if new_control_pressed => {
                         if cursor.is_cursor() {
                             cursor.start = 0;
                             cursor.end = self.text.chars().count();
                         }
-                    },
+                    }
                     E if new_control_pressed => {
                         if cursor.is_cursor() {
                             cursor.start = self.text.chars().count();
                             cursor.end = self.text.chars().count();
                         }
-                    },
+                    }
                     _ => (),
                 }
             }
@@ -504,7 +571,7 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
                 match *key {
                     LCtrl | RCtrl if new_control_pressed => {
                         new_control_pressed = false;
-                    },
+                    }
                     _ => (),
                 }
             }
@@ -513,13 +580,17 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
             // the cursor is limited to the current number of chars.
             cursor.limit_end_to(self.text.chars().count());
 
-            new_interaction = Interaction::Captured(View { cursor: cursor, .. captured });
+            new_interaction = Interaction::Captured(View { cursor: cursor, ..captured });
         }
 
         // Check the interactions to determine whether we need to capture or uncapture the keyboard.
         match (state.view().interaction, new_interaction) {
-            (Interaction::Uncaptured(_), Interaction::Captured(_)) => { ui.capture_keyboard(); },
-            (Interaction::Captured(_), Interaction::Uncaptured(_)) => { ui.uncapture_keyboard(); },
+            (Interaction::Uncaptured(_), Interaction::Captured(_)) => {
+                ui.capture_keyboard();
+            }
+            (Interaction::Captured(_), Interaction::Uncaptured(_)) => {
+                ui.uncapture_keyboard();
+            }
             _ => (),
         }
 
@@ -562,7 +633,10 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
                 Anchor::End => cursor.start,
                 Anchor::Start | Anchor::None => cursor.end,
             };
-            let cursor_x = cursor_position(ui.glyph_cache(), cursor_idx, text_start_x, font_size,
+            let cursor_x = cursor_position(ui.glyph_cache(),
+                                           cursor_idx,
+                                           text_start_x,
+                                           font_size,
                                            &self.text);
 
             if cursor.is_cursor() {
@@ -578,7 +652,10 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
             } else {
                 let (rel_x, w) = {
                     let (start, end) = (cursor.start, cursor.end);
-                    let cursor_x = cursor_position(ui.glyph_cache(), start, text_start_x, font_size,
+                    let cursor_x = cursor_position(ui.glyph_cache(),
+                                                   start,
+                                                   text_start_x,
+                                                   font_size,
                                                    &self.text);
                     let highlighted_text = &self.text[start..end];
                     let w = ui.glyph_cache().width(font_size, &highlighted_text);
@@ -595,7 +672,6 @@ impl<'a, F> Widget for TextBox<'a, F> where F: FnMut(&mut String) {
             }
         }
     }
-
 }
 
 

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -1,22 +1,5 @@
-use {
-    Align,
-    CharacterCache,
-    Color,
-    Colorable,
-    Dimension,
-    FontSize,
-    Frameable,
-    FramedRectangle,
-    IndexSlot,
-    Labelable,
-    Mouse,
-    Positionable,
-    Scalar,
-    Sizeable,
-    Text,
-    TextWrap,
-    Ui,
-};
+use {Align, CharacterCache, Color, Colorable, Dimension, FontSize, Frameable, FramedRectangle,
+     IndexSlot, Labelable, Mouse, Positionable, Scalar, Sizeable, Text, TextWrap, Ui};
 use widget::{self, Widget};
 
 
@@ -86,29 +69,29 @@ fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Intera
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
-        (true,  _,       Up)   => Highlighted,
+        (true, Normal, Down) => Normal,
+        (true, _, Down) => Clicked,
+        (true, _, Up) => Highlighted,
         (false, Clicked, Down) => Clicked,
-        _                      => Normal,
+        _ => Normal,
     }
 }
 
 
-impl<'a, F> TitleBar<'a, F>
-    where F: FnOnce(Interaction),
+impl<'a, F> TitleBar<'a, F> where F: FnOnce(Interaction)
 {
-
     /// Construct a new TitleBar widget and attach it to the widget at the given index.
     pub fn new<I>(label: &'a str, idx: I) -> Self
-        where I: Into<widget::Index> + Copy,
+        where I: Into<widget::Index> + Copy
     {
         TitleBar {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
             label: label,
             maybe_react: None,
-        }.w_of(idx).mid_top_of(idx)
+        }
+        .w_of(idx)
+        .mid_top_of(idx)
     }
 
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
@@ -133,7 +116,6 @@ impl<'a, F> TitleBar<'a, F>
         pub line_spacing { style.line_spacing = Some(Scalar) }
         pub react { maybe_react = Some(F) }
     }
-
 }
 
 
@@ -143,8 +125,7 @@ pub fn calc_height(font_size: FontSize) -> Scalar {
 }
 
 
-impl<'a, F> Widget for TitleBar<'a, F>
-    where F: FnOnce(Interaction),
+impl<'a, F> Widget for TitleBar<'a, F> where F: FnOnce(Interaction)
 {
     type State = State;
     type Style = Style;
@@ -189,7 +170,7 @@ impl<'a, F> Widget for TitleBar<'a, F>
             Some(mouse) => {
                 let is_over = rect.is_over(mouse.xy);
                 get_new_interaction(is_over, state.view().interaction, mouse)
-            },
+            }
         };
 
         // FramedRectangle widget.
@@ -216,8 +197,7 @@ impl<'a, F> Widget for TitleBar<'a, F>
         let mut text = Text::new(label);
         text.style.maybe_wrap = Some(maybe_wrap);
         text.style.text_align = Some(text_align);
-        text
-            .padded_w_of(rectangle_idx, frame)
+        text.padded_w_of(rectangle_idx, frame)
             .middle_of(rectangle_idx)
             .color(text_color)
             .font_size(font_size)
@@ -234,7 +214,6 @@ impl<'a, F> Widget for TitleBar<'a, F>
             state.update(|state| state.interaction = new_interaction);
         }
     }
-
 }
 
 
@@ -256,4 +235,3 @@ impl<'a, F> Labelable<'a> for TitleBar<'a, F> {
         label_font_size { style.font_size = Some(FontSize) }
     }
 }
-

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -1,19 +1,6 @@
 
-use {
-    CharacterCache,
-    Color,
-    Colorable,
-    FontSize,
-    Frameable,
-    FramedRectangle,
-    IndexSlot,
-    Labelable,
-    Mouse,
-    Positionable,
-    Scalar,
-    Text,
-    Widget,
-};
+use {CharacterCache, Color, Colorable, FontSize, Frameable, FramedRectangle, IndexSlot, Labelable,
+     Mouse, Positionable, Scalar, Text, Widget};
 use widget;
 
 
@@ -86,23 +73,20 @@ impl Interaction {
 
 
 /// Check the current state of the button.
-fn get_new_interaction(is_over: bool,
-                       prev: Interaction,
-                       mouse: Mouse) -> Interaction {
+fn get_new_interaction(is_over: bool, prev: Interaction, mouse: Mouse) -> Interaction {
     use mouse::ButtonPosition::{Down, Up};
     use self::Interaction::{Normal, Highlighted, Clicked};
     match (is_over, prev, mouse.left.position) {
-        (true,  Normal,  Down) => Normal,
-        (true,  _,       Down) => Clicked,
-        (true,  _,       Up)   => Highlighted,
+        (true, Normal, Down) => Normal,
+        (true, _, Down) => Clicked,
+        (true, _, Up) => Highlighted,
         (false, Clicked, Down) => Clicked,
-        _                      => Normal,
+        _ => Normal,
     }
 }
 
 
 impl<'a, F> Toggle<'a, F> {
-
     /// Construct a new Toggle widget.
     pub fn new(value: bool) -> Toggle<'a, F> {
         Toggle {
@@ -119,11 +103,9 @@ impl<'a, F> Toggle<'a, F> {
         pub react { maybe_react = Some(F) }
         pub enabled { enabled = bool }
     }
-
 }
 
-impl<'a, F> Widget for Toggle<'a, F>
-    where F: FnOnce(bool),
+impl<'a, F> Widget for Toggle<'a, F> where F: FnOnce(bool)
 {
     type State = State;
     type Style = Style;
@@ -165,14 +147,18 @@ impl<'a, F> Widget for Toggle<'a, F>
             (true, Some(mouse)) => {
                 let is_over = rect.is_over(mouse.xy);
                 get_new_interaction(is_over, state.view().interaction, mouse)
-            },
+            }
         };
 
         // Capture the mouse if clicked, uncapture if released.
         match (state.view().interaction, new_interaction) {
-            (Interaction::Highlighted, Interaction::Clicked) => { ui.capture_mouse(); },
+            (Interaction::Highlighted, Interaction::Clicked) => {
+                ui.capture_mouse();
+            }
             (Interaction::Clicked, Interaction::Highlighted) |
-            (Interaction::Clicked, Interaction::Normal)      => { ui.uncapture_mouse(); },
+            (Interaction::Clicked, Interaction::Normal) => {
+                ui.uncapture_mouse();
+            }
             _ => (),
         }
 
@@ -184,7 +170,7 @@ impl<'a, F> Widget for Toggle<'a, F>
                     react(new_value)
                 }
                 new_value
-            },
+            }
             _ => value,
         };
 
@@ -194,7 +180,11 @@ impl<'a, F> Widget for Toggle<'a, F>
         let frame = style.frame(ui.theme());
         let color = {
             let color = style.color(ui.theme());
-            let color = if new_value { color } else { color.with_luminance(0.1) };
+            let color = if new_value {
+                color
+            } else {
+                color.with_luminance(0.1)
+            };
             new_interaction.color(color)
         };
         let frame_color = style.frame_color(ui.theme());


### PR DESCRIPTION
Requested in #600, I ran rustfmt on the src directory and then double checked the result, removing extra whitespace left by rustfmt.

A few lines exceeded the maximum line length of rustfmt - I fixed some of them, but not all of them because I am not sure if having lines of that length is a style guideline or just a limitation of rustfmt. The lines that caused that error are here:

line 399 in color.rs.
lines 523, 535, 547, 558, 677, 751, 752, 753, 755, 763 in graph/mod.rs.
lines 185 and 1049 in widget/mod.rs.
lines 141 and 161 in widget/style.rs.