### PR TITLE
Update to latest changes in graphics and piston_window crates. Removes some unused dev-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,5 @@ vecmath = "0.2.0"
 
 [dev-dependencies]
 find_folder = "0.3.0"
-gfx = "0.8.1"
-piston-viewport = "0.2.0"
 piston_window = "0.33.0"
-piston2d-gfx_graphics = "0.17.0"
-piston2d-opengl_graphics = "0.22.0"
-pistoncore-glutin_window = "0.20.0"
 piston = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ path = "./src/lib.rs"
 [dependencies]
 daggy = "0.4.0"
 pistoncore-input = "0.8.0"
-piston2d-graphics = "0.13.0"
-num = "0.1.27"
-rand = "0.3.12"
+piston2d-graphics = "0.14.0"
+num = "0.1.30"
+rand = "0.3.13"
 time = "0.1.34"
 vecmath = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "./src/lib.rs"
 [dependencies]
 daggy = "0.4.0"
 pistoncore-input = "0.8.0"
-piston2d-graphics = "0.14.0"
+piston2d-graphics = "0.15.0"
 num = "0.1.30"
 rand = "0.3.13"
 time = "0.1.34"
@@ -32,5 +32,5 @@ vecmath = "0.2.0"
 
 [dev-dependencies]
 find_folder = "0.3.0"
-piston_window = "0.35.0"
+piston_window = "0.37.0"
 piston = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.32.0"
+version = "0.31.3"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ vecmath = "0.2.0"
 
 [dev-dependencies]
 find_folder = "0.3.0"
-piston_window = "0.33.0"
-piston = "0.16.0"
+piston_window = "0.35.0"
+piston = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conrod"
-version = "0.31.3"
+version = "0.32.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -91,7 +91,7 @@ impl DemoApp {
             bg_color: rgb(0.2, 0.35, 0.45),
             show_button: false,
             toggle_label: "OFF".to_string(),
-            title_pad: 350.0,
+            title_pad: 320.0,
             v_slider_height: 230.0,
             frame_width: 1.0,
             bool_matrix: [ [true, true, true, true, true, true, true, true],
@@ -222,7 +222,7 @@ fn set_widgets(ui: &mut Ui, app: &mut DemoApp) {
         };
 
         // Slider widget example slider(value, min, max).
-        Slider::new(pad as f32, 30.0, 700.0)
+        Slider::new(pad as f32, 0.0, 670.0)
             .w_h(200.0, 50.0)
             .mid_left_of(CANVAS)
             .down_from(TITLE, 45.0)

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -31,7 +31,7 @@ fn main() {
     for event in window.ups(60) {
         ui.handle_event(&event);
         event.update(|_| ui.set_widgets(set_ui));
-        event.draw_2d(|c, g| ui.draw(c, g));
+        event.draw_2d(|c, g| ui.draw_if_changed(c, g));
     }
 
 }

--- a/src/backend/graphics.rs
+++ b/src/backend/graphics.rs
@@ -146,26 +146,27 @@ fn crop_context(context: Context, rect: Rect) -> Context {
     let h = h * h_scale;
 
     // If we ended up with negative coords for the crop area, we'll use 0 instead as we
-    // can't represent the negative coords with `u16` (the target DrawState dimension type).
+    // can't represent the negative coords with `u32` (the target DrawState dimension type).
     // We'll hold onto the lost negative values (x_neg and y_neg) so that we can compensate
     // with the width and height.
     let x_neg = if x < 0 { x } else { 0 };
     let y_neg = if y < 0 { y } else { 0 };
-    let mut x = ::std::cmp::max(0, x) as u16;
-    let mut y = ::std::cmp::max(0, y) as u16;
-    let mut w = ::std::cmp::max(0, (w as i32 + x_neg)) as u16;
-    let mut h = ::std::cmp::max(0, (h as i32 + y_neg)) as u16;
+    let mut x = ::std::cmp::max(0, x) as u32;
+    let mut y = ::std::cmp::max(0, y) as u32;
+    let mut w = ::std::cmp::max(0, (w as i32 + x_neg)) as u32;
+    let mut h = ::std::cmp::max(0, (h as i32 + y_neg)) as u32;
 
     // If there was already some scissor set, we must check for the intersection.
     if let Some(rect) = draw_state.scissor {
-        if x + w < rect.x || rect.x + rect.w < x || y + h < rect.y || rect.y + rect.h < y {
+        let (r_x, r_y, r_w, r_h) = (rect[0], rect[1], rect[2], rect[3]);
+        if x + w < r_x || r_x + r_w < x || y + h < r_y || r_y + r_h < y {
             // If there is no intersection, we have no scissor.
             w = 0;
             h = 0;
         } else {
             // If there is some intersection, calculate the overlapping rect.
             let (a_l, a_r, a_b, a_t) = (x, x+w, y, y+h);
-            let (b_l, b_r, b_b, b_t) = (rect.x, rect.x+rect.w, rect.y, rect.y+rect.h);
+            let (b_l, b_r, b_b, b_t) = (r_x, r_x+r_w, r_y, r_y+r_h);
             let l = if a_l > b_l { a_l } else { b_l };
             let r = if a_r < b_r { a_r } else { b_r };
             let b = if a_b > b_b { a_b } else { b_b };
@@ -177,7 +178,7 @@ fn crop_context(context: Context, rect: Rect) -> Context {
         }
     }
 
-    Context { draw_state: draw_state.scissor(x, y, w, h), ..context }
+    Context { draw_state: draw_state.scissor([x, y, w, h]), ..context }
 }
 
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -469,7 +469,7 @@ impl Graph {
     }
 
     /// Return the index of the parent along the given widget's **Depth** **Edge**.
-    pub fn depth_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn depth_parent<I, J>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
               J: GraphIndex,
     {
@@ -477,7 +477,7 @@ impl Graph {
     }
 
     /// Return the index of the parent along the given widget's **Position** **Edge**.
-    pub fn x_position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn x_position_parent<I, J>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
               J: GraphIndex,
     {
@@ -485,7 +485,7 @@ impl Graph {
     }
 
     /// Return the index of the parent along the given widget's **Position** **Edge**.
-    pub fn y_position_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn y_position_parent<I, J>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
               J: GraphIndex,
     {
@@ -494,7 +494,7 @@ impl Graph {
 
     /// Produces an iterator yielding the parents along both the **X** and **Y** **Position**
     /// **Edge**s respectively.
-    pub fn position_parents<I, J=NodeIndex>(&self, idx: I) -> PositionParents<J>
+    pub fn position_parents<I, J>(&self, idx: I) -> PositionParents<J>
         where I: GraphIndex,
               J: GraphIndex,
     {
@@ -502,7 +502,7 @@ impl Graph {
     }
 
     /// Return the index of the parent along the given widget's **Graphic** **Edge**.
-    pub fn graphic_parent<I, J=NodeIndex>(&self, idx: I) -> Option<J>
+    pub fn graphic_parent<I, J>(&self, idx: I) -> Option<J>
         where I: GraphIndex,
               J: GraphIndex,
     {

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -123,7 +123,7 @@ pub enum Length {
 
 /// The direction in which a sequence of canvas splits will be laid out.
 #[derive(Copy, Clone, Debug)]
-enum Direction {
+pub enum Direction {
     X(position::Direction),
     Y(position::Direction),
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -296,6 +296,7 @@ pub type Kind = &'static str;
 /// We do this so that if this **Widget** were to internally `set` some other **Widget**s, this
 /// **Widget**'s positioning and dimension data already exists within the widget **Graph** for
 /// reference.
+#[allow(missing_copy_implementations)]
 pub struct PreUpdateCache {
     /// The **Widget**'s unique kind.
     pub kind: Kind,


### PR DESCRIPTION
**Don't merge yet.**

Since updating, all of the colours in all of the examples have become much lighter:

Before
![screen shot 2016-02-13 at 1 42 58 am](https://cloud.githubusercontent.com/assets/4587373/13009923/266fd812-d1f3-11e5-8501-1604fb245134.png)

After
![screen shot 2016-02-13 at 1 41 18 am](https://cloud.githubusercontent.com/assets/4587373/13009895/05f52f2e-d1f3-11e5-9068-8e5940416b7e.png)


It's possible that there might be some other change we have to update to in conrod, but perhaps also possible that there may have been a bug introduced to the graphics or gfx_graphics crates during the update to the latest gfx. Will look into this soon as this should be fixed before merging this PR. Ping @bvssvni