### PR TITLE
Update dependencies. The piston_window version used in examples should now use rusttype instead of freetype!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.32.0"
+version = "0.33.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -28,4 +28,4 @@ vecmath = "0.2.0"
 
 [dev-dependencies]
 find_folder = "0.3.0"
-piston_window = "0.40.0"
+piston_window = "0.42.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ path = "./src/lib.rs"
 
 [dependencies]
 daggy = "0.4.0"
-pistoncore-input = "0.8.0"
-piston2d-graphics = "0.15.0"
+pistoncore-input = "0.9.0"
+piston2d-graphics = "0.16.0"
 num = "0.1.30"
 rand = "0.3.13"
 time = "0.1.34"
@@ -28,5 +28,4 @@ vecmath = "0.2.0"
 
 [dev-dependencies]
 find_folder = "0.3.0"
-piston_window = "0.37.0"
-piston = "0.17.0"
+piston_window = "0.40.0"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ An easy-to-use, 2D GUI library written entirely in Rust.
     - [The Builder Pattern][1.6]
 2. [**Getting Started**][2]
     - [Installing Rust and Cargo][2.1]
-    - [Installing FreeType][2.2]
-    - [Running the Conrod Examples][2.3]
+    - [Running the Conrod Examples][2.2]
 3. **Let's Create a GUI**
     - Setup a Basic Window (using piston_window)
     - Conrod Setup
@@ -102,13 +101,9 @@ dual licensed as above, without any additional terms or conditions.
 [1.6]:      http://docs.piston.rs/conrod/conrod/guide/chapter_1/index.html#the-builder-pattern
 [2]:        http://docs.piston.rs/conrod/conrod/guide/chapter_2/index.html
 [2.1]:      http://docs.piston.rs/conrod/conrod/guide/chapter_2/index.html#installing-rust-and-cargo
-[2.2]:      http://docs.piston.rs/conrod/conrod/guide/chapter_2/index.html#installing-freetype
-[2.3]:      http://docs.piston.rs/conrod/conrod/guide/chapter_2/index.html#running-the-conrod-examples
+[2.2]:      http://docs.piston.rs/conrod/conrod/guide/chapter_2/index.html#running-the-conrod-examples
 
 [issues]: https://github.com/PistonDevelopers/conrod/issues
 [1.0.0 milestone]: https://github.com/PistonDevelopers/conrod/milestones/1.0.0
-
-[freetype download]: http://www.freetype.org/download.html
-[freetype-rs]: https://github.com/PistonDevelopers/freetype-rs
 
 [Contributing]: https://github.com/PistonDevelopers/piston/blob/master/CONTRIBUTING.md

--- a/src/events/ui_event.rs
+++ b/src/events/ui_event.rs
@@ -149,7 +149,7 @@ impl UiEvent {
 #[cfg(test)]
 mod test {
     use super::*;
-    use input::{Input, MouseButton, Motion, Button, JoystickAxisArgs};
+    use input::{Input, MouseButton, Motion, Button, ControllerAxisArgs};
     use input::keyboard::{self, Key, NO_MODIFIER};
 
     // We'll see if this approach causes problems later on down the road...
@@ -228,7 +228,7 @@ mod test {
         let non_mouse_events = vec![
             UiEvent::Raw(Input::Press(Button::Keyboard(Key::G))),
             UiEvent::Raw(Input::Release(Button::Keyboard(Key::G))),
-            UiEvent::Raw(Input::Move(Motion::JoystickAxis(JoystickAxisArgs{
+            UiEvent::Raw(Input::Move(Motion::ControllerAxis(ControllerAxisArgs{
                 id: 0,
                 axis: 0,
                 position: 0f64

--- a/src/guide/chapter_2.rs
+++ b/src/guide/chapter_2.rs
@@ -66,7 +66,7 @@ encountered your problem.
 Otherwise, you're now ready to use conrod!
 
 
-
+[rust-lang]:                https://www.rust-lang.org/                          "The Rust Homepage"
 [The Official Rust Book]:   https://doc.rust-lang.org/book/                     "The Official Rust Book"
 [rust getting started]:     https://doc.rust-lang.org/book/getting-started.html "Getting Started with Rust"
 [issue tracker]:            https://github.com/PistonDevelopers/conrod/issues   "Conrod issue tracker"

--- a/src/guide/chapter_2.rs
+++ b/src/guide/chapter_2.rs
@@ -27,17 +27,6 @@ with more details on installing Rust, which may be useful in the case that you r
 with the above steps.
 
 
-## Installing Freetype
-
-Unfortunately there aren't many mature options for pure-Rust font rendering at the moment (*if you
-know of any, please let us know with a github issue or PR!*), so Conrod uses a set of bindings to
-the FreeType library for now (called [freetype-rs]).
-
-This means that you'll need to have the FreeType2 development libraries installed on your system.
-Here is the [FreeType download page], and [here are some extra tips for Windows
-users][freetype-sys].
-
-
 ## Running the Conrod Examples
 
 We can test that everything is working by cloning the github repository and running the examples.
@@ -78,10 +67,6 @@ Otherwise, you're now ready to use conrod!
 
 
 
-[freetype-rs]:              https://github.com/PistonDevelopers/freetype-rs     "freetype-rs"
-[freetype-sys]:             https://github.com/PistonDevelopers/freetype-sys    "freetype-sys"
-[FreeType download page]:   http://www.freetype.org/download.html               "FreeType download"
-[rust-lang]:                https://www.rust-lang.org/                          "The Rust Homepage"
 [The Official Rust Book]:   https://doc.rust-lang.org/book/                     "The Official Rust Book"
 [rust getting started]:     https://doc.rust-lang.org/book/getting-started.html "Getting Started with Rust"
 [issue tracker]:            https://github.com/PistonDevelopers/conrod/issues   "Conrod issue tracker"

--- a/src/guide/mod.rs
+++ b/src/guide/mod.rs
@@ -18,8 +18,7 @@
     - [The Builder Pattern][1.6]
 2. [**Getting Started**][2]
     - [Installing Rust and Cargo][2.1]
-    - [Installing FreeType][2.2]
-    - [Running the Conrod Examples][2.3]
+    - [Running the Conrod Examples][2.2]
 3. **Let's Create a GUI**
     - Setup a Basic Window (using piston_window)
     - Conrod Setup
@@ -56,8 +55,7 @@
 [1.6]:      ./chapter_1/index.html#the-builder-pattern
 [2]:        ./chapter_2/index.html
 [2.1]:      ./chapter_2/index.html#installing-rust-and-cargo
-[2.2]:      ./chapter_2/index.html#installing-freetype
-[2.3]:      ./chapter_2/index.html#running-the-conrod-examples
+[2.2]:      ./chapter_2/index.html#running-the-conrod-examples
 
 */
 


### PR DESCRIPTION
This PR is in preparation for the rustc `1.8.0` stable release (which we are waiting for as a result of [this issue](https://github.com/PistonDevelopers/piston/issues/1050)).

The use of rusttype instead of freetype has not yet been tested and it is very possible that once 1.8.0 drops and this can be tested that we may need to review the rusttype `CharacterCache` implementation upstream, or re-adjust the text handling in conrod. Hopefully everything just goes smoothly and we're able to merge and publish this straight away!

This should also fix a number of issues:
- closes #705 (fixed by an upstream glutin commit)
- all the freetype issues: closes #546, closes #695, closes #321, closes #706, closes #707.

Note: travis will fail for now, but we'll re-run once travis gets 1.8.0 stable.