### PR TITLE
Make it easier to change the OpenGL version in the examples.

### DIFF
--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -35,7 +35,7 @@ use conrod::{
     WidgetMatrix,
     XYPad,
 };
-use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{EventLoop, Glyphs, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 use std::sync::mpsc;
 
 
@@ -130,10 +130,13 @@ impl DemoApp {
 
 fn main() {
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+    
     // Construct the window.
     let mut window: PistonWindow =
         WindowSettings::new("All The Widgets!", [1100, 560])
-            .exit_on_esc(true).vsync(true).build().unwrap();
+            .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
 
     // construct our `Ui`.
     let mut ui = {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -9,7 +9,7 @@ extern crate piston_window;
 
 
 use conrod::{Canvas, Theme, Widget, color};
-use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{EventLoop, Glyphs, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 
 /// Conrod is backend agnostic. Here, we define the `piston_window` backend to use for our `Ui`.
@@ -20,10 +20,13 @@ type UiCell<'a> = conrod::UiCell<'a, Backend>;
 
 fn main() {
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+    
     // Construct the window.
     let mut window: PistonWindow =
         WindowSettings::new("Canvas Demo", [800, 600])
-            .exit_on_esc(true).vsync(true).build().unwrap();
+            .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
 
     // construct our `Ui`.
     let mut ui = {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -5,15 +5,18 @@ extern crate piston_window;
 
 fn main() {
     use conrod::{Labelable, Positionable, Sizeable, Theme, Widget};
-    use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings};
+    use piston_window::{EventLoop, Glyphs, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
     // Conrod is backend agnostic. Here, we define the `piston_window` backend to use for our `Ui`.
     type Backend = (<piston_window::G2d<'static> as conrod::Graphics>::Texture, Glyphs);
     type Ui = conrod::Ui<Backend>;
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+    
     // Construct the window.
     let mut window: PistonWindow = WindowSettings::new("Click me!", [200, 200])
-        .exit_on_esc(true).build().unwrap();
+        .opengl(opengl).exit_on_esc(true).build().unwrap();
 
     // construct our `Ui`.
     let mut ui = {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -400,12 +400,15 @@ pub fn main() {
     type Backend = (<piston_window::G2d<'static> as conrod::Graphics>::Texture, Glyphs);
     type Ui = conrod::Ui<Backend>;
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+
     // PistonWindow has two type parameters, but the default type is
     // PistonWindow<T = (), W: Window = GlutinWindow>. To change the Piston backend,
     // specify a different type in the let binding, e.g.
     // let window: PistonWindow<(), Sdl2Window>.
     let mut window: PistonWindow = WindowSettings::new("Control Panel", [1200, 800])
-        .opengl(OpenGL::V3_2)
+        .opengl(opengl)
         .exit_on_esc(true)
         .build().unwrap();
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -8,7 +8,7 @@ extern crate piston_window;
 
 fn main() {
     use conrod::{Canvas, Colorable, Image, Positionable, Theme, Widget, color};
-    use piston_window::{EventLoop, Flip, G2d, Glyphs, PistonWindow, Texture, TextureSettings,
+    use piston_window::{EventLoop, Flip, G2d, Glyphs, OpenGL, PistonWindow, Texture, TextureSettings,
                         UpdateEvent, WindowSettings};
     use std::sync::Arc;
 
@@ -16,10 +16,13 @@ fn main() {
     type Backend = (<G2d<'static> as conrod::Graphics>::Texture, Glyphs);
     type Ui = conrod::Ui<Backend>;
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+
     // Construct the window.
     let mut window: PistonWindow =
         WindowSettings::new("Image Widget Demonstration", [800, 600])
-            .exit_on_esc(true).vsync(true).samples(4).build().unwrap();
+            .opengl(opengl).exit_on_esc(true).vsync(true).samples(4).build().unwrap();
 
     // Get the path to our `assets` directory (where the fonts and images are).
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -15,10 +15,13 @@ type UiCell<'a> = conrod::UiCell<'a, Backend>;
 
 fn main() {
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+
     // Construct the window.
     let mut window: PistonWindow =
         WindowSettings::new("Primitives Demo", [400, 720])
-            .exit_on_esc(true).build().unwrap();
+            .opengl(opengl).exit_on_esc(true).build().unwrap();
 
     // construct our `Ui`.
     let mut ui = {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -3,7 +3,7 @@ extern crate find_folder;
 extern crate piston_window;
 
 use conrod::{Theme, Widget};
-use piston_window::{EventLoop, Glyphs, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{EventLoop, Glyphs, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 
 /// Conrod is backend agnostic. Here, we define the `piston_window` backend to use for our `Ui`.
@@ -14,10 +14,13 @@ type UiCell<'a> = conrod::UiCell<'a, Backend>;
 
 fn main() {
 
+    // Change this to OpenGL::V2_1 if not working.
+    let opengl = OpenGL::V3_2;
+
     // Construct the window.
     let mut window: PistonWindow =
         WindowSettings::new("Text Demo", [1080, 720])
-            .exit_on_esc(true).build().unwrap();
+            .opengl(opengl).exit_on_esc(true).build().unwrap();
 
     // Construct our `Ui`.
     let mut ui = {


### PR DESCRIPTION
This is a followup to issue [#717](https://github.com/PistonDevelopers/conrod/issues/717 "#717"), to make it easy for beginners with older hardware to step down the OpenGL version specified in the examples. 