### PR TITLE
Add new `KeyPress(Vec<std::path::PathBuf>)` event to `FileNavigator` along with more styling options.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 
 rust:
     - stable
+    - beta
     - nightly
 
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.36.3"
+version = "0.36.4"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -53,7 +53,7 @@ fn main() {
                 // Navigate the conrod directory only showing `.rs` and `.toml` files.
                 FileNavigator::with_extension(&conrod_directory, &["rs", "toml"])
                     .color(color::LIGHT_BLUE)
-                    .font_size(18)
+                    .font_size(16)
                     .wh_of(CANVAS)
                     .middle_of(CANVAS)
                     .react(|event| println!("{:?}", &event))

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -619,9 +619,6 @@ impl<B> Ui<B>
                                     }
                                 }
 
-                                // TODO: Check for dragging of the scrollbar, and whether or not a
-                                // `event::Scroll` needs to be created.
-
                                 // Update the position of the mouse within the global_input's
                                 // input::State.
                                 self.global_input.current.mouse.xy = mouse_xy;

--- a/src/widget/file_navigator.rs
+++ b/src/widget/file_navigator.rs
@@ -87,9 +87,9 @@ widget_style!{
     KIND;
     /// Unique styling for the widget.
     style Style {
-        /// Color of the FileNavigator's pressable area.
+        /// Color of the selected entries.
         - color: Color { theme.shape_color }
-        /// The color of the unselected area of the `FileNavigator`.
+        /// The color of the unselected entries.
         - unselected_color: Option<Color> { None }
         /// The color of the directory and file names.
         - text_color: Option<Color> { None }
@@ -484,9 +484,9 @@ pub mod directory_view {
         KIND;
         /// Unique styling for the widget.
         style Style {
-            /// Color of the FileNavigator's pressable area.
+            /// Color of the selected entries.
             - color: Color { theme.shape_color }
-            /// The color of the unselected area of the `FileNavigator`.
+            /// The color of the unselected entries.
             - unselected_color: Option<Color> { None }
             /// The color of the directory and file names.
             - text_color: Option<Color> { None }


### PR DESCRIPTION
New styling options include:
- custom width for resize handle
- unique colors for selected, unselected and text.

Also adds an auto-scroll when the column width is resized beyond the width of the FileNavigator, or when a directory is added to the stack that would exceed the FileNavigator width.