### PR TITLE
Remove unnecessary inline hints causing bloated stack size (and in turn overflowing the stack) in downstream crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.37.1"
+version = "0.37.2"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/position/mod.rs
+++ b/src/position/mod.rs
@@ -664,109 +664,92 @@ pub trait Sizeable: Sized {
     // Provided defaults.
 
     /// Set the absolute width for the widget.
-    #[inline]
     fn w(self, w: Scalar) -> Self {
         self.x_dimension(Dimension::Absolute(w))
     }
 
     /// Set the absolute height for the widget.
-    #[inline]
     fn h(self, h: Scalar) -> Self {
         self.y_dimension(Dimension::Absolute(h))
     }
 
     /// Set the dimensions for the widget.
-    #[inline]
     fn wh(self, wh: Dimensions) -> Self {
         self.w(wh[0]).h(wh[1])
     }
 
     /// Set the width and height for the widget.
-    #[inline]
     fn w_h(self, width: Scalar, height: Scalar) -> Self {
         self.wh([width, height])
     }
 
     /// Set the width as the width of the widget at the given index.
-    #[inline]
     fn w_of<I: Into<widget::Index>>(self, idx: I) -> Self {
         self.x_dimension(Dimension::Of(idx.into(), None))
     }
 
     /// Set the width as the width of the widget at the given index padded at both ends by the
     /// given Scalar.
-    #[inline]
     fn padded_w_of<I: Into<widget::Index>>(self, idx: I, pad: Scalar) -> Self {
         self.x_dimension(Dimension::Of(idx.into(), Some(pad)))
     }
 
     /// Set the height as the height of the widget at the given index.
-    #[inline]
     fn h_of<I: Into<widget::Index>>(self, idx: I) -> Self {
         self.y_dimension(Dimension::Of(idx.into(), None))
     }
 
     /// Set the height as the height of the widget at the given index padded at both ends by the
     /// given Scalar.
-    #[inline]
     fn padded_h_of<I: Into<widget::Index>>(self, idx: I, pad: Scalar) -> Self {
         self.y_dimension(Dimension::Of(idx.into(), Some(pad)))
     }
 
     /// Set the dimensions as the dimensions of the widget at the given index.
-    #[inline]
     fn wh_of<I: Into<widget::Index> + Copy>(self, idx: I) -> Self {
         self.w_of(idx).h_of(idx)
     }
 
     /// Set the dimensions as the dimensions of the widget at the given index with all four edges
     /// padded by the given scalar.
-    #[inline]
     fn padded_wh_of<I: Into<widget::Index> + Copy>(self, idx: I, pad: Scalar) -> Self {
         self.padded_w_of(idx, pad).padded_h_of(idx, pad)
     }
 
     /// Set the width as the width of the padded area of the widget at the given index.
-    #[inline]
     fn kid_area_w_of<I: Into<widget::Index>>(self, idx: I) -> Self {
         self.x_dimension(Dimension::KidAreaOf(idx.into(), None))
     }
 
     /// Set the width as the `KidArea` width for the widget at the given index, padded at both ends
     /// by the given scalar.
-    #[inline]
     fn padded_kid_area_w_of<I: Into<widget::Index>>(self, idx: I, pad: Scalar) -> Self {
         self.x_dimension(Dimension::KidAreaOf(idx.into(), Some(pad)))
     }
 
     /// Set the height as the `KidArea` height of the widget at the given index.
-    #[inline]
     fn kid_area_h_of<I: Into<widget::Index>>(self, idx: I) -> Self {
         self.y_dimension(Dimension::KidAreaOf(idx.into(), None))
     }
 
     /// Set the height as the `KidArea` height of the widget at the given index, padded at both
     /// ends by the given scalar.
-    #[inline]
     fn padded_kid_area_h_of<I: Into<widget::Index>>(self, idx: I, pad: Scalar) -> Self {
         self.y_dimension(Dimension::KidAreaOf(idx.into(), Some(pad)))
     }
 
     /// Set the dimensions as the `KidArea` dimensions of the widget at the given index.
-    #[inline]
     fn kid_area_wh_of<I: Into<widget::Index> + Copy>(self, idx: I) -> Self {
         self.kid_area_w_of(idx).kid_area_h_of(idx)
     }
 
     /// Set the dimensions as the `KidArea` dimensions of the widget at the given index, padded at
     /// all four edges by the given scalar.
-    #[inline]
     fn padded_kid_area_wh_of<I: Into<widget::Index> + Copy>(self, idx: I, pad: Scalar) -> Self {
         self.padded_kid_area_w_of(idx, pad).padded_kid_area_h_of(idx, pad)
     }
 
     /// Get the absolute width of the widget as a Scalar value.
-    #[inline]
     fn get_w<B: Backend>(&self, ui: &Ui<B>) -> Option<Scalar> {
         match self.get_x_dimension(ui) {
             Dimension::Absolute(width) => Some(width),
@@ -778,7 +761,6 @@ pub trait Sizeable: Sized {
     }
 
     /// Get the height of the widget.
-    #[inline]
     fn get_h<B: Backend>(&self, ui: &Ui<B>) -> Option<Scalar> {
         match self.get_y_dimension(ui) {
             Dimension::Absolute(height) => Some(height),
@@ -790,7 +772,6 @@ pub trait Sizeable: Sized {
     }
 
     /// The dimensions for the widget.
-    #[inline]
     fn get_wh<B: Backend>(&self, ui: &Ui<B>) -> Option<Dimensions> {
         self.get_w(ui).and_then(|w| self.get_h(ui).map(|h| [w, h]))
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1188,17 +1188,14 @@ impl CommonStyle {
 impl<W> Positionable for W
     where W: Widget,
 {
-    #[inline]
     fn x_position(mut self, x: Position) -> Self {
         self.common_mut().style.maybe_x_position = Some(x);
         self
     }
-    #[inline]
     fn y_position(mut self, y: Position) -> Self {
         self.common_mut().style.maybe_y_position = Some(y);
         self
     }
-    #[inline]
     fn get_x_position<B: Backend>(&self, ui: &Ui<B>) -> Position {
         let from_y_position = || self.common().style.maybe_y_position
             .and_then(|y_pos| infer_position_from_other_position(y_pos, Align::Start));
@@ -1206,7 +1203,6 @@ impl<W> Positionable for W
             .or_else(from_y_position)
             .unwrap_or(self.default_x_position(ui))
     }
-    #[inline]
     fn get_y_position<B: Backend>(&self, ui: &Ui<B>) -> Position {
         let from_x_position = || self.common().style.maybe_x_position
             .and_then(|x_pos| infer_position_from_other_position(x_pos, Align::End));
@@ -1214,12 +1210,10 @@ impl<W> Positionable for W
             .or_else(from_x_position)
             .unwrap_or(self.default_y_position(ui))
     }
-    #[inline]
     fn depth(mut self, depth: Depth) -> Self {
         self.common_mut().style.maybe_depth = Some(depth);
         self
     }
-    #[inline]
     fn get_depth(&self) -> Depth {
         const DEFAULT_DEPTH: Depth = 0.0;
         self.common().style.maybe_depth.unwrap_or(DEFAULT_DEPTH)
@@ -1244,24 +1238,20 @@ fn infer_position_from_other_position(other_pos: Position, dir_align: Align) -> 
 impl<W> Sizeable for W
     where W: Widget,
 {
-    #[inline]
     fn x_dimension(mut self, w: Dimension) -> Self {
         self.common_mut().style.maybe_x_dimension = Some(w);
         self
     }
-    #[inline]
     fn y_dimension(mut self, h: Dimension) -> Self {
         self.common_mut().style.maybe_y_dimension = Some(h);
         self
     }
-    #[inline]
     /// We attempt to retrieve the `x` **Dimension** for the widget via the following:
     /// - Check for specified value at `maybe_x_dimension`
     /// - Otherwise, use the default returned by **Widget::default_x_dimension**.
     fn get_x_dimension<B: Backend>(&self, ui: &Ui<B>) -> Dimension {
         self.common().style.maybe_x_dimension.unwrap_or_else(|| self.default_x_dimension(ui))
     }
-    #[inline]
     /// We attempt to retrieve the `y` **Dimension** for the widget via the following:
     /// - Check for specified value at `maybe_y_dimension`
     /// - Otherwise, use the default returned by **Widget::default_y_dimension**.


### PR DESCRIPTION
I've run into several stack overflows using conrod over the past couple of days, only when compiling in release. When instantiating many widgets (i.e. via helper macros), the large amount of inlining lead to a huge stack size that overflowed the designated 8mb stack on my OS X release build. This fixes the problem and hasn't caused any noticeable difference in performance. It seems that in this case, it's best to let LLVM automatically infer what cases are best for inlining. Perhaps it uses some sort of main-thread stack size consideration when deciding upon what to inline?