### PR TITLE
Remove the unnecessary `widget::Kind` type and `Widget::unique_kind` method

### DIFF
--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -18,29 +18,13 @@ extern crate piston_window;
 
 /// The module in which we'll implement our own custom circular button.
 mod circular_button {
-    use conrod::{
-        self,
-        Circle,
-        Color,
-        Colorable,
-        CommonBuilder,
-        Dimensions,
-        FontSize,
-        IndexSlot,
-        Labelable,
-        Point,
-        Positionable,
-        Text,
-        UpdateArgs,
-        Widget,
-        WidgetKind,
-    };
+    use conrod::{self, Colorable, Dimensions, Labelable, Point, Positionable, Widget};
 
     /// The type upon which we'll implement the `Widget` trait.
     pub struct CircularButton<'a, F> {
         /// An object that handles some of the dirty work of rendering a GUI. We don't
         /// really have to worry about it.
-        common: CommonBuilder,
+        common: conrod::CommonBuilder,
         /// Optional label string for the button.
         maybe_label: Option<&'a str>,
         /// Optional callback for when the button is pressed. If you want the button to
@@ -53,24 +37,20 @@ mod circular_button {
         enabled: bool
     }
 
-    /// A `&'static str` that can be used to uniquely identify our widget type.
-    pub const KIND: WidgetKind = "CircularButton";
-
     // We use the `widget_style!` macro to vastly simplify the definition and implementation of the
     // widget's associated `Style` type. This generates both a `Style` struct, as well as an
     // implementation that automatically retrieves defaults from the provided theme.
     //
     // See the documenation of the macro for a more details.
     widget_style!{
-        KIND;
         /// Represents the unique styling for our CircularButton widget.
         style Style {
             /// Color of the button.
-            - color: Color { theme.shape_color }
+            - color: conrod::Color { theme.shape_color }
             /// Color of the button's label.
-            - label_color: Color { theme.label_color }
+            - label_color: conrod::Color { theme.label_color }
             /// Font size of the button's label.
-            - label_font_size: FontSize { theme.font_size_medium }
+            - label_font_size: conrod::FontSize { theme.font_size_medium }
         }
     }
 
@@ -78,9 +58,9 @@ mod circular_button {
     #[derive(Clone, Debug, PartialEq)]
     pub struct State {
         /// An index to use for our **Circle** primitive graphics widget.
-        circle_idx: IndexSlot,
+        circle_idx: conrod::IndexSlot,
         /// An index to use for our **Text** primitive graphics widget (for the label).
-        text_idx: IndexSlot,
+        text_idx: conrod::IndexSlot,
     }
 
     /// Return whether or not a given point is over a circle at a given point on a
@@ -101,7 +81,7 @@ mod circular_button {
         /// Create a button context to be built upon.
         pub fn new() -> CircularButton<'a, F> {
             CircularButton {
-                common: CommonBuilder::new(),
+                common: conrod::CommonBuilder::new(),
                 maybe_react: None,
                 maybe_label: None,
                 style: Style::new(),
@@ -136,22 +116,18 @@ mod circular_button {
         /// The Style struct that we defined using the `widget_style!` macro.
         type Style = Style;
 
-        fn common(&self) -> &CommonBuilder {
+        fn common(&self) -> &conrod::CommonBuilder {
             &self.common
         }
 
-        fn common_mut(&mut self) -> &mut CommonBuilder {
+        fn common_mut(&mut self) -> &mut conrod::CommonBuilder {
             &mut self.common
-        }
-
-        fn unique_kind(&self) -> &'static str {
-            KIND
         }
 
         fn init_state(&self) -> State {
             State {
-                circle_idx: IndexSlot::new(),
-                text_idx: IndexSlot::new(),
+                circle_idx: conrod::IndexSlot::new(),
+                text_idx: conrod::IndexSlot::new(),
             }
         }
 
@@ -161,8 +137,8 @@ mod circular_button {
 
         /// Update the state of the button by handling any input that has occurred since the last
         /// update.
-        fn update(self, args: UpdateArgs<Self>) {
-            let UpdateArgs { idx, state, rect, mut ui, style, .. } = args;
+        fn update(self, args: conrod::UpdateArgs<Self>) {
+            let conrod::UpdateArgs { idx, state, rect, mut ui, style, .. } = args;
 
             let color = {
                 let input = ui.widget_input(idx);
@@ -207,7 +183,7 @@ mod circular_button {
             // First, we'll draw the **Circle** with a radius that is half our given width.
             let radius = rect.w() / 2.0;
             let circle_idx = state.circle_idx.get(&mut ui);
-            Circle::fill(radius)
+            conrod::Circle::fill(radius)
                 .middle_of(idx)
                 .graphics_for(idx)
                 .color(color)
@@ -218,7 +194,7 @@ mod circular_button {
             let font_size = style.label_font_size(ui.theme());
             let text_idx = state.text_idx.get(&mut ui);
             if let Some(ref label) = self.maybe_label {
-                Text::new(label)
+                conrod::Text::new(label)
                     .middle_of(idx)
                     .font_size(font_size)
                     .graphics_for(idx)
@@ -231,7 +207,7 @@ mod circular_button {
 
     /// Provide the chainable color() configuration method.
     impl<'a, F> Colorable for CircularButton<'a, F> {
-        fn color(mut self, color: Color) -> Self {
+        fn color(mut self, color: conrod::Color) -> Self {
             self.style.color = Some(color);
             self
         }
@@ -244,11 +220,11 @@ mod circular_button {
             self.maybe_label = Some(text);
             self
         }
-        fn label_color(mut self, color: Color) -> Self {
+        fn label_color(mut self, color: conrod::Color) -> Self {
             self.style.label_color = Some(color);
             self
         }
-        fn label_font_size(mut self, size: FontSize) -> Self {
+        fn label_font_size(mut self, size: conrod::FontSize) -> Self {
             self.style.label_font_size = Some(size);
             self
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,6 @@ pub use widget::{KidArea, KidAreaArgs};
 pub use widget::CommonState as WidgetCommonState;
 pub use widget::Id as WidgetId;
 pub use widget::Index as WidgetIndex;
-pub use widget::Kind as WidgetKind;
 pub use widget::State as WidgetState;
 
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -40,7 +40,7 @@ pub struct Theme {
     /// A default "small" font size.
     pub font_size_small: u32,
     /// Unique styling for each widget, index-able by the **Widget::kind**.
-    pub widget_styling: std::collections::HashMap<&'static str, WidgetDefault>,
+    pub widget_styling: std::collections::HashMap<std::any::TypeId, WidgetDefault>,
     /// Mouse Drag distance threshold determines the minimum distance from the mouse-down point
     /// that the mouse must move before starting a drag operation.
     pub mouse_drag_threshold: Scalar,
@@ -103,10 +103,11 @@ impl Theme {
     /// Retrieve the unique default styling for a widget.
     ///
     /// Attempts to cast the `Box<WidgetStyle>` to the **Widget**'s unique associated style **T**.
-    pub fn widget_style<T>(&self, kind: &'static str) -> Option<UniqueDefault<T>>
+    pub fn widget_style<T>(&self) -> Option<UniqueDefault<T>>
         where T: widget::Style,
     {
-        self.widget_styling.get(kind).and_then(|boxed_default| {
+        let style_id = std::any::TypeId::of::<T>();
+        self.widget_styling.get(&style_id).and_then(|boxed_default| {
             boxed_default.style.downcast_ref().map(|style| {
                 let common = &boxed_default.common;
                 UniqueDefault {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -26,11 +26,7 @@ pub struct Button<'a, F> {
     enabled: bool,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "Button";
-
 widget_style!{
-    KIND;
     /// Unique styling for the Button.
     style Style {
         /// Color of the Button's pressable area.
@@ -85,10 +81,6 @@ impl<'a, F> Widget for Button<'a, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -62,7 +62,6 @@ pub struct State {
 }
 
 widget_style!{
-    KIND;
     /// Unique styling for the Canvas.
     style Style {
         /// The color of the Canvas' rectangle surface.
@@ -97,9 +96,6 @@ widget_style!{
         - title_bar_text_align: Align { Align::Middle }
     }
 }
-
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "Canvas";
 
 /// A series of **Canvas** splits along with their unique identifiers.
 pub type ListOfSplits<'a> = &'a [(widget::Id, Canvas<'a>)];
@@ -225,10 +221,6 @@ impl<'a> Widget for Canvas<'a> {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -35,11 +35,7 @@ pub struct DropDownList<'a, F> {
     enabled: bool,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "DropDownList";
-
 widget_style!{
-    KIND;
     /// Styling for the DropDownList, necessary for constructing its renderable Element.
     style Style {
         /// Color of the widget.
@@ -162,10 +158,6 @@ impl<'a, F> Widget for DropDownList<'a, F>
         &mut self.common
     }
 
-    fn unique_kind(&self) -> &'static str {
-        KIND
-    }
-
     fn init_state(&self) -> State {
         State {
             menu_state: MenuState::Closed,
@@ -266,7 +258,7 @@ impl<'a, F> Widget for DropDownList<'a, F>
                 let scrollbar_position = style.scrollbar_position(&ui.theme);
                 let scrollbar_width = style.scrollbar_width(&ui.theme)
                     .unwrap_or_else(|| {
-                        ui.theme.widget_style::<ScrollbarStyle>(super::scrollbar::KIND)
+                        ui.theme.widget_style::<ScrollbarStyle>()
                             .and_then(|style| style.style.thickness)
                             .unwrap_or(10.0)
                     });

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -47,11 +47,7 @@ pub struct EnvelopeEditor<'a, E:'a, F>
     enabled: bool,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "EnvelopeEditor";
-
 widget_style!{
-    KIND;
     /// Styling for the EnvelopeEditor, necessary for constructing its renderable Element.
     style Style {
         /// Coloring for the EnvelopeEditor's **FramedRectangle**.
@@ -169,10 +165,6 @@ impl<'a, E, F> Widget for EnvelopeEditor<'a, E, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/file_navigator.rs
+++ b/src/widget/file_navigator.rs
@@ -79,11 +79,7 @@ pub struct Directory {
     column_width: Scalar,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "FileNavigator";
-
 widget_style!{
-    KIND;
     /// Unique styling for the widget.
     style Style {
         /// Color of the selected entries.
@@ -178,10 +174,6 @@ impl<'a, F> Widget for FileNavigator<'a, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
     }
 
     fn init_state(&self) -> State {
@@ -474,11 +466,7 @@ pub mod directory_view {
         is_selected: bool,
     }
 
-    /// Unique kind for the widget.
-    pub const KIND: widget::Kind = "FileNavigatorDirectoryView";
-
     widget_style!{
-        KIND;
         /// Unique styling for the widget.
         style Style {
             /// Color of the selected entries.
@@ -547,10 +535,6 @@ pub mod directory_view {
 
         fn common_mut(&mut self) -> &mut widget::CommonBuilder {
             &mut self.common
-        }
-
-        fn unique_kind(&self) -> widget::Kind {
-            KIND
         }
 
         fn init_state(&self) -> Self::State {

--- a/src/widget/framed_rectangle.rs
+++ b/src/widget/framed_rectangle.rs
@@ -31,9 +31,6 @@ pub struct FramedRectangle {
     pub style: Style,
 }
 
-/// Unique kind for the Widget.
-pub const KIND: widget::Kind = "FramedRectangle";
-
 /// Unique state for the `FramedRectangle`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct State {
@@ -42,7 +39,6 @@ pub struct State {
 }
 
 widget_style!{
-    KIND;
     /// Unique styling for the **FramedRectangle** widget.
     style Style {
         /// Shape styling for the inner rectangle.
@@ -79,10 +75,6 @@ impl Widget for FramedRectangle {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -32,11 +32,7 @@ pub struct List<F> {
     maybe_item: Option<F>,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "List";
-
 widget_style! {
-    KIND;
     /// Unique styling for the `List`.
     style Style {
         /// The width of the scrollbar if it is visible.
@@ -186,10 +182,6 @@ impl<F> Widget for List<F>
         &mut self.common
     }
 
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
-    }
-
     fn init_state(&self) -> State {
         State {
             scroll_trigger_idx: IndexSlot::new(),
@@ -219,7 +211,7 @@ impl<F> Widget for List<F>
         // The width of the scrollbar.
         let scrollbar_w = style.scrollbar_width(&ui.theme)
             .unwrap_or_else(|| {
-                ui.theme.widget_style::<ScrollbarStyle>(super::scrollbar::KIND)
+                ui.theme.widget_style::<ScrollbarStyle>()
                     .and_then(|style| style.style.thickness)
                     .unwrap_or(10.0)
             });

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -32,11 +32,7 @@ pub struct State {
     indices: Vec<Vec<NodeIndex>>,
 }
 
-/// Unique kind for the widget.
-pub const KIND: &'static str = "WidgetMatrix";
-
 widget_style!{
-    KIND;
     /// Unique styling for the `Matrix`.
     style Style {
         /// The width of the padding for each matrix element's "cell".
@@ -92,10 +88,6 @@ impl<'a, F, W> Widget for Matrix<F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -44,11 +44,7 @@ pub struct NumberDialer<'a, T, F> {
     enabled: bool,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "NumberDialer";
-
 widget_style!{
-    KIND;
     /// Unique graphical styling for the NumberDialer.
     style Style {
         /// Color of the NumberDialer's rectangle.
@@ -169,10 +165,6 @@ impl<'a, T, F> Widget for NumberDialer<'a, T, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/plot_path.rs
+++ b/src/widget/plot_path.rs
@@ -26,11 +26,7 @@ pub struct PlotPath<X, Y, F> {
     f: F,
 }
 
-/// The unique `WidgetKind` for the `PlotPath`.
-pub const KIND: widget::Kind = "PlotPath";
-
 widget_style!{
-    KIND;
     /// Unique styling parameters for the `PlotPath` widget.
     style Style {
         /// The thickness of the plotted line.
@@ -79,10 +75,6 @@ impl<X, Y, F> Widget for PlotPath<X, Y, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/primitive/image.rs
+++ b/src/widget/primitive/image.rs
@@ -22,11 +22,7 @@ pub struct State {
     pub src_rect: Option<Rect>,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "Image";
-
 widget_style!{
-    KIND;
     /// Unique styling for the `Image` widget.
     style Style {
         /// Optionally specify a single colour to use for the image.
@@ -94,10 +90,6 @@ impl Widget for Image {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/primitive/line.rs
+++ b/src/widget/primitive/line.rs
@@ -51,9 +51,6 @@ pub struct Style {
     pub maybe_cap: Option<Cap>,
 }
 
-/// Unique kind for the widget.
-pub const KIND: &'static str = "Line";
-
 /// The pattern used to draw the line.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Pattern {
@@ -229,14 +226,14 @@ impl Style {
     /// The Pattern for the Line.
     pub fn get_pattern(&self, theme: &Theme) -> Pattern {
         const DEFAULT_PATTERN: Pattern = Pattern::Solid;
-        self.maybe_pattern.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
+        self.maybe_pattern.or_else(|| theme.widget_style::<Style>().map(|default| {
             default.style.maybe_pattern.unwrap_or(DEFAULT_PATTERN)
         })).unwrap_or(DEFAULT_PATTERN)
     }
 
     /// The Color for the Line.
     pub fn get_color(&self, theme: &Theme) -> Color {
-        self.maybe_color.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
+        self.maybe_color.or_else(|| theme.widget_style::<Style>().map(|default| {
             default.style.maybe_color.unwrap_or(theme.shape_color)
         })).unwrap_or(theme.shape_color)
     }
@@ -244,7 +241,7 @@ impl Style {
     /// The width or thickness of the Line.
     pub fn get_thickness(&self, theme: &Theme) -> Scalar {
         const DEFAULT_THICKNESS: Scalar = 1.0;
-        self.maybe_thickness.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
+        self.maybe_thickness.or_else(|| theme.widget_style::<Style>().map(|default| {
             default.style.maybe_thickness.unwrap_or(DEFAULT_THICKNESS)
         })).unwrap_or(DEFAULT_THICKNESS)
     }
@@ -252,7 +249,7 @@ impl Style {
     /// The styling for the ends of the Line.
     pub fn get_cap(&self, theme: &Theme) -> Cap {
         const DEFAULT_CAP: Cap = Cap::Flat;
-        self.maybe_cap.or_else(|| theme.widget_style::<Style>(KIND).map(|default| {
+        self.maybe_cap.or_else(|| theme.widget_style::<Style>().map(|default| {
             default.style.maybe_cap.unwrap_or(DEFAULT_CAP)
         })).unwrap_or(DEFAULT_CAP)
     }
@@ -270,10 +267,6 @@ impl Widget for Line {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/primitive/point_path.rs
+++ b/src/widget/primitive/point_path.rs
@@ -36,9 +36,6 @@ pub struct State {
     pub points: Vec<Point>,
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "PointPath";
-
 
 /// Find the bounding rect for the given series of points.
 fn bounding_box_for_points<I>(mut points: I) -> Rect
@@ -165,10 +162,6 @@ impl<I> Widget for PointPath<I>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> widget::Kind {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -24,9 +24,6 @@ pub struct Oval {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct State;
 
-/// Unique Kind for the Widget.
-pub const KIND: widget::Kind = "Oval";
-
 
 impl Oval {
 
@@ -71,10 +68,6 @@ impl Widget for Oval {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/primitive/shape/polygon.rs
+++ b/src/widget/primitive/shape/polygon.rs
@@ -49,9 +49,6 @@ pub enum Kind {
     Fill,
 }
 
-/// Unique Kind for the Widget.
-pub const KIND: widget::Kind = "Polygon";
-
 
 impl<I> Polygon<I> {
 
@@ -198,10 +195,6 @@ impl<I> Widget for Polygon<I>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        "Polygon"
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/primitive/shape/rectangle.rs
+++ b/src/widget/primitive/shape/rectangle.rs
@@ -34,9 +34,6 @@ pub enum Kind {
     Fill,
 }
 
-/// Unique Kind for the widget.
-pub const KIND: widget::Kind = "Rectangle";
-
 
 impl Rectangle {
 
@@ -81,10 +78,6 @@ impl Widget for Rectangle {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -29,11 +29,7 @@ pub struct Text<'a> {
     pub style: Style,
 }
 
-/// The unique kind for the widget.
-pub const KIND: widget::Kind = "Text";
-
 widget_style!{
-    KIND;
     /// The styling for a **Text**'s graphics.
     style Style {
         /// The font size for the **Text**.
@@ -153,10 +149,6 @@ impl<'a> Widget for Text<'a> {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/range_slider.rs
+++ b/src/widget/range_slider.rs
@@ -35,11 +35,7 @@ pub struct RangeSlider<'a, T, F> {
     style: Style,
 }
 
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "RangeSlider";
-
 widget_style!{
-    KIND;
     /// Graphical styling unique to the RangeSlider widget.
     style Style {
         /// The color of the slidable rectangle.
@@ -115,10 +111,6 @@ impl<'a, T, F> Widget for RangeSlider<'a, T, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -44,12 +44,8 @@ pub trait Axis: scroll::Axis + Sized {
     fn to_2d(scalar: Scalar) -> [Scalar; 2];
 }
 
-/// Unique kind for the widget.
-pub const KIND: widget::Kind = "Scrollbar";
-
 
 widget_style!{
-    KIND;
     /// Styling for the DropDownList, necessary for constructing its renderable Element.
     style Style {
         /// Color of the widget.
@@ -147,10 +143,6 @@ impl<A> Widget for Scrollbar<A>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -51,7 +51,6 @@ pub struct Slider<'a, T, F> {
 }
 
 widget_style!{
-    KIND;
     /// Graphical styling unique to the Slider widget.
     style Style {
         /// The color of the slidable rectangle.
@@ -74,9 +73,6 @@ pub struct State {
     slider_idx: IndexSlot,
     label_idx: IndexSlot,
 }
-
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "Slider";
 
 impl<'a, T, F> Slider<'a, T, F> {
 
@@ -116,10 +112,6 @@ impl<'a, T, F> Widget for Slider<'a, T, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -99,25 +99,25 @@ macro_rules! impl_widget_style_new {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_widget_style_retrieval_method {
-    ($KIND:ident, $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }) => {
+    ($field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ }) => {
         /// Retrieves the value from the `Style`.
         ///
         /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
         pub fn $field_name(&self, theme: &$crate::Theme) -> $FieldType {
             self.$field_name
-                .or_else(|| theme.widget_style::<Self>($KIND).and_then(|default| {
+                .or_else(|| theme.widget_style::<Self>().and_then(|default| {
                     default.style.$field_name
                 }))
                 .unwrap_or_else(|| theme.$($theme_field).+)
         }
     };
-    ($KIND:ident, $field_name:ident: $FieldType:ty { $default:expr }) => {
+    ($field_name:ident: $FieldType:ty { $default:expr }) => {
         /// Retrieves the value from the `Style`.
         ///
         /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
         pub fn $field_name(&self, theme: &$crate::Theme) -> $FieldType {
             self.$field_name
-                .or_else(|| theme.widget_style::<Self>($KIND).and_then(|default| {
+                .or_else(|| theme.widget_style::<Self>().and_then(|default| {
                     default.style.$field_name
                 }))
                 .unwrap_or_else(|| $default)
@@ -131,27 +131,25 @@ macro_rules! impl_widget_style_retrieval_methods {
 
     // Retrieval methods with a field on the `theme` to use as the default.
     (
-        $KIND:ident,
         $(#[$field_attr:meta])*
         - $field_name:ident: $FieldType:ty { theme.$($theme_field:ident).+ } $($rest:tt)*
     ) => {
-        impl_widget_style_retrieval_method!($KIND, $field_name: $FieldType { theme.$($theme_field).+});
-        impl_widget_style_retrieval_methods!($KIND, $($rest)*);
+        impl_widget_style_retrieval_method!($field_name: $FieldType { theme.$($theme_field).+});
+        impl_widget_style_retrieval_methods!($($rest)*);
     };
 
 
     // Retrieval methods with an expression to use as the default.
     (
-        $KIND:ident,
         $(#[$field_attr:meta])*
         - $field_name:ident: $FieldType:ty { $default:expr } $($rest:tt)*
     ) => {
-        impl_widget_style_retrieval_method!($KIND, $field_name: $FieldType { $default });
-        impl_widget_style_retrieval_methods!($KIND, $($rest)*);
+        impl_widget_style_retrieval_method!($field_name: $FieldType { $default });
+        impl_widget_style_retrieval_methods!($($rest)*);
     };
 
     // All methods have been implemented.
-    ($KIND:ident,) => {};
+    () => {};
 }
 
 
@@ -168,9 +166,7 @@ macro_rules! impl_widget_style_retrieval_methods {
 /// ```
 /// # #[macro_use] extern crate conrod;
 /// # fn main() {}
-/// # const KIND: conrod::WidgetKind = "Example";
 /// widget_style!{
-///     KIND;
 ///     // Doc comment or attr for the generated `Style` struct can go here.
 ///     style Style {
 ///         // Fields and their type T (which get converted to `Option<T>` in the struct definition)
@@ -208,13 +204,7 @@ macro_rules! impl_widget_style_retrieval_methods {
 ///     // Other necessary fields...
 /// }
 ///
-/// /// A unique string used to dynamically identify the widget type.
-/// ///
-/// /// Conrod uses this to store unique styling for each widget in a `HashMap` within the `Theme`.
-/// const KIND: conrod::WidgetKind = "MyWidget";
-///
 /// widget_style!{
-///     KIND;
 ///     /// Unique, awesome styling for a `MyWidget`.
 ///     style Style {
 ///         /// The totally amazing color to use for the `MyWidget`.
@@ -248,11 +238,6 @@ macro_rules! impl_widget_style_retrieval_methods {
 ///     // Other necessary fields...
 /// }
 ///
-/// /// A unique string used to dynamically identify the widget type.
-/// ///
-/// /// Conrod uses this to store unique styling for each widget in a `HashMap` within the `Theme`.
-/// const KIND: conrod::WidgetKind = "MyWidget";
-///
 /// /// Unique, awesome styling for a `MyWidget`.
 /// #[derive(Copy, Clone, Debug, PartialEq)]
 /// pub struct Style {
@@ -283,7 +268,7 @@ macro_rules! impl_widget_style_retrieval_methods {
 ///     /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
 ///     pub fn color(&self, theme: &conrod::Theme) -> conrod::Color {
 ///         self.color
-///             .or_else(|| theme.widget_style::<Self>(KIND).and_then(|default| {
+///             .or_else(|| theme.widget_style::<Self>().and_then(|default| {
 ///                 default.style.color
 ///             }))
 ///             .unwrap_or_else(|| theme.shape_color)
@@ -294,7 +279,7 @@ macro_rules! impl_widget_style_retrieval_methods {
 ///     /// If the `Style`'s field is `None`, falls back to default specified within the `Theme`.
 ///     pub fn label_color(&self, theme: &conrod::Theme) -> conrod::Color {
 ///         self.label_color
-///             .or_else(|| theme.widget_style::<Self>(KIND).and_then(|default| {
+///             .or_else(|| theme.widget_style::<Self>().and_then(|default| {
 ///                 default.style.label_color
 ///             }))
 ///             .unwrap_or_else(|| conrod::color::PURPLE)
@@ -311,7 +296,6 @@ macro_rules! impl_widget_style_retrieval_methods {
 #[macro_export]
 macro_rules! widget_style {
     (
-        $KIND:ident;
         $(#[$Style_attr:meta])*
         style $Style:ident {
             $($fields:tt)*
@@ -331,7 +315,7 @@ macro_rules! widget_style {
 
         // The "field, theme or default" retrieval methods.
         impl $Style {
-            impl_widget_style_retrieval_methods!($KIND, $($fields)*);
+            impl_widget_style_retrieval_methods!($($fields)*);
         }
     };
 }

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -45,14 +45,10 @@ pub struct Tab {
     button_idx: NodeIndex,
 }
 
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "Tabs";
-
 /// The padding between the edge of the title bar and the title bar's label.
 const TAB_BAR_LABEL_PADDING: f64 = 4.0;
 
 widget_style!{
-    KIND;
     /// Unique styling for the `Tabs` widget.
     style Style {
         /// Layout for the tab selection bar.
@@ -177,10 +173,6 @@ impl<'a> Widget for Tabs<'a> {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -32,11 +32,7 @@ pub struct TextBox<'a, F> {
     style: Style,
 }
 
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "TextBox";
-
 widget_style!{
-    KIND;
     /// Unique graphical styling for the TextBox.
     style Style {
         /// The length of the gap between the bounding rectangle's frame and the edge of the text.
@@ -115,10 +111,6 @@ impl<'a, F> Widget for TextBox<'a, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -37,11 +37,7 @@ pub struct TextEdit<'a, F> {
     style: Style,
 }
 
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "TextEdit";
-
 widget_style!{
-    KIND;
     /// Unique graphical styling for the TextEdit.
     style Style {
         /// The color of the text (this includes cursor and selection color).
@@ -190,10 +186,6 @@ impl<'a, F> Widget for TextEdit<'a, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -36,7 +36,6 @@ pub struct State {
 }
 
 widget_style!{
-    KIND;
     /// Unique styling for the **TitleBar** widget.
     style Style {
         /// The color of the TitleBar's rectangle surface.
@@ -58,9 +57,6 @@ widget_style!{
         - text_align: Align { Align::Middle }
     }
 }
-
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "TitleBar";
 
 /// The padding between the edge of the title bar and the title bar's label.
 ///
@@ -122,10 +118,6 @@ impl<'a> Widget for TitleBar<'a> {
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -32,11 +32,7 @@ pub struct Toggle<'a, F> {
     pub enabled: bool,
 }
 
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "Toggle";
-
 widget_style!{
-    KIND;
     /// Styling for the Toggle including coloring, framing and labelling.
     style Style {
         /// Color of the Toggle's pressable area.
@@ -94,10 +90,6 @@ impl<'a, F> Widget for Toggle<'a, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> State {

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -36,11 +36,7 @@ pub struct XYPad<'a, X, Y, F> {
     pub enabled: bool,
 }
 
-/// Unique kind for the widget type.
-pub const KIND: widget::Kind = "XYPad";
-
 widget_style!{
-    KIND;
     /// Unique graphical styling for the XYPad.
     style Style {
         /// The color of the XYPad's rectangle.
@@ -109,10 +105,6 @@ impl<'a, X, Y, F> Widget for XYPad<'a, X, Y, F>
 
     fn common_mut(&mut self) -> &mut widget::CommonBuilder {
         &mut self.common
-    }
-
-    fn unique_kind(&self) -> &'static str {
-        KIND
     }
 
     fn init_state(&self) -> Self::State {


### PR DESCRIPTION
The `widget::Kind` concept was added long ago as an ad-hoc readable form of dynamic typing. Since then, the `std::any::TypeId` API was stabilised and there's no longer any need for the widget kind API.

This should remove some cruft from all custom widget implementations.

Closes #751 

cc @Hyperchaotic just a heads up, this should allow you to remove the `unique_kind` method and `KIND` constant from your list select widget in #749.