### PR TITLE
Fix `TextEdit` cursor jump bugs

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -503,7 +503,7 @@ pub mod cursor {
                 let new_line = line - 1;
                 line_infos.nth(new_line)
                     .map(|info| {
-                        let new_char = info.end_char();
+                        let new_char = info.end_char() - info.start_char;
                         Index { line: new_line, char: new_char }
                     })
             } else {
@@ -559,7 +559,7 @@ pub mod cursor {
         for (i, line_info) in line_infos.enumerate() {
             let start_char = line_info.start_char;
             let end_char = line_info.end_char();
-            if start_char <= char_index && char_index <= end_char + 1 {
+            if start_char <= char_index && char_index <= end_char {
                 return Some(Index { line: i, char: char_index - start_char });
             }
         }
@@ -941,11 +941,6 @@ pub mod line {
                 return (break_, width);
             }
 
-            // Check for a new whitespace.
-            else if ch.is_whitespace() {
-                last_whitespace_start = Last { byte: byte_i, char: char_i, width_before: width };
-            }
-
             // Add the character's width to the width so far.
             let new_width = width + advance_width(ch, font, scale, &mut last_glyph);
 
@@ -954,6 +949,11 @@ pub mod line {
                 let Last { byte, char, width_before } = last_whitespace_start;
                 let break_ = Break::Wrap { byte: byte, char: char, len_bytes: 1 };
                 return (break_, width_before);
+            }
+
+            // Check for a new whitespace.
+            if ch.is_whitespace() {
+                last_whitespace_start = Last { byte: byte_i, char: char_i, width_before: width };
             }
 
             width = new_width;

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -374,16 +374,13 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                         text::glyph::index_after_cursor(line_infos, cursor_idx)
                                     };
                                     if let Some(idx) = idx_after_cursor {
-                                        let idx_to_remove = idx - 1;
-                                        let new_cursor_idx = {
-                                            let line_infos = state.line_infos.iter().cloned();
-                                            text::cursor::index_before_char(line_infos, idx_to_remove)
-                                        };
-                                        if let Some(new_cursor_idx) = new_cursor_idx {
-                                            cursor = Cursor::Idx(new_cursor_idx);
+                                        if idx > 0 {
+                                            let idx_to_remove = idx - 1;
+
                                             *text = text.chars().take(idx_to_remove)
                                                 .chain(text.chars().skip(idx))
                                                 .collect();
+
                                             state.update(|state| {
                                                 let font = ui.fonts.get(font_id).unwrap();
                                                 let w = rect.w();
@@ -391,6 +388,13 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                                     line_infos(text, font, font_size, line_wrap, w)
                                                         .collect();
                                             });
+
+                                            let line_infos = state.line_infos.iter().cloned();
+                                            let new_cursor_idx =
+                                                 text::cursor::index_before_char(line_infos, idx_to_remove)
+                                                 // in case we removed the last character
+                                                .unwrap_or(text::cursor::Index {line: 0, char: 0});
+                                            cursor = Cursor::Idx(new_cursor_idx);
                                         }
                                     }
                                 },
@@ -439,7 +443,6 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                             let line_infos = state.line_infos.iter().cloned();
                                             cursor_idx.previous(line_infos).unwrap_or(cursor_idx)
                                         };
-
                                         cursor = Cursor::Idx(new_cursor_idx);
                                     },
 


### PR DESCRIPTION
Fix bugs in `TextEdit` where the cursor can jump to unexpected locations
(usually the upper left of the screen) while editing. This could happen
when pressing the left arrow key or backspace at the beginning of a line,
or when pressing space at the end of a line.

The causes were minor mistakes like off-by-one errors. Related: #729