### PR TITLE
Add a new `render::OwnedPrimitives` type as an owned alternative to the `render::Primitives` type. Useful for threading the UI.

### DIFF
--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -180,10 +180,11 @@ fn main() {
         //
         // If instead you need to re-draw your conrod GUI every frame, use `Ui::draw`.
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -52,10 +52,11 @@ fn main() {
         });
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -65,10 +65,11 @@ fn main() {
 
         // Draw the `Ui` if it has changed.
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -303,10 +303,11 @@ pub fn main() {
 
         // Draws the whole Ui (in this case, just our widget) whenever a change occurs.
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -68,10 +68,11 @@ fn main() {
         });
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/glutin_glium.rs
+++ b/examples/glutin_glium.rs
@@ -106,9 +106,6 @@ mod feature {
             (cache, texture)
         };
 
-        // Mappings from `Image` widget indices to their image data.
-        let image_map = conrod::image::Map::<()>::new();
-
         // Start the loop:
         //
         // - Render the current state of the `Ui`.
@@ -127,7 +124,7 @@ mod feature {
             ui.handle_event(conrod::event::render(dt_secs, win_w, win_h, dpi_factor as conrod::Scalar));
 
             // Draw the `Ui`.
-            if let Some(mut primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(mut primitives) = ui.draw_if_changed() {
                 use conrod::render;
                 use conrod::text::rt;
 
@@ -148,7 +145,7 @@ mod feature {
                 let mut vertices: Vec<Vertex> = Vec::new();
 
                 // Draw each primitive in order of depth.
-                while let Some(render::Primitive { kind, scizzor, rect }) = primitives.next() {
+                while let Some(render::Primitive { index, kind, scizzor, rect }) = primitives.next() {
                     match kind {
 
                         render::PrimitiveKind::Rectangle { color } => {
@@ -223,7 +220,7 @@ mod feature {
                             vertices.extend(extension);
                         },
 
-                        render::PrimitiveKind::Image { maybe_color, image, source_rect } => {
+                        render::PrimitiveKind::Image { color, source_rect } => {
                             // TODO
                         },
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -45,10 +45,11 @@ fn main() {
         ui.handle_event(event.clone());
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -46,10 +46,11 @@ fn main() {
         });
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -37,10 +37,11 @@ fn main() {
         event.update(|_| ui.set_widgets(set_ui));
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -38,10 +38,11 @@ fn main() {
 
         // Draw the `Ui`.
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -48,10 +48,11 @@ fn main() {
         });
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -49,10 +49,11 @@ fn main() {
 
         window.draw_2d(&event, |c, g| {
             // Only re-draw if there was some change in the `Ui`.
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -50,10 +50,11 @@ fn main() {
         event.update(|_| ui.set_widgets(|ui_cell| set_ui(ui_cell, &mut demo_text)));
 
         window.draw_2d(&event, |c, g| {
-            if let Some(primitives) = ui.draw_if_changed(&image_map) {
+            if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
                 conrod::backend::piston_window::draw(c, g, primitives,
                                                      &mut text_texture_cache,
+                                                     &image_map,
                                                      texture_from_image);
             }
         });

--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -5,8 +5,8 @@ extern crate glium;
 use render;
 
 /// Render the given sequence of conrod primitive widgets.
-pub fn primitives<Img>(mut primitives: render::Primitives<Img>) {
-    while let Some(render::Primitive { kind, scizzor, rect }) = primitives.next() {
+pub fn primitives(mut primitives: render::Primitives) {
+    while let Some(render::Primitive { index, kind, scizzor, rect }) = primitives.next() {
         match kind {
 
             render::PrimitiveKind::Rectangle { color } => {
@@ -21,7 +21,7 @@ pub fn primitives<Img>(mut primitives: render::Primitives<Img>) {
             render::PrimitiveKind::Text { color, text, font_id } => {
             },
 
-            render::PrimitiveKind::Image { maybe_color, image, source_rect } => {
+            render::PrimitiveKind::Image { color, source_rect } => {
             },
 
             render::PrimitiveKind::Other(_) => (),

--- a/src/render.rs
+++ b/src/render.rs
@@ -11,16 +11,21 @@
 
 use {Align, Color, Dimensions, FontSize, Point, Rect, Scalar};
 use graph::{self, Graph, NodeIndex};
-use image;
 use std;
 use text;
 use theme::Theme;
-use widget::primitive;
+use widget::{self, primitive};
 
 
 /// An iterator-like type that yields a reference to each primitive in order of depth for
 /// rendering.
-pub struct Primitives<'a, Img: 'a> {
+///
+/// This type is produced by the `Ui::draw` and `Ui::draw_if_changed` methods.
+///
+/// This type borrows data from the `Ui` in order to lazily produce each `Primitive`. If you
+/// require ownership over the sequence of primitives, consider using the `OwnedPrimitives` type.
+/// The `OwnedPrimitives` type can be produced by calling the `Primitives::owned` method.
+pub struct Primitives<'a> {
     crop_stack: Vec<(NodeIndex, Rect)>,
     depth_order: std::slice::Iter<'a, NodeIndex>,
     graph: &'a Graph,
@@ -31,15 +36,50 @@ pub struct Primitives<'a, Img: 'a> {
     points: Vec<Point>,
     /// The slice of rusttype `PositionedGlyph`s to re-use for the `Text` primitive.
     positioned_glyphs: Vec<text::PositionedGlyph>,
-    /// The type that the `Primitives` will use to retrieve `Image<T>` data so that it may be
-    /// yielded via `Primitive::Image` variants.
-    image_map: &'a image::Map<Img>,
 }
 
+/// An owned alternative to the `Primitives` type.
+///
+/// This is particularly useful for sending rendering data across threads.
+///
+/// Produce an `OwnedPrimitives` instance via the `Primitives::owned` method.
+#[derive(Clone)]
+pub struct OwnedPrimitives {
+    primitives: Vec<OwnedPrimitive>,
+    points: Vec<Point>,
+    max_glyphs: usize,
+    line_infos: Vec<text::line::Info>,
+    texts_string: String,
+}
+
+
+/// A trait that allows the user to remain generic over types yielding `Primitive`s.
+///
+/// This trait is implemented for both the `Primitives` and `WalkOwnedPrimitives` types.
+pub trait PrimitiveWalker {
+    /// Yield the next `Primitive` in order of depth, bottom to top.
+    fn next_primitive(&mut self) -> Option<Primitive>;
+}
+
+impl<'a> PrimitiveWalker for Primitives<'a> {
+    fn next_primitive(&mut self) -> Option<Primitive> {
+        self.next()
+    }
+}
+
+impl<'a> PrimitiveWalker for WalkOwnedPrimitives<'a> {
+    fn next_primitive(&mut self) -> Option<Primitive> {
+        self.next()
+    }
+}
+
+
 /// Data required for rendering a single primitive widget.
-pub struct Primitive<'a, Img: 'a> {
+pub struct Primitive<'a> {
+    /// The index of the widget within the widget graph.
+    pub index: widget::Index,
     /// State and style for this primitive widget.
-    pub kind: PrimitiveKind<'a, Img>,
+    pub kind: PrimitiveKind<'a>,
     /// The Rect to which the primitive widget should be cropped.
     ///
     /// Only parts of the widget within this `Rect` should be drawn.
@@ -49,7 +89,7 @@ pub struct Primitive<'a, Img: 'a> {
 }
 
 /// The unique kind for each primitive element in the Ui.
-pub enum PrimitiveKind<'a, Img: 'a> {
+pub enum PrimitiveKind<'a> {
 
     /// A filled `Rectangle`.
     ///
@@ -91,12 +131,8 @@ pub enum PrimitiveKind<'a, Img: 'a> {
 
     /// A single `Image`, produced by the primitive `Image` widget.
     Image {
-        /// The `Image` along with the data with which it was instantiated.
-        ///
-        /// This is normally produced by a `conrod::texture::Map` instance.
-        image: Option<&'a Img>,
         /// When `Some`, colours the `Image`. When `None`, the `Image` uses its regular colours.
-        maybe_color: Option<Color>,
+        color: Option<Color>,
         /// The area of the texture that will be drawn to the `Image`'s `Rect`.
         source_rect: Option<Rect>,
     },
@@ -127,7 +163,6 @@ pub enum PrimitiveKind<'a, Img: 'a> {
 
 }
 
-
 /// A type used for producing a `PositionedGlyph` iterator.
 ///
 /// We produce this type rather than the `&[PositionedGlyph]`s directly so that we can properly
@@ -144,6 +179,64 @@ pub struct Text<'a> {
     y_align: Align,
     line_spacing: Scalar,
 }
+
+
+#[derive(Clone)]
+struct OwnedPrimitive {
+    index: widget::Index,
+    kind: OwnedPrimitiveKind,
+    scizzor: Rect,
+    rect: Rect,
+}
+
+#[derive(Clone)]
+enum OwnedPrimitiveKind {
+    Rectangle {
+        color: Color,
+    },
+    Polygon {
+        color: Color,
+        point_range: std::ops::Range<usize>,
+    },
+    Lines {
+        color: Color,
+        cap: primitive::line::Cap,
+        thickness: Scalar,
+        point_range: std::ops::Range<usize>,
+    },
+    Image {
+        color: Option<Color>,
+        source_rect: Option<Rect>,
+    },
+    Text {
+        color: Color,
+        font_id: text::font::Id,
+        text: OwnedText,
+    },
+}
+
+#[derive(Clone)]
+struct OwnedText {
+    str_byte_range: std::ops::Range<usize>,
+    line_infos_range: std::ops::Range<usize>,
+    window_dim: Dimensions,
+    font: text::Font,
+    font_size: FontSize,
+    rect: Rect,
+    x_align: Align,
+    y_align: Align,
+    line_spacing: Scalar,
+}
+
+/// An iterator-like type for yielding `Primitive`s from an `OwnedPrimitives`.
+pub struct WalkOwnedPrimitives<'a> {
+    primitives: std::slice::Iter<'a, OwnedPrimitive>,
+    points: &'a [Point],
+    line_infos: &'a [text::line::Info],
+    texts_str: &'a str,
+    positioned_glyphs: Vec<text::PositionedGlyph>,
+}
+
 
 impl<'a> Text<'a> {
 
@@ -200,15 +293,14 @@ const CIRCLE_RESOLUTION: usize = 50;
 const NUM_POINTS: usize = CIRCLE_RESOLUTION + 1;
 
 
-impl<'a, Img> Primitives<'a, Img> {
+impl<'a> Primitives<'a> {
 
     /// Constructor for the `Primitives` iterator.
     pub fn new(graph: &'a Graph,
                depth_order: &'a [NodeIndex],
                theme: &'a Theme,
                fonts: &'a text::font::Map,
-               window_dim: Dimensions,
-               image_map: &'a image::Map<Img>) -> Self
+               window_dim: Dimensions) -> Self
     {
         Primitives {
             crop_stack: Vec::new(),
@@ -222,22 +314,20 @@ impl<'a, Img> Primitives<'a, Img> {
             // before writing points for an `Oval` or `Rectangle`.
             points: vec![[0.0, 0.0]; NUM_POINTS],
             positioned_glyphs: Vec::new(),
-            image_map: image_map,
         }
     }
 
     /// Yield the next `Primitive` for rendering.
-    pub fn next(&mut self) -> Option<Primitive<Img>> {
+    pub fn next(&mut self) -> Option<Primitive> {
         let Primitives {
             ref mut crop_stack,
             ref mut depth_order,
+            ref mut points,
+            ref mut positioned_glyphs,
             graph,
             theme,
             fonts,
             window_rect,
-            ref mut points,
-            ref mut positioned_glyphs,
-            ref image_map,
         } = *self;
 
         while let Some(widget) = next_widget(depth_order, graph, crop_stack, window_rect) {
@@ -247,6 +337,7 @@ impl<'a, Img> Primitives<'a, Img> {
             use widget::primitive::shape::Style as ShapeStyle;
 
             let (idx, scizzor, container) = widget;
+            let index = graph.widget_id(idx).map_or_else(|| idx.into(), Into::into);
             let rect = container.rect;
 
             fn state_type_id<W>() -> std::any::TypeId
@@ -263,7 +354,7 @@ impl<'a, Img> Primitives<'a, Img> {
                     match *style {
                         ShapeStyle::Fill(_) => {
                             let kind = PrimitiveKind::Rectangle { color: color };
-                            return Some(new_primitive(kind, scizzor, rect));
+                            return Some(new_primitive(index, kind, scizzor, rect));
                         },
                         ShapeStyle::Outline(ref line_style) => {
                             let (l, r, b, t) = rect.l_r_b_t();
@@ -280,7 +371,7 @@ impl<'a, Img> Primitives<'a, Img> {
                                 thickness: thickness,
                                 points: &points[..5],
                             };
-                            return Some(new_primitive(kind, scizzor, rect));
+                            return Some(new_primitive(index, kind, scizzor, rect));
                         },
                     }
                 }
@@ -304,7 +395,7 @@ impl<'a, Img> Primitives<'a, Img> {
                     match *style {
                         ShapeStyle::Fill(_) => {
                             let kind = PrimitiveKind::Polygon { color: color, points: points };
-                            return Some(new_primitive(kind, scizzor, rect));
+                            return Some(new_primitive(index, kind, scizzor, rect));
                         },
                         ShapeStyle::Outline(ref line_style) => {
                             let cap = line_style.get_cap(theme);
@@ -315,7 +406,7 @@ impl<'a, Img> Primitives<'a, Img> {
                                 thickness: thickness,
                                 points: points,
                             };
-                            return Some(new_primitive(kind, scizzor, rect));
+                            return Some(new_primitive(index, kind, scizzor, rect));
                         },
                     }
                 }
@@ -330,7 +421,7 @@ impl<'a, Img> Primitives<'a, Img> {
                     match *style {
                         ShapeStyle::Fill(_) => {
                             let kind = PrimitiveKind::Polygon { color: color, points: points };
-                            return Some(new_primitive(kind, scizzor, rect));
+                            return Some(new_primitive(index, kind, scizzor, rect));
                         },
                         ShapeStyle::Outline(ref line_style) => {
                             let cap = line_style.get_cap(theme);
@@ -341,7 +432,7 @@ impl<'a, Img> Primitives<'a, Img> {
                                 thickness: thickness,
                                 points: points,
                             };
-                            return Some(new_primitive(kind, scizzor, rect));
+                            return Some(new_primitive(index, kind, scizzor, rect));
                         },
                     }
                 }
@@ -361,7 +452,7 @@ impl<'a, Img> Primitives<'a, Img> {
                         thickness: thickness,
                         points: points,
                     };
-                    return Some(new_primitive(kind, scizzor, rect));
+                    return Some(new_primitive(index, kind, scizzor, rect));
                 }
 
             } else if container.type_id == std::any::TypeId::of::<PointPathState>() {
@@ -378,7 +469,7 @@ impl<'a, Img> Primitives<'a, Img> {
                         thickness: thickness,
                         points: points,
                     };
-                    return Some(new_primitive(kind, scizzor, rect));
+                    return Some(new_primitive(index, kind, scizzor, rect));
                 }
 
             } else if container.type_id == state_type_id::<TextWidget>() {
@@ -418,41 +509,277 @@ impl<'a, Img> Primitives<'a, Img> {
                         text: text,
                         font_id: font_id,
                     };
-                    return Some(new_primitive(kind, scizzor, rect));
+                    return Some(new_primitive(index, kind, scizzor, rect));
                 }
 
             } else if container.type_id == state_type_id::<Image>() {
                 use widget::primitive::image::{State, Style};
                 if let Some(image) = container.state_and_style::<State, Style>() {
                     let graph::UniqueWidgetState { ref state, ref style } = *image;
-                    let maybe_color = style.maybe_color(theme);
-                    let image = graph.widget_id(idx)
-                        .and_then(|id| image_map.get(id))
-                        .or_else(|| image_map.get(idx));
+                    let color = style.maybe_color(theme);
                     let kind = PrimitiveKind::Image {
-                        maybe_color: maybe_color,
-                        image: image,
+                        color: color,
                         source_rect: state.src_rect,
                     };
-                    return Some(new_primitive(kind, scizzor, rect));
+                    return Some(new_primitive(index, kind, scizzor, rect));
                 }
 
             // Return an `Other` variant for all non-primitive widgets.
             } else {
                 let kind = PrimitiveKind::Other(container);
-                return Some(new_primitive(kind, scizzor, rect));
+                return Some(new_primitive(index, kind, scizzor, rect));
             }
         }
 
         None
     }
+
+    /// Collect the `Primitives` list into an owned collection.
+    ///
+    /// This is useful for sending `Ui` rendering data across threads in an efficient manner.
+    pub fn owned(mut self) -> OwnedPrimitives {
+        let mut primitives = Vec::with_capacity(self.depth_order.len());
+        let mut primitive_points = Vec::new();
+        let mut primitive_line_infos = Vec::new();
+        let mut texts_string = String::new();
+        let mut max_glyphs = 0;
+
+        while let Some(Primitive { index, rect, scizzor, kind }) = self.next() {
+            let new = |kind| OwnedPrimitive {
+                index: index,
+                rect: rect,
+                scizzor: scizzor,
+                kind: kind,
+            };
+
+            match kind {
+
+                PrimitiveKind::Rectangle { color } => {
+                    let kind = OwnedPrimitiveKind::Rectangle { color: color };
+                    primitives.push(new(kind));
+                },
+
+                PrimitiveKind::Polygon { color, points } => {
+                    let start = primitive_points.len();
+                    primitive_points.extend(points.iter().cloned());
+                    let end = primitive_points.len();
+                    let kind = OwnedPrimitiveKind::Polygon {
+                        color: color,
+                        point_range: start..end,
+                    };
+                    primitives.push(new(kind));
+                },
+
+                PrimitiveKind::Lines { color, cap, thickness, points } => {
+                    let start = primitive_points.len();
+                    primitive_points.extend(points.iter().cloned());
+                    let end = primitive_points.len();
+                    let kind = OwnedPrimitiveKind::Lines {
+                        color: color,
+                        cap: cap,
+                        thickness: thickness,
+                        point_range: start..end,
+                    };
+                    primitives.push(new(kind));
+                },
+
+                PrimitiveKind::Image { color, source_rect } => {
+                    let kind = OwnedPrimitiveKind::Image {
+                        color: color,
+                        source_rect: source_rect,
+                    };
+                    primitives.push(new(kind));
+                },
+
+                PrimitiveKind::Text { color, font_id, text } => {
+                    let Text {
+                        window_dim,
+                        text,
+                        line_infos,
+                        font,
+                        font_size,
+                        rect,
+                        x_align,
+                        y_align,
+                        line_spacing,
+                        ..
+                    } = text;
+
+                    // Keep a rough estimate of the maximum number of glyphs so that we know what
+                    // capacity we should allocate the `PositionedGlyph` buffer with.
+                    max_glyphs = std::cmp::max(max_glyphs, text.len());
+
+                    // Pack the `texts_string`.
+                    let start_str_byte = texts_string.len();
+                    texts_string.push_str(text);
+                    let end_str_byte = texts_string.len();
+
+                    // Pack the `line_infos`.
+                    let start_line_info_idx = primitive_line_infos.len();
+                    primitive_line_infos.extend(line_infos.iter().cloned());
+                    let end_line_info_idx = primitive_line_infos.len();
+
+                    let owned_text = OwnedText {
+                        str_byte_range: start_str_byte..end_str_byte,
+                        line_infos_range: start_line_info_idx..end_line_info_idx,
+                        window_dim: window_dim,
+                        font: font.clone(),
+                        font_size: font_size,
+                        rect: rect,
+                        x_align: x_align,
+                        y_align: y_align,
+                        line_spacing: line_spacing,
+                    };
+
+                    let kind = OwnedPrimitiveKind::Text {
+                        color: color,
+                        font_id: font_id,
+                        text: owned_text,
+                    };
+                    primitives.push(new(kind));
+                },
+
+                // TODO: Not sure how we should handle this yet.
+                PrimitiveKind::Other(_) => (),
+
+            }
+        }
+
+        OwnedPrimitives {
+            primitives: primitives,
+            points: primitive_points,
+            max_glyphs: max_glyphs,
+            line_infos: primitive_line_infos,
+            texts_string: texts_string,
+        }
+    }
+
+}
+
+
+impl OwnedPrimitives {
+
+    /// Produce an iterator-like type for yielding `Primitive`s.
+    pub fn walk(&self) -> WalkOwnedPrimitives {
+        let OwnedPrimitives {
+            ref primitives,
+            ref points,
+            ref line_infos,
+            ref texts_string,
+            max_glyphs,
+        } = *self;
+        WalkOwnedPrimitives {
+            primitives: primitives.iter(),
+            points: points,
+            line_infos: line_infos,
+            texts_str: texts_string,
+            positioned_glyphs: Vec::with_capacity(max_glyphs),
+        }
+    }
+
+}
+
+impl<'a> WalkOwnedPrimitives<'a> {
+
+    /// Yield the next `Primitive` in order or rendering depth, bottom to top.
+    pub fn next(&mut self) -> Option<Primitive> {
+        let WalkOwnedPrimitives {
+            ref mut primitives,
+            ref mut positioned_glyphs,
+            points,
+            line_infos,
+            texts_str,
+        } = *self;
+
+        primitives.next().map(move |&OwnedPrimitive { index, rect, scizzor, ref kind }| {
+            let new = |kind| Primitive {
+                index: index,
+                rect: rect,
+                scizzor: scizzor,
+                kind: kind,
+            };
+
+            match *kind {
+
+                OwnedPrimitiveKind::Rectangle { color } => {
+                    let kind = PrimitiveKind::Rectangle { color: color };
+                    new(kind)
+                },
+
+                OwnedPrimitiveKind::Polygon { color, ref point_range } => {
+                    let kind = PrimitiveKind::Polygon {
+                        color: color,
+                        points: &points[point_range.clone()],
+                    };
+                    new(kind)
+                },
+
+                OwnedPrimitiveKind::Lines { color, cap, thickness, ref point_range } => {
+                    let kind = PrimitiveKind::Lines {
+                        color: color,
+                        cap: cap,
+                        thickness: thickness,
+                        points: &points[point_range.clone()],
+                    };
+                    new(kind)
+                },
+
+                OwnedPrimitiveKind::Text { color, font_id, ref text } => {
+                    let OwnedText {
+                        ref str_byte_range,
+                        ref line_infos_range,
+                        ref font,
+                        window_dim,
+                        font_size,
+                        rect,
+                        x_align,
+                        y_align,
+                        line_spacing,
+                    } = *text;
+
+                    let text_str = &texts_str[str_byte_range.clone()];
+                    let line_infos = &line_infos[line_infos_range.clone()];
+
+                    let text = Text {
+                        positioned_glyphs: positioned_glyphs,
+                        window_dim: window_dim,
+                        text: text_str,
+                        line_infos: line_infos,
+                        font: font,
+                        font_size: font_size,
+                        rect: rect,
+                        x_align: x_align,
+                        y_align: y_align,
+                        line_spacing: line_spacing,
+                    };
+
+                    let kind = PrimitiveKind::Text {
+                        color: color,
+                        font_id: font_id,
+                        text: text,
+                    };
+                    new(kind)
+                },
+
+                OwnedPrimitiveKind::Image { color, source_rect } => {
+                    let kind = PrimitiveKind::Image {
+                        color: color,
+                        source_rect: source_rect,
+                    };
+                    new(kind)
+                },
+            }
+        })
+    }
+
 }
 
 
 
 /// Simplify the constructor for a `Primitive`.
-fn new_primitive<Img>(kind: PrimitiveKind<Img>, scizzor: Rect, rect: Rect) -> Primitive<Img> {
+fn new_primitive(index: widget::Index, kind: PrimitiveKind, scizzor: Rect, rect: Rect) -> Primitive {
     Primitive {
+        index: index,
         kind: kind,
         scizzor: scizzor,
         rect: rect,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,6 @@
 use color::Color;
 use event;
 use graph::{self, Graph, NodeIndex};
-use image;
 use input;
 use position::{Align, Direction, Dimensions, Padding, Place, Point, Position, Range, Rect, Scalar};
 use render;
@@ -990,9 +989,7 @@ impl Ui {
     ///
     /// NOTE: If you don't need to redraw your conrod GUI every frame, it is recommended to use the
     /// `Ui::draw_if_changed` method instead.
-    pub fn draw<'a, Img>(&'a mut self, image_map: &'a image::Map<Img>)
-        -> render::Primitives<'a, Img>
-    {
+    pub fn draw(&mut self) -> render::Primitives {
         let Ui {
             ref mut redraw_count,
             ref widget_graph,
@@ -1011,10 +1008,7 @@ impl Ui {
             *redraw_count -= 1;
         }
 
-        // We're about to draw, so we can reset the image::Map's redraw trigger.
-        image_map.trigger_redraw.set(false);
-
-        render::Primitives::new(widget_graph, indices, theme, fonts, [win_w, win_h], image_map)
+        render::Primitives::new(widget_graph, indices, theme, fonts, [win_w, win_h])
     }
 
 
@@ -1032,15 +1026,9 @@ impl Ui {
     /// This ensures that conrod is drawn to each buffer in the case that there is buffer swapping
     /// happening. Let us know if you need finer control over this and we'll expose a way for you
     /// to set the redraw count manually.
-    pub fn draw_if_changed<'a, Img>(&'a mut self, image_map: &'a image::Map<Img>)
-        -> Option<render::Primitives<'a, Img>>
-    {
-        if image_map.trigger_redraw.get() {
-            self.needs_redraw();
-        }
-
+    pub fn draw_if_changed(&mut self) -> Option<render::Primitives> {
         if self.redraw_count > 0 {
-            return Some(self.draw(image_map))
+            return Some(self.draw())
         }
 
         None


### PR DESCRIPTION
I started on this after overflowing the stack on main in a personal project with a particularly large GUI. In conrod the user builds new widgets by instantiating other widgets within the `Widget::update` method. This normally isn't an issue but can lead to very large stack sizes when the widget hierarchy gets very deep. Rust currently does not provide a portable way of requesting a greater stack size for the main thread, however it does for spawning child threads. This lead me to want to instantiate the `Ui` on a dedicated thread (with a larger stack size), which in turn lead me to requiring an "owned" version of the `Primitives` type so that I could still send rendering data to main.

This also removes the `image::Map` field from the Primitives type in favour of passing it directly to the backend as necessary. This simplifies cases where the `Ui` is running on a thread other than main. As a result however, there is no longer any way for the `image::Map` to notify the `Ui` of when a redraw is necessary due to some mutation of state. For now the user is required to manually check whether redraw is required via the `image::Map`'s `trigger_redraw` field (which will also need to be manually reset after drawing) until we can come up with a nicer automated solution.

I also added new functions to the `piston` and `piston_draw` backends for drawing individual `Primitive`s.