### PR TITLE
Bump minor version to publish recent breaking changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.38.2"
+version = "0.39.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"


### PR DESCRIPTION
Breakages include:

- Renaming `frame` to `border` throughout the crate #764 
- Removed `image::Map` param from `Ui`'s draw methods #773 
- Added `UiBuilder` type to replace `Ui::new` #770 