### PR TITLE
[Breaking Change] Add new `Widget::Event` associated type as a replacement for the `react` closure convention.

### DIFF
--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -109,22 +109,27 @@ fn set_widgets(ref mut ui: conrod::UiCell) {
     widget::Text::new("BAZ!").color(color::WHITE).font_size(36).middle_of(TAB_BAZ).set(BAZ_LABEL, ui);
 
     let footer_wh = ui.wh_of(FOOTER).unwrap();
-    widget::Matrix::new(COLS, ROWS)
+    let mut elements = widget::Matrix::new(COLS, ROWS)
         .w_h(footer_wh[0], footer_wh[1] * 2.0)
         .mid_top_of(FOOTER)
-        .each_widget(|n, _col, _row| {
-            widget::Button::new()
-                .color(color::BLUE.with_luminance(n as f32 / (COLS * ROWS) as f32))
-                .react(move || println!("Hey! {:?}", n))
-        })
         .set(BUTTON_MATRIX, ui);
+    while let Some(elem) = elements.next(ui) {
+        let (r, c) = (elem.row, elem.col);
+        let n = c + r * c;
+        let luminance = n as f32 / (COLS * ROWS) as f32;
+        let button = widget::Button::new().color(color::BLUE.with_luminance(luminance));
+        for _click in elem.set(button, ui) {
+            println!("Hey! {:?}", (r, c));
+        }
+    }
 
-    widget::Button::new().color(color::RED).w_h(30.0, 30.0).middle_of(FLOATING_A)
-        .react(|| println!("Bing!"))
-        .set(BING, ui);
-    widget::Button::new().color(color::RED).w_h(30.0, 30.0).middle_of(FLOATING_B)
-        .react(|| println!("Bong!"))
-        .set(BONG, ui);
+    let button = widget::Button::new().color(color::RED).w_h(30.0, 30.0);
+    for _click in button.clone().middle_of(FLOATING_A).set(BING, ui) {
+        println!("Bing!");
+    }
+    for _click in button.middle_of(FLOATING_B).set(BONG, ui) {
+        println!("Bong!");
+    }
 }
 
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -54,12 +54,14 @@ fn main() {
                 widget::Canvas::new().pad(40.0).set(CANVAS, ui);
 
                 // Draw the button and increment `count` if pressed.
-                widget::Button::new()
+                for _click in widget::Button::new()
                     .middle_of(CANVAS)
                     .w_h(80.0, 80.0)
                     .label(&count.to_string())
-                    .react(|| count += 1)
-                    .set(COUNTER, ui);
+                    .set(COUNTER, ui)
+                {
+                    count += 1;
+                }
             });
         });
 

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -35,7 +35,7 @@ fn main() {
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
 
-    let conrod_directory = find_folder::Search::KidsThenParents(3, 5).for_folder("conrod").unwrap();
+    let directory = find_folder::Search::KidsThenParents(3, 5).for_folder("conrod").unwrap();
 
     // Poll events from the window.
     while let Some(event) = window.next() {
@@ -56,13 +56,15 @@ fn main() {
                 widget::Canvas::new().color(conrod::color::DARK_CHARCOAL).set(CANVAS, ui);
 
                 // Navigate the conrod directory only showing `.rs` and `.toml` files.
-                widget::FileNavigator::with_extension(&conrod_directory, &["rs", "toml"])
+                for event in widget::FileNavigator::with_extension(&directory, &["rs", "toml"])
                     .color(conrod::color::LIGHT_BLUE)
                     .font_size(16)
                     .wh_of(CANVAS)
                     .middle_of(CANVAS)
-                    .react(|event| println!("{:?}", &event))
-                    .set(FILE_NAVIGATOR, ui);
+                    .set(FILE_NAVIGATOR, ui)
+                {
+                    println!("{:?}", event);
+                }
             });
 
         });

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -67,20 +67,27 @@ fn set_ui(ref mut ui: conrod::UiCell, list: &mut [bool]) {
     widget::Canvas::new().color(conrod::color::DARK_CHARCOAL).set(CANVAS, ui);
 
     const ITEM_HEIGHT: conrod::Scalar = 50.0;
+    let num_items = list.len() as u32;
 
-    widget::List::new(list.len() as u32, ITEM_HEIGHT)
+    let (mut items, scrollbar) = widget::List::new(num_items, ITEM_HEIGHT)
         .scrollbar_on_top()
         .middle_of(CANVAS)
         .wh_of(CANVAS)
-        .item(|item| {
-            let i = item.i;
-            let label = format!("item {}: {}", i, list[i]);
-            let toggle = widget::Toggle::new(list[i])
-                .label(&label)
-                .label_color(conrod::color::WHITE)
-                .color(conrod::color::LIGHT_BLUE)
-                .react(|v| list[i] = v);
-            item.set(toggle);
-        })
         .set(LIST, ui);
+
+    while let Some(item) = items.next(ui) {
+        let i = item.i;
+        let label = format!("item {}: {}", i, list[i]);
+        let toggle = widget::Toggle::new(list[i])
+            .label(&label)
+            .label_color(conrod::color::WHITE)
+            .color(conrod::color::LIGHT_BLUE);
+        for v in item.set(toggle, ui) {
+            list[i] = v;
+        }
+    }
+
+    if let Some(scrollbar) = scrollbar {
+        scrollbar.set(ui);
+    }
 }

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -72,16 +72,18 @@ fn set_ui(ref mut ui: conrod::UiCell, oval_range: &mut (conrod::Scalar, conrod::
     let (ref mut start, ref mut end) = *oval_range;
     let min = 0.0;
     let max = 1.0;
-    widget::RangeSlider::new(*start, *end, min, max)
+    for (edge, value) in widget::RangeSlider::new(*start, *end, min, max)
         .color(color::LIGHT_BLUE)
         .padded_w_of(CANVAS, PAD)
         .h(30.0)
         .mid_top_with_margin_on(CANVAS, PAD)
-        .react(|edge, value| match edge {
+        .set(RANGE_SLIDER, ui)
+    {
+        match edge {
             widget::range_slider::Edge::Start => *start = value,
             widget::range_slider::Edge::End => *end = value,
-        })
-        .set(RANGE_SLIDER, ui);
+        }
+    }
 
     let range_slider_w = ui.w_of(RANGE_SLIDER).unwrap();
     let w = (*end - *start) * range_slider_w;

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -70,12 +70,14 @@ fn set_ui(ref mut ui: conrod::UiCell, demo_text: &mut String) {
 
     widget::Canvas::new().color(color::DARK_CHARCOAL).set(CANVAS, ui);
 
-    widget::TextEdit::new(demo_text)
+    for edit in widget::TextEdit::new(demo_text)
         .color(color::LIGHT_BLUE)
         .padded_wh_of(CANVAS, 20.0)
         .mid_top_of(CANVAS)
         .align_text_x_middle()
         .line_spacing(2.5)
-        .react(|_: &mut String| {})
-        .set(TEXT_EDIT, ui);
+        .set(TEXT_EDIT, ui)
+    {
+        *demo_text = edit;
+    }
 }

--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -93,7 +93,6 @@ fn ui_should_reset_global_input_after_widget_are_set() {
         widget::Button::new()
             .w_h(100.0, 200.0)
             .label("MyButton")
-            .react(|| {})
             .bottom_right_of(CANVAS_ID)
             .set(BUTTON_ID, ui);
     });

--- a/src/widget/bordered_rectangle.rs
+++ b/src/widget/bordered_rectangle.rs
@@ -68,6 +68,7 @@ impl BorderedRectangle {
 impl Widget for BorderedRectangle {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -89,7 +90,7 @@ impl Widget for BorderedRectangle {
     }
 
     /// Update the state of the Rectangle.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { idx, state, style, rect, mut ui, .. } = args;
 
         let border = style.border(&ui.theme);

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -214,6 +214,7 @@ impl<'a> Canvas<'a> {
 impl<'a> Widget for Canvas<'a> {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common

--- a/src/widget/plot_path.rs
+++ b/src/widget/plot_path.rs
@@ -62,6 +62,7 @@ impl<X, Y, F> Widget for PlotPath<X, Y, F>
 {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -82,7 +83,7 @@ impl<X, Y, F> Widget for PlotPath<X, Y, F>
     }
 
     /// Update the state of the PlotPath.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
 
         let widget::UpdateArgs { idx, state, style, rect, mut ui, .. } = args;
         let PlotPath { min_x, max_x, min_y, max_y, mut f, .. } = self;

--- a/src/widget/primitive/image.rs
+++ b/src/widget/primitive/image.rs
@@ -85,6 +85,7 @@ impl Image {
 impl Widget for Image {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -118,7 +119,7 @@ impl Widget for Image {
         }
     }
 
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { state, .. } = args;
         let Image { src_rect, .. } = self;
 

--- a/src/widget/primitive/line.rs
+++ b/src/widget/primitive/line.rs
@@ -256,6 +256,7 @@ impl Style {
 impl Widget for Line {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -277,7 +278,7 @@ impl Widget for Line {
     }
 
     /// Update the state of the Line.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { rect, state, .. } = args;
         let Line { mut start, mut end, should_centre_points, .. } = self;
 

--- a/src/widget/primitive/point_path.rs
+++ b/src/widget/primitive/point_path.rs
@@ -157,6 +157,7 @@ impl<I> Widget for PointPath<I>
 {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -177,7 +178,7 @@ impl<I> Widget for PointPath<I>
     }
 
     /// Update the state of the Line.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         use utils::{iter_diff, IterDiff};
         let widget::UpdateArgs { rect, state, .. } = args;
         let PointPath { points, maybe_shift_to_centre_from, .. } = self;

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -55,6 +55,7 @@ impl Oval {
 impl Widget for Oval {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -72,7 +73,7 @@ impl Widget for Oval {
         self.style.clone()
     }
 
-    fn update(self, _args: widget::UpdateArgs<Self>) {
+    fn update(self, _args: widget::UpdateArgs<Self>) -> Self::Event {
         // Nothing to be updated here.
     }
 

--- a/src/widget/primitive/shape/polygon.rs
+++ b/src/widget/primitive/shape/polygon.rs
@@ -181,6 +181,7 @@ impl<I> Widget for Polygon<I>
 {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -202,7 +203,7 @@ impl<I> Widget for Polygon<I>
     }
 
     /// Update the state of the Polygon.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         use utils::{iter_diff, IterDiff};
         let widget::UpdateArgs { rect, state, style, .. } = args;
         let Polygon { points, maybe_shift_to_centre_from, .. } = self;

--- a/src/widget/primitive/shape/rectangle.rs
+++ b/src/widget/primitive/shape/rectangle.rs
@@ -69,6 +69,7 @@ impl Rectangle {
 impl Widget for Rectangle {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -89,7 +90,7 @@ impl Widget for Rectangle {
     }
 
     /// Update the state of the Rectangle.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { state, style, .. } = args;
 
         let kind = match *style {

--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -144,6 +144,7 @@ impl<'a> Text<'a> {
 impl<'a> Widget for Text<'a> {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -225,7 +226,7 @@ impl<'a> Widget for Text<'a> {
     }
 
     /// Update the state of the Text.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { rect, state, style, ui, .. } = args;
         let Text { text, .. } = self;
 

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -136,6 +136,7 @@ impl<A> Widget for Scrollbar<A>
 {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -164,7 +165,7 @@ impl<A> Widget for Scrollbar<A>
         A::default_y_dimension(self, ui)
     }
 
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { idx, state, rect, style, mut ui, .. } = args;
         let Scrollbar { widget, .. } = self;
 

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -168,6 +168,7 @@ impl<'a> Tabs<'a> {
 impl<'a> Widget for Tabs<'a> {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -281,7 +282,7 @@ impl<'a> Widget for Tabs<'a> {
                 let (xy, dim) = tab_rect.xy_dim();
 
                 // We'll instantiate each selectable **Tab** as a **Button** widget.
-                widget::Button::new()
+                if widget::Button::new()
                     .wh(dim)
                     .xy_relative_to(idx, xy)
                     .color(color)
@@ -290,8 +291,11 @@ impl<'a> Widget for Tabs<'a> {
                     .label(label)
                     .label_color(label_color)
                     .parent(idx)
-                    .react(|| maybe_selected_tab_idx = Some(i))
-                    .set(tab.button_idx, &mut ui);
+                    .set(tab.button_idx, &mut ui)
+                    .was_clicked()
+                {
+                    maybe_selected_tab_idx = Some(i);
+                }
 
                 i += 1;
             }

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -633,10 +633,13 @@ impl<'a> Widget for TextEdit<'a> {
             state.update(|state| state.drag = drag);
         }
 
-        let event = match text {
-            std::borrow::Cow::Borrowed(_) => None,
-            std::borrow::Cow::Owned(ref s) => Some(s.clone()),
-        };
+        /// Takes the `String` from the `Cow` if the `Cow` is `Owned`.
+        fn take_if_owned(text: std::borrow::Cow<str>) -> Option<String> {
+            match text {
+                std::borrow::Cow::Borrowed(_) => None,
+                std::borrow::Cow::Owned(s) => Some(s),
+            }
+        }
 
         let color = style.color(ui.theme());
         let font_size = style.font_size(ui.theme());
@@ -646,8 +649,8 @@ impl<'a> Widget for TextEdit<'a> {
         let text_rect = Rect { x: rect.x, y: text_y_range };
 
         match line_wrap {
-            Wrap::Whitespace => widget::Text::new(&self.text).wrap_by_word(),
-            Wrap::Character => widget::Text::new(&self.text).wrap_by_character(),
+            Wrap::Whitespace => widget::Text::new(&text).wrap_by_word(),
+            Wrap::Character => widget::Text::new(&text).wrap_by_character(),
         }
             .wh(text_rect.dim())
             .xy(text_rect.xy())
@@ -666,7 +669,7 @@ impl<'a> Widget for TextEdit<'a> {
 
         // If this widget is not capturing the keyboard, no need to draw cursor or selection.
         if ui.global_input().current.widget_capturing_keyboard != Some(idx) {
-            return event;
+            return take_if_owned(text);
         }
 
         // TODO: Simplify this block.
@@ -728,7 +731,7 @@ impl<'a> Widget for TextEdit<'a> {
             }
         }
 
-        event
+        take_if_owned(text)
     }
 
 }

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -27,11 +27,9 @@ use widget::primitive::text::Wrap;
 ///
 /// By default the text is wrapped via the first whitespace before the line exceeds the
 /// `TextEdit`'s width, however a user may change this using the `.wrap_by_character` method.
-pub struct TextEdit<'a, F> {
+pub struct TextEdit<'a> {
     common: widget::CommonBuilder,
-    text: &'a mut String,
-    /// The reaction for the TextEdit.
-    pub maybe_react: Option<F>,
+    text: &'a str,
     style: Style,
 }
 
@@ -97,14 +95,13 @@ pub enum Cursor {
 }
 
 
-impl<'a, F> TextEdit<'a, F> {
+impl<'a> TextEdit<'a> {
 
     /// Construct a TextEdit widget.
-    pub fn new(text: &'a mut String) -> Self {
+    pub fn new(text: &'a str) -> Self {
         TextEdit {
             common: widget::CommonBuilder::new(),
             text: text,
-            maybe_react: None,
             style: Style::new(),
         }
     }
@@ -162,7 +159,6 @@ impl<'a, F> TextEdit<'a, F> {
 
     builder_methods!{
         pub font_size { style.font_size = Some(FontSize) }
-        pub react { maybe_react = Some(F) }
         pub x_align_text { style.x_align = Some(Align) }
         pub y_align_text { style.y_align = Some(Align) }
         pub line_wrap { style.line_wrap = Some(Wrap) }
@@ -172,11 +168,14 @@ impl<'a, F> TextEdit<'a, F> {
 
 }
 
-impl<'a, F> Widget for TextEdit<'a, F>
-    where F: FnMut(&mut String),
-{
+impl<'a> Widget for TextEdit<'a> {
     type State = State;
     type Style = Style;
+    // TODO: We should create a more specific `Event` type that:
+    // - Allows for mutating an existing `String` directly
+    // - Enumerates possible mutations (i.e. InsertChar, RemoveCharRange, etc).
+    // - Enumerates cursor movement and range selection.
+    type Event = Option<String>;
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -204,9 +203,10 @@ impl<'a, F> Widget for TextEdit<'a, F>
     }
 
     /// Update the state of the TextEdit.
-    fn update(self, args: widget::UpdateArgs<Self>) {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { idx, state, rect, style, mut ui, .. } = args;
         let TextEdit { text, .. } = self;
+        let mut text = std::borrow::Cow::Borrowed(text);
 
         // Retrieve the `font_id`, as long as a valid `Font` for it still exists.
         //
@@ -216,7 +216,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
             .and_then(|id| ui.fonts.get(id).map(|_| id))
         {
             Some(font_id) => font_id,
-            None => return,
+            None => return None,
         };
 
         let font_size = style.font_size(ui.theme());
@@ -248,7 +248,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
             let maybe_new_line_infos = {
                 let line_info_slice = &state.line_infos[..];
                 let font = ui.fonts.get(font_id).unwrap();
-                let new_line_infos = line_infos(text, font, font_size, line_wrap, rect.w());
+                let new_line_infos = line_infos(&text, font, font_size, line_wrap, rect.w());
                 match utils::write_if_different(line_info_slice, new_line_infos) {
                     std::borrow::Cow::Owned(new) => Some(new),
                     _ => None,
@@ -349,7 +349,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
                         let abs_xy = utils::vec2_add(rel_xy, rect.xy());
                         let infos = &state.line_infos;
                         let font = ui.fonts.get(font_id).unwrap();
-                        let closest = closest_cursor_index_and_xy(abs_xy, text, infos, font);
+                        let closest = closest_cursor_index_and_xy(abs_xy, &text, infos, font);
                         if let Some((closest_cursor, _)) = closest {
                             cursor = Cursor::Idx(closest_cursor);
                         }
@@ -375,7 +375,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                         if idx > 0 {
                                             let idx_to_remove = idx - 1;
 
-                                            *text = text.chars().take(idx_to_remove)
+                                            *text.to_mut() = text.chars().take(idx_to_remove)
                                                 .chain(text.chars().skip(idx))
                                                 .collect();
 
@@ -383,7 +383,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                                 let font = ui.fonts.get(font_id).unwrap();
                                                 let w = rect.w();
                                                 state.line_infos =
-                                                    line_infos(text, font, font_size, line_wrap, w)
+                                                    line_infos(&text, font, font_size, line_wrap, w)
                                                         .collect();
                                             });
 
@@ -416,14 +416,14 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                             .expect("char index was out of range")
                                     };
                                     cursor = Cursor::Idx(new_cursor_idx);
-                                    *text = text.chars().take(start_idx)
+                                    *text.to_mut() = text.chars().take(start_idx)
                                         .chain(text.chars().skip(end_idx))
                                         .collect();
                                     state.update(|state| {
                                         let font = ui.fonts.get(font_id).unwrap();
                                         let w = rect.w();
                                         state.line_infos =
-                                            line_infos(text, font, font_size, line_wrap, w)
+                                            line_infos(&text, font, font_size, line_wrap, w)
                                                 .collect();
                                     });
                                 },
@@ -582,7 +582,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
                         let new_cursor = Cursor::Idx(new_cursor_idx);
 
                         // Update the text, cursor and line_infos.
-                        *text = new_text;
+                        *text.to_mut() = new_text;
                         cursor = new_cursor;
                         state.update(|state| state.line_infos = new_line_infos);
                     }
@@ -601,7 +601,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
                                 let abs_xy = utils::vec2_add(drag_event.to, rect.xy());
                                 let infos = &state.line_infos;
                                 let font = ui.fonts.get(font_id).unwrap();
-                                match closest_cursor_index_and_xy(abs_xy, text, infos, font) {
+                                match closest_cursor_index_and_xy(abs_xy, &text, infos, font) {
                                     Some((end_cursor_idx, _)) =>
                                         cursor = Cursor::Selection {
                                             start: start_cursor_idx,
@@ -633,6 +633,11 @@ impl<'a, F> Widget for TextEdit<'a, F>
             state.update(|state| state.drag = drag);
         }
 
+        let event = match text {
+            std::borrow::Cow::Borrowed(_) => None,
+            std::borrow::Cow::Owned(ref s) => Some(s.clone()),
+        };
+
         let color = style.color(ui.theme());
         let font_size = style.font_size(ui.theme());
         let num_lines = state.line_infos.iter().count();
@@ -661,7 +666,7 @@ impl<'a, F> Widget for TextEdit<'a, F>
 
         // If this widget is not capturing the keyboard, no need to draw cursor or selection.
         if ui.global_input().current.widget_capturing_keyboard != Some(idx) {
-            return;
+            return event;
         }
 
         // TODO: Simplify this block.
@@ -722,11 +727,13 @@ impl<'a, F> Widget for TextEdit<'a, F>
                     .set(selected_rectangle_idx, &mut ui);
             }
         }
+
+        event
     }
 
 }
 
 
-impl<'a, F> Colorable for TextEdit<'a, F> {
+impl<'a> Colorable for TextEdit<'a> {
     builder_method!(color { style.color = Some(Color) });
 }

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -109,6 +109,7 @@ pub fn calc_height(font_size: FontSize) -> Scalar {
 impl<'a> Widget for TitleBar<'a> {
     type State = State;
     type Style = Style;
+    type Event = ();
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common


### PR DESCRIPTION
This new associated type is intended as a replacement for the current ad-hoc convention of using `react` closures. By allowing each `Widget` to return its own unique event type we avoid ownership issues, support more flexible control flow (important for error handling) and no longer require awkward react builder methods or type params. See #741 for a more detailed listing of the motivations behind this PR.

As a nice side effect, the APIs for several widgets have changed slightly. All widgets that used to take a mutable reference to the data they controlled now take immutable references instead. The mutations are now performed directly after widget instantiation using the produced `Widget::Event` types. This solves some awkward ownership issues that would result from the widget uniquely borrowing the data.

This closes #741.