### PR TITLE
Implemented issue 746: Add a method to `FileNavigator` for optionally...

### DIFF
--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -61,6 +61,7 @@ fn main() {
                 .font_size(16)
                 .wh_of(CANVAS)
                 .middle_of(CANVAS)
+                //.show_hidden_files(true)  // Use this to show hidden files
                 .set(FILE_NAVIGATOR, ui)
             {
                 println!("{:?}", event);

--- a/src/widget/file_navigator.rs
+++ b/src/widget/file_navigator.rs
@@ -495,11 +495,11 @@ pub mod directory_view {
         KeyPress(Vec<std::path::PathBuf>, event::KeyPress),
     }
 
-    #[cfg(all(target_os = "windows", not(windows_metadataext)))]
+    #[cfg(all(target_os = "windows", not(feature = "windows_metadataext")))]
     fn is_file_hidden(_path: &std::path::PathBuf) -> bool {
         false
     }
-    #[cfg(all(target_os = "windows", windows_metadataext))]
+    #[cfg(all(target_os = "windows", feature = "windows_metadataext"))]
     /// Check if a file is hidden on windows, using the file attributes.
     /// To be enabled once windows::fs::MetadataExt is no longer an unstable API.
     fn is_file_hidden(path: &std::path::PathBuf) -> bool {
@@ -521,9 +521,9 @@ pub mod directory_view {
     /// Check if a file is hidden on any other OS than windows, using the dot file namings.
     fn is_file_hidden(path: &std::path::PathBuf) -> bool {
         let name = path.file_name();
-        println!("Linux metadataext");
+
         if let Some(name) = name {
-            return name.to_string_lossy().to_owned().starts_with(".");
+            return name.to_string_lossy().starts_with(".");
         }
         false
     }

--- a/src/widget/file_navigator.rs
+++ b/src/widget/file_navigator.rs
@@ -149,8 +149,7 @@ impl<'a> FileNavigator<'a> {
         self
     }
 
-    /// Whether to show hidden files and directories. On Windows a hidden file is identified
-    /// by a file attribute flag, on other OSs the file name starts with a '.'.
+    /// Whether to show hidden files and directories.
     pub fn show_hidden_files(mut self, show_hidden: bool) -> Self {
         self.show_hidden = show_hidden;
         self
@@ -496,8 +495,13 @@ pub mod directory_view {
         KeyPress(Vec<std::path::PathBuf>, event::KeyPress),
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", not(windows_metadataext)))]
+    fn is_file_hidden(_path: &std::path::PathBuf) -> bool {
+        false
+    }
+    #[cfg(all(target_os = "windows", windows_metadataext))]
     /// Check if a file is hidden on windows, using the file attributes.
+    /// To be enabled once windows::fs::MetadataExt is no longer an unstable API.
     fn is_file_hidden(path: &std::path::PathBuf) -> bool {
 
         use std::os::windows::fs::MetadataExt;
@@ -517,6 +521,7 @@ pub mod directory_view {
     /// Check if a file is hidden on any other OS than windows, using the dot file namings.
     fn is_file_hidden(path: &std::path::PathBuf) -> bool {
         let name = path.file_name();
+        println!("Linux metadataext");
         if let Some(name) = name {
             return name.to_string_lossy().to_owned().starts_with(".");
         }

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -232,8 +232,8 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
             // If set, a widget event was generated. Set in inner closure
             let mut list_index_event: Option<usize> = None;
 
-            let mut txt_col = unsel_text_color;
-            let mut rect_col = unsel_rect_color;
+            let mut txt_col;
+            let mut rect_col;
 
             let num_items = self.entries.len() as u32;
             let (mut list_items, list_scrollbar) = widget::List::new(num_items, rect_h)


### PR DESCRIPTION
… displaying hidden files and folders.

FileNavigator now defaults to not showing hidden files and directories. Have to be enabled with the show_hidden_files builder method.

Tested successfully on Linux Mint and Windows. Couldn't get my trusty 2006 MacBook Pro to install Rust due to Snow Leopard :(   

The implementation uses the unstable API mentioned in #746, I assumed we're using the nightly compiler.