### PR TITLE
Refactor the `Ui::set_widgets` method to be more control-flow friendly [Slightly Breaking]

### DIFF
--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -135,9 +135,8 @@ fn main() {
 
         // We'll set all our widgets in a single function called `set_widgets`.
         event.update(|_| {
-            ui.set_widgets(|mut ui| {
-                set_widgets(&mut ui, &mut app);
-            });
+            let mut ui = ui.set_widgets();
+            set_widgets(&mut ui, &mut app);
         });
 
         // Draw our Ui!

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -43,7 +43,7 @@ fn main() {
         }
 
         event.update(|_| {
-            ui.set_widgets(set_widgets)
+            set_widgets(ui.set_widgets());
         });
 
         window.draw_2d(&event, |c, g| {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -45,24 +45,23 @@ fn main() {
 
         // `Update` the widgets.
         event.update(|_| {
-            ui.set_widgets(|ref mut ui| {
+            let ui = &mut ui.set_widgets();
 
-                // Generate the ID for the Button COUNTER.
-                widget_ids!(CANVAS, COUNTER);
+            // Generate the ID for the Button COUNTER.
+            widget_ids!(CANVAS, COUNTER);
 
-                // Create a background canvas upon which we'll place the button.
-                widget::Canvas::new().pad(40.0).set(CANVAS, ui);
+            // Create a background canvas upon which we'll place the button.
+            widget::Canvas::new().pad(40.0).set(CANVAS, ui);
 
-                // Draw the button and increment `count` if pressed.
-                for _click in widget::Button::new()
-                    .middle_of(CANVAS)
-                    .w_h(80.0, 80.0)
-                    .label(&count.to_string())
-                    .set(COUNTER, ui)
-                {
-                    count += 1;
-                }
-            });
+            // Draw the button and increment `count` if pressed.
+            for _click in widget::Button::new()
+                .middle_of(CANVAS)
+                .w_h(80.0, 80.0)
+                .label(&count.to_string())
+                .set(COUNTER, ui)
+            {
+                count += 1;
+            }
         });
 
         // Draw the `Ui` if it has changed.

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -263,7 +263,8 @@ pub fn main() {
             ui.handle_event(e);
         }
 
-        event.update(|_| ui.set_widgets(|ref mut ui| {
+        event.update(|_| {
+            let ui = &mut ui.set_widgets();
 
             // Sets a color to clear the background with before the Ui draws our widget.
             widget::Canvas::new().color(conrod::color::DARK_RED).set(BACKGROUND, ui);
@@ -289,7 +290,7 @@ pub fn main() {
             {
                 println!("Click!");
             }
-        }));
+        });
 
         // Draws the whole Ui (in this case, just our widget) whenever a change occurs.
         window.draw_2d(&event, |c, g| {

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -46,27 +46,25 @@ fn main() {
         }
 
         event.update(|_| {
+            use conrod::{widget, Colorable, Positionable, Sizeable, Widget};
 
             // Instantiate the conrod widgets.
-            ui.set_widgets(|ref mut ui| {
-                use conrod::{widget, Colorable, Positionable, Sizeable, Widget};
+            let ui = &mut ui.set_widgets();
 
-                widget_ids!(CANVAS, FILE_NAVIGATOR);
+            widget_ids!(CANVAS, FILE_NAVIGATOR);
 
-                widget::Canvas::new().color(conrod::color::DARK_CHARCOAL).set(CANVAS, ui);
+            widget::Canvas::new().color(conrod::color::DARK_CHARCOAL).set(CANVAS, ui);
 
-                // Navigate the conrod directory only showing `.rs` and `.toml` files.
-                for event in widget::FileNavigator::with_extension(&directory, &["rs", "toml"])
-                    .color(conrod::color::LIGHT_BLUE)
-                    .font_size(16)
-                    .wh_of(CANVAS)
-                    .middle_of(CANVAS)
-                    .set(FILE_NAVIGATOR, ui)
-                {
-                    println!("{:?}", event);
-                }
-            });
-
+            // Navigate the conrod directory only showing `.rs` and `.toml` files.
+            for event in widget::FileNavigator::with_extension(&directory, &["rs", "toml"])
+                .color(conrod::color::LIGHT_BLUE)
+                .font_size(16)
+                .wh_of(CANVAS)
+                .middle_of(CANVAS)
+                .set(FILE_NAVIGATOR, ui)
+            {
+                println!("{:?}", event);
+            }
         });
 
         window.draw_2d(&event, |c, g| {

--- a/examples/glutin_glium.rs
+++ b/examples/glutin_glium.rs
@@ -265,7 +265,7 @@ mod feature {
             }
 
             // Update all widgets within the `Ui`.
-            ui.set_widgets(|ui| set_widgets(ui));
+            set_widgets(ui.set_widgets());
 
             // Avoid hogging the CPU.
             std::thread::sleep(std::time::Duration::from_millis(10));

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -54,12 +54,13 @@ fn main() {
             }
         });
 
-        event.update(|_| ui.set_widgets(|mut ui| {
+        event.update(|_| {
+            let ui = &mut ui.set_widgets();
             // Draw a light blue background.
-            widget::Canvas::new().color(color::LIGHT_BLUE).set(BACKGROUND, &mut ui);
+            widget::Canvas::new().color(color::LIGHT_BLUE).set(BACKGROUND, ui);
             // Instantiate the `Image` at its full size in the middle of the window.
-            widget::Image::new().w_h(w as f64, h as f64).middle().set(RUST_LOGO, &mut ui);
-        }));
+            widget::Image::new().w_h(w as f64, h as f64).middle().set(RUST_LOGO, ui);
+        });
     }
 }
 

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -42,7 +42,7 @@ fn main() {
         }
 
         event.update(|_| {
-            ui.set_widgets(|ui_cell| set_ui(ui_cell, &mut list))
+            set_ui(ui.set_widgets(), &mut list);
         });
 
         window.draw_2d(&event, |c, g| {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -69,38 +69,39 @@ fn main() {
         }
 
         event.update(|_| {
+            use conrod::{widget, color, Colorable, Positionable, Sizeable, Widget};
+
             // Instantiate the conrod widgets.
-            ui.set_widgets(|ref mut ui| {
-                use conrod::{widget, color, Colorable, Positionable, Sizeable, Widget};
+            let ui = &mut ui.set_widgets();
 
-                widget_ids!(CANVAS, LIST_BOX);
+            widget_ids!(CANVAS, LIST_BOX);
 
-                widget::Canvas::new().color(color::BLUE).set(CANVAS, ui);
+            widget::Canvas::new().color(color::BLUE).set(CANVAS, ui);
 
-                widget::ListSelect::multiple(&list_items, &mut list_selected)
-                    .w_h(350.0, 220.0)
-                    .top_left_with_margins_on(CANVAS, 40.0, 40.0)
-                    .color(color::LIGHT_GREY)
-                    .selected_color(color::LIGHT_BLUE)
-                    .text_color(color::BLACK)
-                    .selected_text_color(color::YELLOW)
-                    .font_size(16)
-                    .scrollbar_auto_hide(false)
-                    .react(|event| {
-                        match event {
-                            widget::list_select::Event::SelectEntry(ix, name) =>
-                                println!("Select Entry: {}, {}", ix, name),
-                            widget::list_select::Event::SelectEntries(list)	=>
-                                println!("Select Entries: {:?}", list),
-                            widget::list_select::Event::DoubleClick(ix, name) =>
-                                println!("Double Click: {}, {}", ix, name),
-                            widget::list_select::Event::KeyPress(list, kp) =>
-                                println!("Keypress: {:?}, {:?}", kp, list),
-                        }
-                    })
-                    .set(LIST_BOX, ui);
-                });
+            widget::ListSelect::multiple(&list_items, &mut list_selected)
+                .w_h(350.0, 220.0)
+                .top_left_with_margins_on(CANVAS, 40.0, 40.0)
+                .color(color::LIGHT_GREY)
+                .selected_color(color::LIGHT_BLUE)
+                .text_color(color::BLACK)
+                .selected_text_color(color::YELLOW)
+                .font_size(16)
+                .scrollbar_auto_hide(false)
+                .react(|event| {
+                    match event {
+                        widget::list_select::Event::SelectEntry(ix, name) =>
+                            println!("Select Entry: {}, {}", ix, name),
+                        widget::list_select::Event::SelectEntries(list)	=>
+                            println!("Select Entries: {:?}", list),
+                        widget::list_select::Event::DoubleClick(ix, name) =>
+                            println!("Double Click: {}, {}", ix, name),
+                        widget::list_select::Event::KeyPress(list, kp) =>
+                            println!("Keypress: {:?}, {:?}", kp, list),
+                    }
+                })
+                .set(LIST_BOX, ui);
         });
+
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -34,7 +34,7 @@ fn main() {
             ui.handle_event(e);
         }
 
-        event.update(|_| ui.set_widgets(set_ui));
+        event.update(|_| set_ui(ui.set_widgets()));
 
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -34,7 +34,7 @@ fn main() {
         }
 
         // Update the widgets.
-        event.update(|_| ui.set_widgets(set_ui));
+        event.update(|_| set_ui(ui.set_widgets()));
 
         // Draw the `Ui`.
         window.draw_2d(&event, |c, g| {

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -44,7 +44,7 @@ fn main() {
         }
 
         event.update(|_| {
-            ui.set_widgets(|ui_cell| set_ui(ui_cell, &mut oval_range));
+            set_ui(ui.set_widgets(), &mut oval_range);
         });
 
         window.draw_2d(&event, |c, g| {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -45,7 +45,7 @@ fn main() {
             ui.handle_event(e);
         }
 
-        event.update(|_| ui.set_widgets(set_ui));
+        event.update(|_| set_ui(ui.set_widgets()));
 
         window.draw_2d(&event, |c, g| {
             // Only re-draw if there was some change in the `Ui`.

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -47,7 +47,7 @@ fn main() {
             ui.handle_event(e);
         }
 
-        event.update(|_| ui.set_widgets(|ui_cell| set_ui(ui_cell, &mut demo_text)));
+        event.update(|_| set_ui(ui.set_widgets(), &mut demo_text));
 
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {

--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -85,7 +85,9 @@ fn ui_should_reset_global_input_after_widget_are_set() {
     left_click_mouse(&mut ui);
 
     assert!(ui.global_input.events().next().is_some());
-    ui.set_widgets(|ref mut ui| {
+
+    {
+        let ui = &mut ui.set_widgets();
 
         widget::Canvas::new()
             .color(Color::Rgba(1.0, 1.0, 1.0, 1.0))
@@ -95,7 +97,7 @@ fn ui_should_reset_global_input_after_widget_are_set() {
             .label("MyButton")
             .bottom_right_of(CANVAS_ID)
             .set(BUTTON_ID, ui);
-    });
+    }
 
     assert!(ui.global_input.events().next().is_none());
 }

--- a/src/widget/matrix.rs
+++ b/src/widget/matrix.rs
@@ -136,7 +136,7 @@ impl Widget for Matrix {
 
     /// Update the state of the Matrix.
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
-        let widget::UpdateArgs { idx, state, rect, style, mut ui, .. } = args;
+        let widget::UpdateArgs { idx, state, rect, style, ui, .. } = args;
         let Matrix { cols, rows, .. } = self;
 
         // First, check that we have the correct number of columns.


### PR DESCRIPTION
Rather than taking a FnOnce for user widget instantiation, we return the UiCell directly and rely on its destructor for finalisation of the widget setting stage. This should make result propagation and general control-flow a bit easier.