### PR TITLE
TextEdit move by word, move to end, fix layout bugs

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -512,15 +512,18 @@ pub mod cursor {
             let Index { line, char } = self;
             if char > 0 {
                 line_infos.nth(line).and_then(|line_info| {
+                    let line_count = line_info.char_range().count();
                     let mut chars_rev = (&text[line_info.byte_range()]).chars().rev();
+                    if char != line_count {
+                        chars_rev.nth(line_count - char - 1);
+                    }
                     let mut new_char = 0;
                     let mut hit_non_whitespace = false;
-                    chars_rev.nth(line_info.char_range().count() - char);
                     for (i, char_) in chars_rev.enumerate() {
                         // loop until word starts, then continue until the word ends
                         if !char_.is_whitespace() { hit_non_whitespace = true; }
                         if char_.is_whitespace() && hit_non_whitespace {
-                            new_char = char - (i + 1);
+                            new_char = char - i;
                             break
                         }
                     }
@@ -548,16 +551,19 @@ pub mod cursor {
             let Index { line, char } = self;
             line_infos.nth(line)
                 .and_then(|line_info| {
-                    if char < line_info.char_range().count() {
+                    let line_count = line_info.char_range().count();
+                    if char < line_count {
                         let mut chars = (&text[line_info.byte_range()]).chars();
-                        let mut new_char = line_info.char_range().count();
+                        let mut new_char = line_count;
                         let mut hit_non_whitespace = false;
-                        chars.nth(char);
+                        if char != 0 {
+                            chars.nth(char - 1);
+                        }
                         for (i, char_) in chars.enumerate() {
                             // loop until word starts, then continue until the word ends
                             if !char_.is_whitespace() { hit_non_whitespace = true; }
                             if char_.is_whitespace() && hit_non_whitespace {
-                                new_char = char + (i + 1);
+                                new_char = char + i;
                                 break
                             }
                         }

--- a/src/text.rs
+++ b/src/text.rs
@@ -506,7 +506,7 @@ pub mod cursor {
         /// the start of the word that precedes the whitespace
         ///
         /// If `self` is in the middle or end of a word, return the index of the start of that word
-        pub fn previous_word<I>(self, text: &str, mut line_infos: I) -> Option<Self>
+        pub fn previous_word_start<I>(self, text: &str, mut line_infos: I) -> Option<Self>
             where I: Iterator<Item=super::line::Info>,
         {
             let Index { line, char } = self;
@@ -533,14 +533,16 @@ pub mod cursor {
 
         /// The cursor index of the end of the first word (block of non-whitespace) after `self`.
         ///
-        /// If `self` is at the end of the line, call previous, which returns the last
-        /// index position of the previous line, or None if it's the first line
+        /// If `self` is at the end of the text, this returns `None`.
+        ///
+        /// If `self` is at the end of a line other than the last, this returns the first index of
+        /// the next line.
         ///
         /// If `self` points to whitespace, skip past that whitespace, then return the index of 
         /// the end of the word after the whitespace
         ///
         /// If `self` is in the middle or start of a word, return the index of the end of that word
-        pub fn next_word<I>(self, text: &str, mut line_infos: I) -> Option<Self>
+        pub fn next_word_end<I>(self, text: &str, mut line_infos: I) -> Option<Self>
             where I: Iterator<Item=super::line::Info>,
         {
             let Index { line, char } = self;

--- a/src/text.rs
+++ b/src/text.rs
@@ -1231,6 +1231,7 @@ pub mod line {
                     line_spacing: Scalar) -> Rects<I>
         where I: Iterator<Item=Info> + ExactSizeIterator,
     {
+        let num_lines = infos.len();
         let first_rect = infos.next().map(|first_info| {
 
             // Calculate the `x` `Range` of the first line `Rect`.
@@ -1242,7 +1243,6 @@ pub mod line {
             };
 
             // Calculate the `y` `Range` of the first line `Rect`.
-            let num_lines = infos.len();
             let total_text_height = super::height(num_lines, font_size, line_spacing);
             let total_text_y_range = Range::new(0.0, total_text_height);
             let total_text_y = match y_align {

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -474,45 +474,27 @@ impl<'a> Widget for TextEdit<'a> {
                             }
                         },
 
-                        input::Key::Left => {
+                        input::Key::Left | input::Key::Right => {
                             if !press.modifiers.contains(input::keyboard::CTRL) {
                                 match cursor {
-
                                     // Move the cursor to the previous position.
                                     Cursor::Idx(cursor_idx) => {
                                         let new_cursor_idx = {
                                             let line_infos = state.line_infos.iter().cloned();
-                                            cursor_idx.previous(line_infos).unwrap_or(cursor_idx)
+                                            match key {
+                                                input::Key::Left => cursor_idx.previous(line_infos).unwrap_or(cursor_idx)
+                                                input::Key::Right => cursor_idx.next(line_infos).unwrap_or(cursor_idx)
+                                            }
                                         };
                                         cursor = Cursor::Idx(new_cursor_idx);
                                     },
-
                                     // Move the cursor to the start of the current selection.
                                     Cursor::Selection { start, end } => {
+                                        let new_cursor_idx = match key {
+                                            input::Key::Left => std::cmp::min(start, end)
+                                            input::Key::Right => std::cmp::max(start, end)
+                                        }
                                         let new_cursor_idx = std::cmp::min(start, end);
-                                        cursor = Cursor::Idx(new_cursor_idx);
-                                    },
-                                }
-                            }
-                        },
-
-                        input::Key::Right => {
-                            if !press.modifiers.contains(input::keyboard::CTRL) {
-                                match cursor {
-
-                                    // Move the cursor to the next position.
-                                    Cursor::Idx(cursor_idx) => {
-                                        let new_cursor_idx = {
-                                            let line_infos = state.line_infos.iter().cloned();
-                                            cursor_idx.next(line_infos).unwrap_or(cursor_idx)
-                                        };
-
-                                        cursor = Cursor::Idx(new_cursor_idx);
-                                    },
-
-                                    // Move the cursor to the end of the current selection.
-                                    Cursor::Selection { start, end } => {
-                                        let new_cursor_idx = std::cmp::max(start, end);
                                         cursor = Cursor::Idx(new_cursor_idx);
                                     },
                                 }

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -554,8 +554,18 @@ impl<'a> Widget for TextEdit<'a> {
                         },
 
                         input::Key::E => {
-                            // If cursor is `Idx`, move cursor to end.
+                            // move cursor to end.
                             if press.modifiers.contains(input::keyboard::CTRL) {
+                                let mut line_infos = state.line_infos.iter().cloned();
+                                let line = line_infos.len() - 1;
+                                match line_infos.nth(line) {
+                                    Some(line_info) => {
+                                        let char = line_info.end_char() - line_info.start_char;
+                                        let new_cursor_idx = text::cursor::Index { line: line, char: char };
+                                        cursor = Cursor::Idx(new_cursor_idx);
+                                    },
+                                    _ => (),
+                                }
                             }
                         },
 

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -488,8 +488,8 @@ impl<'a> Widget for TextEdit<'a> {
                                     let new_cursor_idx = {
                                         let line_infos = state.line_infos.iter().cloned();
                                         match (left_move, move_word) {
-                                            (true, true) => cursor_idx.previous_word(&text, line_infos).unwrap_or(cursor_idx),
-                                            (false, true) => cursor_idx.next_word(&text, line_infos).unwrap_or(cursor_idx),
+                                            (true, true) => cursor_idx.previous_word_start(&text, line_infos).unwrap_or(cursor_idx),
+                                            (false, true) => cursor_idx.next_word_end(&text, line_infos).unwrap_or(cursor_idx),
                                             (true, false) => cursor_idx.previous(line_infos).unwrap_or(cursor_idx),
                                             (false, false) => cursor_idx.next(line_infos).unwrap_or(cursor_idx),
                                         }
@@ -506,9 +506,9 @@ impl<'a> Widget for TextEdit<'a> {
                                             // Move by word from the beginning or end of selection
                                             let line_infos = state.line_infos.iter().cloned();
                                             if left_move {
-                                                cursor_idx.previous_word(&text, line_infos).unwrap_or(cursor_idx)
+                                                cursor_idx.previous_word_start(&text, line_infos).unwrap_or(cursor_idx)
                                             } else {
-                                                cursor_idx.next_word(&text, line_infos).unwrap_or(cursor_idx)
+                                                cursor_idx.next_word_end(&text, line_infos).unwrap_or(cursor_idx)
                                             }
                                         }
                                     };


### PR DESCRIPTION
Implemented Ctrl+E to move to end of the text, and Ctrl+Left/Ctrl+Right to move by word through the text.

I think this also fixes the 5th item in https://github.com/PistonDevelopers/conrod/issues/729

Finally, fixed a bug with line breaking by new line, when a word is longer than max_width, it would insert empty lines rather than breaking up the oversized word.