### PR TITLE
Refactor `ListSelect` to behave more like `List`. Fix bug in `List`.

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -67,7 +67,7 @@ fn set_ui(ref mut ui: conrod::UiCell, list: &mut [bool]) {
     widget::Canvas::new().color(conrod::color::DARK_CHARCOAL).set(CANVAS, ui);
 
     const ITEM_HEIGHT: conrod::Scalar = 50.0;
-    let num_items = list.len() as u32;
+    let num_items = list.len();
 
     let (mut items, scrollbar) = widget::List::new(num_items, ITEM_HEIGHT)
         .scrollbar_on_top()

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -104,6 +104,44 @@ fn main() {
                     widget::list_select::Event::DoubleClick(_double_click) => (),
                 }
             }
+
+            // Instantiate the `ListSelect` widget.
+            let num_items = list_items.len();
+            let item_h = 32.0;
+            let (events, mut items, scrollbar) =
+                widget::ListSelect::multiple(num_items, item_h, |i| list_selected[i])
+                    .w_h(350.0, 220.0)
+                    .top_left_with_margins_on(CANVAS, 40.0, 40.0)
+                    .scrollbar_next_to()
+                    .set(LIST_BOX, ui);
+
+            // Handle the `ListSelect`s events.
+            for event in events {
+                match event {
+                    widget::list_select::Event::Selection(selection) => {
+                        selection.update_bool_slice(&mut list_selected);
+                        println!("selected indices: {:?}", &selection);
+                    },
+                    widget::list_select::Event::Press(_press) => (),
+                    widget::list_select::Event::Release(_release) => (),
+                    widget::list_select::Event::Click(_click) => (),
+                    widget::list_select::Event::DoubleClick(_double_click) => (),
+                }
+            }
+
+            // Now we'll instantiate each item as a `Button`.
+            while let Some((events, item)) = items.next(ui) {
+                let label = &list_items[item.i];
+                let (color, label_color) = match list_selected[item.i] {
+                    true => (color::LIGHT_BLUE, color::YELLOW),
+                    false => (color::LIGHT_GREY, color::BLACK),
+                };
+                let button = Button::new().color(color).label(label).label_color(label_color);
+                item.set(button, ui);
+            }
+
+            // Instantiate the scrollbar for the list.
+            scrollbar.unwrap().set(ui);
         });
 
         window.draw_2d(&event, |c, g| {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -37,22 +37,24 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // List of entries to display. They should implement the Display trait.
-    let list_items = vec!["African Sideneck Turtle".to_string(),
-                              "Alligator Snapping Turtle".to_string(),
-                              "Common Snapping Turtle".to_string(),
-                              "Indian Peacock Softshelled Turtle".to_string(),
-                              "Eastern River Cooter".to_string(),
-                              "Eastern Snake Necked Turtle".to_string(),
-                              "Diamond Terrapin".to_string(),
-                              "Indian Peacock Softshelled Turtle".to_string(),
-                              "Musk Turtle".to_string(),
-                              "Reeves Turtle".to_string(),
-                              "Eastern Spiny Softshell Turtle".to_string(),
-                              "Red Ear Slider Turtle".to_string(),
-                              "Indian Tent Turtle".to_string(),
-                              "Mud Turtle".to_string(),
-                              "Painted Turtle".to_string(),
-                              "Spotted Turtle".to_string()];
+    let list_items = [
+        "African Sideneck Turtle".to_string(),
+        "Alligator Snapping Turtle".to_string(),
+        "Common Snapping Turtle".to_string(),
+        "Indian Peacock Softshelled Turtle".to_string(),
+        "Eastern River Cooter".to_string(),
+        "Eastern Snake Necked Turtle".to_string(),
+        "Diamond Terrapin".to_string(),
+        "Indian Peacock Softshelled Turtle".to_string(),
+        "Musk Turtle".to_string(),
+        "Reeves Turtle".to_string(),
+        "Eastern Spiny Softshell Turtle".to_string(),
+        "Red Ear Slider Turtle".to_string(),
+        "Indian Tent Turtle".to_string(),
+        "Mud Turtle".to_string(),
+        "Painted Turtle".to_string(),
+        "Spotted Turtle".to_string()
+    ];
 
     // List of selections, should be same length as list of entries. Will be updated by the widget.
     let mut list_selected = vec![false; list_items.len()];

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -78,7 +78,7 @@ fn main() {
 
             widget::Canvas::new().color(color::BLUE).set(CANVAS, ui);
 
-            widget::ListSelect::multiple(&list_items, &mut list_selected)
+            for event in widget::ListSelect::multiple(&list_items, &list_selected)
                 .w_h(350.0, 220.0)
                 .top_left_with_margins_on(CANVAS, 40.0, 40.0)
                 .color(color::LIGHT_GREY)
@@ -87,19 +87,21 @@ fn main() {
                 .selected_text_color(color::YELLOW)
                 .font_size(16)
                 .scrollbar_auto_hide(false)
-                .react(|event| {
-                    match event {
-                        widget::list_select::Event::SelectEntry(ix, name) =>
-                            println!("Select Entry: {}, {}", ix, name),
-                        widget::list_select::Event::SelectEntries(list)	=>
-                            println!("Select Entries: {:?}", list),
-                        widget::list_select::Event::DoubleClick(ix, name) =>
-                            println!("Double Click: {}, {}", ix, name),
-                        widget::list_select::Event::KeyPress(list, kp) =>
-                            println!("Keypress: {:?}, {:?}", kp, list),
-                    }
-                })
-                .set(LIST_BOX, ui);
+                .set(LIST_BOX, ui)
+            {
+                match event {
+                    widget::list_select::Event::Selection(selection) => {
+                        println!("{:?}", &selection);
+                        for (i, is_selected) in list_selected.iter_mut().enumerate() {
+                            *is_selected = selection.contains(&i);
+                        }
+                    },
+                    widget::list_select::Event::Press(_press) => (),
+                    widget::list_select::Event::Release(_release) => (),
+                    widget::list_select::Event::Click(_click) => (),
+                    widget::list_select::Event::DoubleClick(_double_click) => (),
+                }
+            }
         });
 
         window.draw_2d(&event, |c, g| {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -93,7 +93,7 @@ fn main() {
             {
                 match event {
                     widget::list_select::Event::Selection(selection) => {
-                        println!("{:?}", &selection);
+                        println!("selected indices: {:?}", &selection);
                         for (i, is_selected) in list_selected.iter_mut().enumerate() {
                             *is_selected = selection.contains(&i);
                         }

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -240,7 +240,7 @@ impl<'a, T> Widget for DropDownList<'a, T>
                 };
 
                 // The list of buttons.
-                let num_items = self.items.len() as u32;
+                let num_items = self.items.len();
                 let item_h = h;
                 let list_h = max_visible_height.min(num_items as Scalar * item_h);
                 let list_idx = state.list_idx.get(&mut ui);
@@ -269,10 +269,7 @@ impl<'a, T> Widget for DropDownList<'a, T>
                 // Instiate the `Button` for each item.
                 while let Some(item) = list_items.next(&ui) {
                     let i = item.i;
-                    let label = match self.items.get(i) {
-                        Some(item) => item.as_ref(),
-                        None => continue,
-                    };
+                    let label = self.items[i].as_ref();
                     let mut button = widget::Button::new().label(label);
                     button.style = style.button_style(Some(i) == selected);
                     if item.set(button, &mut ui).was_clicked() {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -27,11 +27,14 @@ use widget;
 #[derive(Clone)]
 #[allow(missing_copy_implementations)]
 pub struct List {
-    common: widget::CommonBuilder,
-    style: Style,
+    /// Common widget building params for the `List`.
+    pub common: widget::CommonBuilder,
+    /// Unique styling for the `List`.
+    pub style: Style,
+    /// Whether all or only visible items should be instantiated.
+    pub item_instantiation: ItemInstantiation,
     item_h: Scalar,
-    num_items: u32,
-    item_instantiation: ItemInstantiation,
+    num_items: usize,
 }
 
 widget_style! {
@@ -114,7 +117,7 @@ pub struct Items {
 impl List {
 
     /// Create a List context to be built upon.
-    pub fn new(num_items: u32, item_height: Scalar) -> Self {
+    pub fn new(num_items: usize, item_height: Scalar) -> Self {
         List {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
@@ -242,7 +245,7 @@ impl Widget for List {
         // Determine the index range of the items that should be instantiated.
         let (item_idx_range, first_item_margin) = match item_instantiation {
             ItemInstantiation::All => {
-                let range = 0..num_items as usize;
+                let range = 0..num_items;
                 let margin = 0.0;
                 (range, margin)
             },
@@ -250,12 +253,12 @@ impl Widget for List {
                 let scroll_trigger_rect = ui.rect_of(scroll_trigger_idx).unwrap();
                 let hidden_range_length = scroll_trigger_rect.top() - rect.top();
                 let num_top_hidden_items = hidden_range_length / item_h;
-                let num_visible_items = (rect.h() / item_h + 1.0).floor() as usize;
+                let num_visible_items = (rect.h() / item_h + 1.0).ceil() as usize;
 
                 let first_visible_item_idx = num_top_hidden_items.floor() as usize;
                 let first_visible_item_margin = first_visible_item_idx as Scalar * item_h;
                 let end_of_visible_idx_range =
-                    std::cmp::min(first_visible_item_idx + num_visible_items, num_items as usize);
+                    std::cmp::min(first_visible_item_idx + num_visible_items, num_items);
                 let range = first_visible_item_idx..end_of_visible_idx_range;
                 (range, first_visible_item_margin)
             },

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -148,7 +148,7 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
     }
 
     /// Update the state of the ListSelect.
-    fn update(mut self, args: widget::UpdateArgs<Self>) -> Self::Event {
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         use Sizeable;
 
         let widget::UpdateArgs { idx, mut state, style, mut ui, .. } = args;
@@ -181,6 +181,7 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
         // If set, a widget event was generated. Set in inner closure
         let mut clicked_item = None;
 
+        let list_idx = state.list_idx.get(&mut ui);
         let num_items = self.entries.len() as u32;
         let (mut list_items, list_scrollbar) = widget::List::new(num_items, rect_h)
             .scrollbar_on_top()

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -18,7 +18,7 @@ use std::fmt::Display;
 
 /// Displays a given Vec<T> where T: Display as a selectable List. Its reaction is triggered upon
 /// selection of a list item.
-pub struct ListSelect<'a, T, F> where F: FnMut(Event), T: Display+'a {
+pub struct ListSelect<'a, T, F> {
     entries: &'a [T],
     selected: &'a mut [bool],
     common: widget::CommonBuilder,
@@ -75,7 +75,10 @@ pub enum Event {
     KeyPress(Vec<(usize, String)>, event::KeyPress),
 }
 
-impl<'a, T, F> ListSelect<'a, T, F> where F: FnMut(Event), T: Display {
+impl<'a, T, F> ListSelect<'a, T, F>
+    where F: FnMut(Event),
+          T: Display,
+{
 
     /// Internal constructor
     fn new(entries: &'a [T], selected: &'a mut [bool], multi_sel: bool) -> Self {
@@ -180,7 +183,8 @@ impl<'a, T, F> ListSelect<'a, T, F> where F: FnMut(Event), T: Display {
 }
 
 impl<'a, T, F> Widget for ListSelect<'a, T, F>
-    where F: FnMut(Event), T: Display+'a
+    where F: FnMut(Event),
+          T: Display + 'a,
 {
     type State = State;
     type Style = Style;
@@ -460,11 +464,11 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
 
 }
 
-impl<'a, T, F> Colorable for ListSelect<'a, T, F> where F: FnMut(Event), T: Display {
+impl<'a, T, F> Colorable for ListSelect<'a, T, F> {
     builder_method!(color { style.color = Some(Color) });
 }
 
-impl<'a, T, F> Borderable for ListSelect<'a, T, F> where F: FnMut(Event), T: Display {
+impl<'a, T, F> Borderable for ListSelect<'a, T, F> {
     builder_methods!{
         border { style.border = Some(Scalar) }
         border_color { style.border_color = Some(Color) }

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -192,23 +192,21 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
             let i = item.i;
             let label = format!("{}", self.entries[i].to_string());
 
-            // Set button colors, depending if selected or not.
-            if self.selected[i] {
-                txt_col = sel_text_color; rect_col = sel_rect_color;
-            } else {
-                txt_col = unsel_text_color; rect_col = unsel_rect_color;
-            }
-            // Save widget NodeIndex so input states can be retrieved later
-            entry_idx_list[i]=item.widget_idx;
+            // Button colors, depending if selected or not.
+            let (rect_color, text_color) =  match selected[i] {
+                true => (sel_rect_color, sel_text_color),
+                false => (unsel_rect_color, unsel_text_color),
+            };
 
+            let item_idx = item.widget_idx;
             let button = widget::Button::new()
                 .label(&label)
-                .label_color(txt_col)
-                .color(rect_col)
+                .label_color(text_color)
+                .color(rect_color)
                 .label_font_size(font_size)
                 .border(0.0);
             if item.set(button, &mut ui).was_clicked() {
-                list_index_event = Some(i);
+                clicked_item = Some((i, item_idx));
             }
         }
 

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -17,11 +17,10 @@ use std::fmt::Display;
 
 /// Displays a given Vec<T> where T: Display as a selectable List. Its reaction is triggered upon
 /// selection of a list item.
-pub struct ListSelect<'a, T: 'a, F> {
+pub struct ListSelect<'a, T: 'a> {
     entries: &'a [T],
-    selected: &'a mut [bool],
+    selected: &'a [bool],
     common: widget::CommonBuilder,
-    maybe_react: Option<F>,
     multiple_selections: bool,
     style: Style,
 }
@@ -63,24 +62,28 @@ pub struct State {
 /// Provides tuple(s) of index in list and string representation of selection
 #[derive(Clone, Debug)]
 pub enum Event {
-    /// If a single enty is selected, return index in list and string representation of item.
-    SelectEntry(usize, String),
-    /// If several entries are elected, return indices in list and string representations of items.
-    SelectEntries(Vec<(usize, String)>),
-    /// If entry selected by doubleclick, return index in list and string representation of item.
-    DoubleClick(usize, String),
-    /// If one or more entries are elected by keyboard, return indices in list and string
-    /// representations of items as well as specific key event.
-    KeyPress(Vec<(usize, String)>, event::KeyPress),
+    /// A change in selection has occurred.
+    ///
+    /// TODO: This might need to be changed to Vec to keep track of the order in which items were
+    /// selected. Not sure if this will be important to the user yet or not, but will likely wait
+    /// for a use-case to arise.
+    Selection(std::collections::HashSet<usize>),
+    /// A button press occurred while the widget was capturing the mouse.
+    Press(event::Press),
+    /// A button release occurred while the widget was capturing the mouse.
+    Release(event::Release),
+    /// A click occurred while the widget was capturing the mouse.
+    Click(event::Click),
+    /// A double click occurred while the widget was capturing the mouse.
+    DoubleClick(event::DoubleClick),
 }
 
-impl<'a, T, F> ListSelect<'a, T, F>
-    where F: FnMut(Event),
-          T: Display,
+impl<'a, T> ListSelect<'a, T>
+    where T: Display,
 {
 
     /// Internal constructor
-    fn new(entries: &'a [T], selected: &'a mut [bool], multi_sel: bool) -> Self {
+    fn new(entries: &'a [T], selected: &'a [bool], multi_sel: bool) -> Self {
 
         // Making sure the two vectors are same length, nicer than a panic
         if entries.len() != selected.len() {
@@ -91,7 +94,6 @@ impl<'a, T, F> ListSelect<'a, T, F>
             common: widget::CommonBuilder::new(),
             entries: entries,
             selected: selected,
-            maybe_react: None,
             multiple_selections: multi_sel,
             style: Style::new(),
         }
@@ -99,20 +101,19 @@ impl<'a, T, F> ListSelect<'a, T, F>
 
     /// Construct a new ListSelect, allowing one selected item at a time.
     /// Second parameter is a list reflecting which entries within the list are currently selected.
-    pub fn single(entries: &'a [T], selected: &'a mut [bool]) -> Self {
+    pub fn single(entries: &'a [T], selected: &'a [bool]) -> Self {
         ListSelect::new(entries, selected, false)
     }
 
     /// Construct a new ListSelect, allowing multiple selected items.
     /// Second parameter is a list reflecting which entries within the list are currently selected.
-    pub fn multiple(entries: &'a [T], selected: &'a mut [bool]) -> Self {
+    pub fn multiple(entries: &'a [T], selected: &'a [bool]) -> Self {
         ListSelect::new(entries, selected, true)
     }
 
     builder_methods!{
         pub font_size { style.font_size = Some(FontSize) }
         pub scrollbar_auto_hide { style.scrollbar_auto_hide = Some(bool) }
-        pub react { maybe_react = Some(F) }
         pub selected_color { style.selected_color = Some(Color) }
         pub text_color { style.text_color = Some(Color) }
         pub selected_text_color { style.selected_text_color = Some(Color) }
@@ -120,13 +121,12 @@ impl<'a, T, F> ListSelect<'a, T, F>
 
 }
 
-impl<'a, T, F> Widget for ListSelect<'a, T, F>
-    where F: FnMut(Event),
-          T: Display + 'a,
+impl<'a, T> Widget for ListSelect<'a, T>
+    where T: Display + 'a,
 {
     type State = State;
     type Style = Style;
-    type Event = ();
+    type Event = Vec<Event>;
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -152,7 +152,7 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
         use Sizeable;
 
         let widget::UpdateArgs { idx, mut state, style, mut ui, .. } = args;
-        let ListSelect { entries, selected, multiple_selections, mut maybe_react, .. } = self;
+        let ListSelect { entries, selected, multiple_selections, .. } = self;
 
         // Make sure that `last_selected_entry` refers to an actual selected value in the list.
         // If not push first selected item, if any.
@@ -178,66 +178,9 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
         let font_size = style.font_size(&ui.theme);
         let rect_h = font_size as Scalar * 2.0;
 
-        // If set, a widget event was generated. Set in inner closure
-        let mut clicked_item = None;
-
-        let list_idx = state.list_idx.get(&mut ui);
-        let num_items = self.entries.len() as u32;
-        let (mut list_items, list_scrollbar) = widget::List::new(num_items, rect_h)
-            .scrollbar_on_top()
-            .middle_of(idx)
-            .wh_of(idx)
-            .set(list_idx, &mut ui);
-
-        while let Some(item) = list_items.next(&ui) {
-            let i = item.i;
-            let label = format!("{}", self.entries[i].to_string());
-
-            // Button colors, depending if selected or not.
-            let (rect_color, text_color) =  match selected[i] {
-                true => (sel_rect_color, sel_text_color),
-                false => (unsel_rect_color, unsel_text_color),
-            };
-
-            let item_idx = item.widget_idx;
-            let button = widget::Button::new()
-                .label(&label)
-                .label_color(text_color)
-                .color(rect_color)
-                .label_font_size(font_size)
-                .border(0.0);
-            if item.set(button, &mut ui).was_clicked() {
-                clicked_item = Some((i, item_idx));
-            }
-        }
-
-        if let Some(scrollbar) = list_scrollbar {
-            scrollbar.set(&mut ui);
-        }
-
-        // Clear selection status for all items.
-        fn clear_all_selected(last_selected_entry: &mut Option<usize>, selected: &mut [bool]) {
-            *last_selected_entry = None;
-            for i in 0..selected.len() {
-                selected[i] = false;
-            }
-        }
-
-        // Returns a Vec of tuples (index, String) to hand over to React closure
-        let selected_entries = |entries: &[T], selected: &[bool]| -> Vec<(usize, String)> {
-            let mut selected_entries = Vec::new();
-
-            for i in 0..selected.len() {
-                if selected[i] {
-                    selected_entries.push((i as usize, entries[i].to_string()));
-                }
-            }
-
-            selected_entries
-        };
-
         // Given an index, find the first and last indices of the enclosing selection.
-        // Used to expand existing selection with shift key.
+        //
+        // This is used when expanding an existing selection with the shift key.
         fn selected_range(selected: &[bool], ix: usize) -> (usize, usize) {
             let mut first = ix;
             while selected[first] && first > 0 {
@@ -256,200 +199,175 @@ impl<'a, T, F> Widget for ListSelect<'a, T, F>
             (first, last)
         }
 
-        // If no list items were clicked, we're done.
-        let (i, item_idx) = match clicked_item {
-            Some(item) => item,
-            None => return,
-        };
+        // Collect all relevant events that have occurred.
+        let mut events = Vec::new();
 
-        // Otherwise, check for changes in selection.
-        for widget_event in ui.widget_input(item_idx).events() {
-            use {event, input};
+        let list_idx = state.list_idx.get(&mut ui);
+        let num_items = self.entries.len() as u32;
+        let (mut list_items, list_scrollbar) = widget::List::new(num_items, rect_h)
+            .scrollbar_on_top()
+            .middle_of(idx)
+            .wh_of(idx)
+            .set(list_idx, &mut ui);
 
-            match widget_event {
+        while let Some(item) = list_items.next(&ui) {
+            let i = item.i;
 
-                // Check if the entry has been `DoubleClick`ed.
-                event::Widget::DoubleClick(click) => {
-                    if let input::MouseButton::Left = click.button {
-                        // Deselect all others.
-                        state.update(|state| {
-                            clear_all_selected(&mut state.last_selected_entry, selected);
-                            selected[i] = true;
-                            state.last_selected_entry = Some(i);
-                        });
-                        if let Some(ref mut react) = maybe_react {
-                            react(Event::DoubleClick(i, entries[i].to_string()));
-                        }
-                    }
-                },
+            // Check for any events that may have occurred to this widget.
+            for widget_event in ui.widget_input(item.widget_idx).events() {
+                use {event, input};
 
-                // Check if the entry has been `Click`ed.
-                event::Widget::Click(click) => {
-                    let is_shift_down = click.modifiers.contains(input::keyboard::SHIFT);
+                match widget_event {
 
-                    // On Mac ALT is use for adding to selection, on Windows it's CTRL
-                    let is_alt_down = click.modifiers.contains(input::keyboard::ALT) ||
-                                      click.modifiers.contains(input::keyboard::CTRL);
-
-                    match state.last_selected_entry {
-
-                        // If there is already a currently selected item and shift is
-                        // held, extend the selection to this one.
-                        Some(idx) if is_shift_down && multiple_selections => {
-
-                            // Default range
-                            let mut start_idx_range = std::cmp::min(idx, i);
-                            let mut end_idx_range = std::cmp::max(idx, i);
-
-                            // Get continous block selected from last selected idx
-                            // so the block can be extended up or down
-                            let (first, last) = selected_range(selected, idx);
-
-                            if i < first {
-                                start_idx_range = i;
-                                end_idx_range = last;
-                            }
-                            if i > last {
-                                start_idx_range = first;
-                                end_idx_range = i;
-                            }
-
-                            // generate react list inline rather than using get_selected_as_tuples()
-                            let mut temp = Vec::new();
-                            state.update(|state| {
-
-                                clear_all_selected(&mut state.last_selected_entry, selected);
-                                state.last_selected_entry = Some(i);
-
-                                // Set selected only for the range. Clearing other blocks.
-                                for j in 0..selected.len() {
-                                    if start_idx_range <= j && j <= end_idx_range {
-                                        selected[j] = true;
-                                        temp.push((j as usize, entries[j].to_string()));
-                                    } else {
-                                        selected[j] = false;
-                                    }
-                                }
-                            });
-
-                            if let Some(ref mut react) = maybe_react {
-                                react(Event::SelectEntries(temp))
-                            }
-                        },
-
-                        // If alt is down, additively select or deselect this item.
-                        Some(_) | None if is_alt_down && multiple_selections => {
-                            state.update(|state| {
-                                let new_is_selected = !selected[i];
-                                selected[i] = new_is_selected;
-                                if new_is_selected {
-                                    state.last_selected_entry = Some(i);
-                                }
-                            });
-
-                            let mut selected_entries = selected_entries(entries, selected);
-                            let num_entries_selected = selected_entries.len();
-
-                            if  num_entries_selected > 0 {
-                                if let Some(ref mut react) = maybe_react {
-                                    if num_entries_selected > 1 {
-                                        react(Event::SelectEntries(selected_entries));
-                                    } else {
-                                        // Safe to unwrap here, as list len is 1
-                                        let (ix, st) = selected_entries.pop().unwrap();
-                                        react(Event::SelectEntry(ix, st));
-                                    }
-                                }
-                            }
-                        },
-
-                        // Otherwise, no shift/ctrl/alt, select just this one
-                        // Clear all others
-                        _ => {
-                            // Deselect all others.
-                            state.update(|state| {
-                                clear_all_selected(&mut state.last_selected_entry, selected);
-                            });
-
-                            // Select the current item.
-                            selected[i] = true;
-                            state.update(|state| state.last_selected_entry = Some(i));
-                            if let Some(ref mut react) = maybe_react {
-                                react(Event::SelectEntry(i, entries[i].to_string()));
-                            }
-                        },
-                    }
-                },
-
-                // Check for whether or not the item should be selected.
-                event::Widget::Press(press) => match press.button {
-
-                    // Keyboard check whether the selection has been bumped up or down.
-                    event::Button::Keyboard(key) => {
-                        if let Some(i) = state.last_selected_entry {
-                            match key {
-
-                                // Bump the selection up the list.
-                                input::Key::Up => state.update(|state| {
-                                    // Clear old selected entries.
-                                    clear_all_selected(&mut state.last_selected_entry, selected);
-
-                                    let i = if i == 0 { 0 } else { i - 1 };
-                                    selected[i] = true;
-                                    state.last_selected_entry = Some(i);
-
-                                    if let Some(ref mut react) = maybe_react {
-                                        react(Event::SelectEntry(i, entries[i].to_string()));
-                                    }
-                                }),
-
-                                // Bump the selection down the list.
-                                input::Key::Down => state.update(|state| {
-                                    // Clear old selected entries.
-                                    clear_all_selected(&mut state.last_selected_entry, selected);
-
-                                    let last_idx = entries.len() - 1;
-                                    let i = if i < last_idx { i + 1 } else { last_idx };
-                                    selected[i] = true;
-                                    state.last_selected_entry = Some(i);
-
-                                    if let Some(ref mut react) = maybe_react {
-                                        react(Event::SelectEntry(i, entries[i].to_string()));
-                                    }
-                                }),
-
-                                _ => (),
-                            }
-
-                            // For any other pressed keys, yield an event along
-                            // with all the paths of all selected entries.
-                            let selected_entries = selected_entries(entries, selected);
-                            if let Some(ref mut react) = maybe_react {
-                                let key_press = event::KeyPress {
-                                    key: key,
-                                    modifiers: press.modifiers,
-                                };
-                                react(Event::KeyPress(selected_entries, key_press));
-                            }
+                    // Check if the entry has been `DoubleClick`ed.
+                    event::Widget::DoubleClick(click) => {
+                        if let input::MouseButton::Left = click.button {
+                            events.push(Event::DoubleClick(click));
                         }
                     },
 
-                    _ => (),
-                },
+                    // Check if the entry has been `Click`ed.
+                    event::Widget::Click(click) => {
+                        let is_shift_down = click.modifiers.contains(input::keyboard::SHIFT);
 
-                _ => (),
+                        // On Mac ALT is use for adding to selection, on Windows it's CTRL
+                        let is_alt_down = click.modifiers.contains(input::keyboard::ALT) ||
+                                          click.modifiers.contains(input::keyboard::CTRL);
+
+                        let selection_event = match state.last_selected_entry {
+
+                            // If there is already a currently selected item and shift is
+                            // held, extend the selection to this one.
+                            Some(idx) if is_shift_down && multiple_selections => {
+
+                                // Default range
+                                let mut start_idx_range = std::cmp::min(idx, i);
+                                let mut end_idx_range = std::cmp::max(idx, i);
+
+                                // Get continous block selected from last selected idx
+                                // so the block can be extended up or down
+                                let (first, last) = selected_range(selected, idx);
+
+                                if i < first {
+                                    start_idx_range = i;
+                                    end_idx_range = last;
+                                }
+                                if i > last {
+                                    start_idx_range = first;
+                                    end_idx_range = i;
+                                }
+
+                                state.update(|state| state.last_selected_entry = Some(i));
+                                let selection = (start_idx_range..end_idx_range + 1).collect();
+                                Event::Selection(selection)
+                            },
+
+                            // If alt is down, additively select or deselect this item.
+                            Some(_) | None if is_alt_down && multiple_selections => {
+                                let mut selection: std::collections::HashSet<_> = selected.iter()
+                                    .enumerate()
+                                    .filter_map(|(i, &s)| if s { Some(i) } else { None })
+                                    .collect();
+                                if !selected[i] {
+                                    selection.insert(i);
+                                    state.update(|state| state.last_selected_entry = Some(i));
+                                } else {
+                                    selection.remove(&i);
+                                };
+                                Event::Selection(selection)
+                            },
+
+                            // Otherwise, no shift/ctrl/alt, select just this one
+                            // Clear all others
+                            _ => {
+                                let selection = std::iter::once(i).collect();
+                                state.update(|state| state.last_selected_entry = Some(i));
+                                Event::Selection(selection)
+                            },
+                        };
+
+                        events.push(Event::Click(click));
+                        events.push(selection_event);
+                    },
+
+                    // Check for whether or not the item should be selected.
+                    event::Widget::Press(press) => {
+                        events.push(Event::Press(press));
+                        match press.button {
+
+                            // Keyboard check whether the selection has been bumped up or down.
+                            event::Button::Keyboard(key) => {
+                                if let Some(i) = state.last_selected_entry {
+                                    let event = match key {
+
+                                        // Bump the selection up the list.
+                                        input::Key::Up => {
+                                            let i = if i == 0 { 0 } else { i - 1 };
+                                            state.update(|state| state.last_selected_entry = Some(i));
+                                            let selection = std::iter::once(i).collect();
+                                            Event::Selection(selection)
+                                        },
+
+                                        // Bump the selection down the list.
+                                        input::Key::Down => {
+                                            let last_idx = entries.len() - 1;
+                                            let i = if i < last_idx { i + 1 } else { last_idx };
+                                            state.update(|state| state.last_selected_entry = Some(i));
+                                            let selection = std::iter::once(i).collect();
+                                            Event::Selection(selection)
+                                        },
+
+                                        _ => continue,
+                                    };
+
+                                    events.push(event);
+                                }
+                            },
+
+                            _ => (),
+                        }
+                    },
+
+                    event::Widget::Release(release) => {
+                        let event = Event::Release(release);
+                        events.push(event);
+                    },
+
+                    _ => (),
+                }
             }
+
+            let label = format!("{}", self.entries[i].to_string());
+
+            // Button colors, depending if selected or not.
+            let (rect_color, text_color) =  match selected[i] {
+                true => (sel_rect_color, sel_text_color),
+                false => (unsel_rect_color, unsel_text_color),
+            };
+
+            let button = widget::Button::new()
+                .label(&label)
+                .label_color(text_color)
+                .color(rect_color)
+                .label_font_size(font_size)
+                .border(0.0);
+            item.set(button, &mut ui);
         }
 
+        if let Some(scrollbar) = list_scrollbar {
+            scrollbar.set(&mut ui);
+        }
+
+        events
     }
 
 }
 
-impl<'a, T, F> Colorable for ListSelect<'a, T, F> {
+impl<'a, T> Colorable for ListSelect<'a, T> {
     builder_method!(color { style.color = Some(Color) });
 }
 
-impl<'a, T, F> Borderable for ListSelect<'a, T, F> {
+impl<'a, T> Borderable for ListSelect<'a, T> {
     builder_methods!{
         border { style.border = Some(Scalar) }
         border_color { style.border_color = Some(Color) }

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -1,7 +1,7 @@
 //! A wrapper around the `List` widget providing the ability to select one or more items.
 
-use {Color, FontSize, Positionable, Scalar, Sizeable, Ui, Widget};
-use {event, widget};
+use {Color, Positionable, Scalar, Sizeable, Ui, Widget};
+use {event, graph, widget};
 use std;
 
 /// A wrapper around the `List` widget that handles single and multiple selection logic.
@@ -10,35 +10,11 @@ use std;
 pub struct ListSelect {
     common: widget::CommonBuilder,
     item_h: Scalar,
-    num_items: u32,
+    num_items: usize,
     multiple_selections: bool,
     style: widget::list::Style,
     item_instantiation: widget::list::ItemInstantiation,
 }
-
-// widget_style!{
-//     /// Styling for the ListSelect, necessary for constructing its renderable Element.
-//     style Style {
-//         /// Size of text font in list
-//         - font_size: FontSize { theme.font_size_medium }
-//         /// The background color of the unselected entries.
-//         - color: Color { theme.shape_color }
-//         /// The background color of the selected entries.
-//         - selected_color: Color { theme.label_color }
-//         /// Color of the item text, when not selected.
-//         - text_color: Color { theme.shape_color }
-//         /// Color of the item text, when selected.
-//         - selected_text_color: Color { color::BLACK }
-//         /// Width of the border surrounding the widget
-//         - border: Scalar { theme.border_width }
-//         /// The color of the border.
-//         - border_color: Color { theme.border_color }
-//         /// Font size for the item labels.
-//         - label_font_size: FontSize { theme.font_size_medium }
-//         /// Auto hide the scrollbar or not
-//         - scrollbar_auto_hide: bool { true }
-//     }
-// }
 
 /// Represents the state of the ListSelect.
 #[derive(PartialEq, Clone, Debug)]
@@ -46,12 +22,15 @@ pub struct State {
     list_idx: widget::IndexSlot,
     /// Tracking index of last selected entry that has been pressed in order to
     /// perform multi selection when `SHIFT` or `ALT`(Mac) / 'CTRL'(Other OS) is held.
-    last_selected_entry: Option<usize>,
+    last_selected_entry: std::cell::Cell<Option<usize>>,
 }
 
 /// An iterator-like type for yielding `ListSelect` `Event`s.
 pub struct Events {
+    idx: widget::Index,
     items: widget::list::Items,
+    num_items: usize,
+    multiple_selections: bool,
     pending_events: std::collections::VecDeque<Event>,
 }
 
@@ -107,8 +86,14 @@ impl Selection {
     /// Update the given set of selected indices with this `Selection`.
     pub fn update_index_set(&self, set: &mut std::collections::HashSet<usize>) {
         match *self {
-            Selection::Add(ref indices) => for &i in indices { set.insert(i) },
-            Selection::Remove(ref indices) => for &i in indices { set.remove(i) },
+            Selection::Add(ref indices) =>
+                for &i in indices {
+                    set.insert(i);
+                },
+            Selection::Remove(ref indices) =>
+                for &i in indices {
+                    set.remove(&i);
+                },
         }
     }
 
@@ -117,25 +102,26 @@ impl Selection {
 impl ListSelect {
 
     /// Internal constructor
-    fn new(num_items: u32, item_h: Scalar, multiple_selection: bool) -> Self {
+    fn new(num_items: usize, item_h: Scalar, multiple_selection: bool) -> Self {
         ListSelect {
             common: widget::CommonBuilder::new(),
-            num_items: num_items,
-            item_h: item_h,
-            multiple_selections: multiple_selection,
             style: widget::list::Style::new(),
+            item_h: item_h,
+            num_items: num_items,
+            multiple_selections: multiple_selection,
+            item_instantiation: widget::list::ItemInstantiation::OnlyVisible,
         }
     }
 
     /// Construct a new ListSelect, allowing one selected item at a time.
     /// Second parameter is a list reflecting which entries within the list are currently selected.
-    pub fn single(num_items: u32, item_h: Scalar) -> Self {
+    pub fn single(num_items: usize, item_h: Scalar) -> Self {
         ListSelect::new(num_items, item_h, false)
     }
 
     /// Construct a new ListSelect, allowing multiple selected items.
     /// Second parameter is a list reflecting which entries within the list are currently selected.
-    pub fn multiple(num_items: u32, item_h: Scalar) -> Self {
+    pub fn multiple(num_items: usize, item_h: Scalar) -> Self {
         ListSelect::new(num_items, item_h, true)
     }
 
@@ -143,14 +129,14 @@ impl ListSelect {
     /// right of the items.
     pub fn scrollbar_next_to(mut self) -> Self {
         self.style.scrollbar_position = Some(Some(widget::list::ScrollbarPosition::NextTo));
-        self.scroll_kids_vertically()
+        self
     }
 
     /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` that hovers
     /// above the right edge of the items and automatically hides when the user is not scrolling.
     pub fn scrollbar_on_top(mut self) -> Self {
         self.style.scrollbar_position = Some(Some(widget::list::ScrollbarPosition::OnTop));
-        self.scroll_kids_vertically()
+        self
     }
 
     /// The width of the `Scrollbar`.
@@ -204,7 +190,7 @@ impl Widget for ListSelect {
     fn init_state(&self) -> Self::State {
         State {
             list_idx: widget::IndexSlot::new(),
-            last_selected_entry:None,
+            last_selected_entry: std::cell::Cell::new(None),
         }
     }
 
@@ -215,31 +201,30 @@ impl Widget for ListSelect {
     /// Update the state of the ListSelect.
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { idx, mut state, style, mut ui, .. } = args;
-        let ListSelect { num_items, item_h, multiple_selections, .. } = self;
+        let ListSelect { num_items, item_h, item_instantiation, multiple_selections, .. } = self;
 
         // Make sure that `last_selected_entry` refers to an actual selected value in the list.
         // If not push first selected item, if any.
-        if let Some(ix) = state.last_selected_entry {
-            if ix >= selected.len() || !selected[ix] {
-                state.update(|state| state.last_selected_entry = None);
-            }
-        }
-        if state.last_selected_entry.is_none() {
-            for j in 0..selected.len() {
-                if selected[j] {
-                    state.update(|state| state.last_selected_entry = Some(j));
-                    break;
-                }
+        if let Some(i) = state.last_selected_entry.get() {
+            if i >= num_items {
+                state.update(|state| state.last_selected_entry.set(None));
             }
         }
 
         let list_idx = state.list_idx.get(&mut ui);
-        let mut list = widget::List::new(num_items, item_h);
-        list.style = style;
+        let scrollbar_position = style.scrollbar_position(&ui.theme);
+
+        let mut list = widget::List::new(num_items, item_h)
+            .and_if(scrollbar_position.is_some(), |ls| ls.scroll_kids_vertically());
+        list.item_instantiation = item_instantiation;
+        list.style = style.clone();
         let (items, scrollbar) = list.middle_of(idx).wh_of(idx).set(list_idx, &mut ui);
 
         let events = Events {
+            idx: idx,
             items: items,
+            num_items: num_items,
+            multiple_selections: multiple_selections,
             pending_events: std::collections::VecDeque::new(),
         };
 
@@ -251,9 +236,15 @@ impl Events {
 
     /// Yield the next `Event`.
     pub fn next<F>(&mut self, ui: &Ui, is_selected: F) -> Option<Event>
-        where F: FnMut(usize) -> bool,
+        where F: Fn(usize) -> bool,
     {
-        let Events { list_select_idx, ref mut items, ref mut pending_events } = *self;
+        let Events {
+            idx,
+            multiple_selections,
+            num_items,
+            ref mut items,
+            ref mut pending_events,
+        } = *self;
 
         if let Some(event) = pending_events.pop_front() {
             return Some(event);
@@ -265,9 +256,18 @@ impl Events {
         };
 
         // Borrow the `ListSelect::State` from the `Ui`'s widget graph.
-        fn state(list_select_idx: widget::Index, ui: &Ui) -> &State {
-            ui.widget_graph().widget(list_select_idx)
-        }
+        let state = || {
+            ui.widget_graph()
+                .widget(idx)
+                .and_then(|container| container.unique_widget_state::<ListSelect>())
+                .map(|&graph::UniqueWidgetState { ref state, .. }| state)
+                .expect("couldn't find `ListSelect` state in the widget graph")
+        };
+
+        // Produce the current selection as a set of indices.
+        let current_selection = || {
+            (0..num_items).filter(|&i| is_selected(i)).collect()
+        };
 
         let i = item.i;
 
@@ -286,98 +286,90 @@ impl Events {
 
                 // Check if the entry has been `Click`ed.
                 event::Widget::Click(click) => {
+                    pending_events.push_back(Event::Click(click));
                     let is_shift_down = click.modifiers.contains(input::keyboard::SHIFT);
 
                     // On Mac ALT is use for adding to selection, on Windows it's CTRL
                     let is_alt_down = click.modifiers.contains(input::keyboard::ALT) ||
                                       click.modifiers.contains(input::keyboard::CTRL);
 
-                    let selection_event = match state.last_selected_entry {
+                    let state = state();
+
+                    let selection_event = match state.last_selected_entry.get() {
 
                         // If there is already a currently selected item and shift is
                         // held, extend the selection to this one.
                         Some(idx) if is_shift_down && multiple_selections => {
 
-                            // Default range
-                            let mut start_idx_range = std::cmp::min(idx, i);
-                            let mut end_idx_range = std::cmp::max(idx, i);
+                            let start_idx_range = std::cmp::min(idx, i);
+                            let end_idx_range = std::cmp::max(idx, i);
 
-                            // Get continous block selected from last selected idx
-                            // so the block can be extended up or down
-                            let (first, last) = selected_range(selected, idx);
-
-                            if i < first {
-                                start_idx_range = i;
-                                end_idx_range = last;
-                            }
-                            if i > last {
-                                start_idx_range = first;
-                                end_idx_range = i;
-                            }
-
-                            state.update(|state| state.last_selected_entry = Some(i));
+                            state.last_selected_entry.set(Some(i));
                             let selection = (start_idx_range..end_idx_range + 1).collect();
-                            Event::Selection(selection)
+                            Event::Selection(Selection::Add(selection))
                         },
 
                         // If alt is down, additively select or deselect this item.
                         Some(_) | None if is_alt_down && multiple_selections => {
-                            let mut selection: std::collections::HashSet<_> = selected.iter()
-                                .enumerate()
-                                .filter_map(|(i, &s)| if s { Some(i) } else { None })
-                                .collect();
-                            if !selected[i] {
-                                selection.insert(i);
-                                state.update(|state| state.last_selected_entry = Some(i));
+                            let selection = std::iter::once(i).collect();
+                            if !is_selected(i) {
+                                state.last_selected_entry.set(Some(i));
+                                Event::Selection(Selection::Add(selection))
                             } else {
-                                selection.remove(&i);
-                            };
-                            Event::Selection(selection)
+                                Event::Selection(Selection::Remove(selection))
+                            }
                         },
 
                         // Otherwise, no shift/ctrl/alt, select just this one
                         // Clear all others
                         _ => {
+                            let old_selection = current_selection();
+                            let event = Event::Selection(Selection::Remove(old_selection));
+                            pending_events.push_back(event);
                             let selection = std::iter::once(i).collect();
-                            state.update(|state| state.last_selected_entry = Some(i));
-                            Event::Selection(selection)
+                            state.last_selected_entry.set(Some(i));
+                            Event::Selection(Selection::Add(selection))
                         },
                     };
 
-                    pending_events.push_back(Event::Click(click));
                     pending_events.push_back(selection_event);
                 },
 
                 // Check for whether or not the item should be selected.
                 event::Widget::Press(press) => {
                     pending_events.push_back(Event::Press(press));
+                    let state = state();
                     match press.button {
 
                         // Keyboard check whether the selection has been bumped up or down.
                         event::Button::Keyboard(key) => {
-                            if let Some(i) = state.last_selected_entry {
-                                let event = match key {
+                            if let Some(i) = state.last_selected_entry.get() {
+                                let alt = press.modifiers.contains(input::keyboard::ALT);
 
-                                    // Bump the selection up the list.
-                                    input::Key::Up => {
-                                        let i = if i == 0 { 0 } else { i - 1 };
-                                        state.update(|state| state.last_selected_entry = Some(i));
-                                        let selection = std::iter::once(i).collect();
-                                        Event::Selection(selection)
-                                    },
-
-                                    // Bump the selection down the list.
+                                let end = match key {
+                                    input::Key::Up =>
+                                        if i == 0 || alt { 0 } else { i - 1 },
                                     input::Key::Down => {
-                                        let last_idx = entries.len() - 1;
-                                        let i = if i < last_idx { i + 1 } else { last_idx };
-                                        state.update(|state| state.last_selected_entry = Some(i));
-                                        let selection = std::iter::once(i).collect();
-                                        Event::Selection(selection)
+                                        let last_idx = num_items - 1;
+                                        if i >= last_idx || alt { last_idx } else { i + 1 }
                                     },
-
                                     _ => continue,
                                 };
 
+                                state.last_selected_entry.set(Some(end));
+
+                                let selection = if press.modifiers.contains(input::keyboard::SHIFT) {
+                                    let start = std::cmp::min(i, end);
+                                    let end = std::cmp::max(i, end) + 1;
+                                    (start..end).collect()
+                                } else {
+                                    let old_selection = current_selection();
+                                    let event = Event::Selection(Selection::Remove(old_selection));
+                                    pending_events.push_back(event);
+                                    std::iter::once(end).collect()
+                                };
+
+                                let event = Event::Selection(Selection::Add(selection));
                                 pending_events.push_back(event);
                             }
                         },

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -1,30 +1,19 @@
 //! A wrapper around the `List` widget providing the ability to select one or more items.
 
-use {
-    color,
-    event,
-    Color,
-    Colorable,
-    FontSize,
-    Labelable,
-    Positionable,
-    Scalar,
-    Borderable,
-};
-use widget::{self, Widget};
+use {Color, FontSize, Positionable, Scalar, Sizeable, Ui, Widget};
+use {event, widget};
 use std;
-use std::fmt::Display;
 
 /// A wrapper around the `List` widget that handles single and multiple selection logic.
 #[derive(Clone)]
 #[allow(missing_copy_implementations)]
 pub struct ListSelect {
     common: widget::CommonBuilder,
-    style: widget::list::Style,
     item_h: Scalar,
     num_items: u32,
-    item_instantiation: list::ItemInstantiation,
     multiple_selections: bool,
+    style: widget::list::Style,
+    item_instantiation: widget::list::ItemInstantiation,
 }
 
 // widget_style!{
@@ -60,20 +49,18 @@ pub struct State {
     last_selected_entry: Option<usize>,
 }
 
-pub struct Items {
+/// An iterator-like type for yielding `ListSelect` `Event`s.
+pub struct Events {
     items: widget::list::Items,
-}
-
-impl Items {
-
-    pub fn next(&mut self, ui: &Ui) -> Option<Item>
-
+    pending_events: std::collections::VecDeque<Event>,
 }
 
 /// The kind of events that the `ListSelect` may `react` to.
 /// Provides tuple(s) of index in list and string representation of selection
 #[derive(Clone, Debug)]
 pub enum Event {
+    /// The next `Item` is ready for instantiation.
+    Item(widget::list::Item),
     /// A change in selection has occurred.
     Selection(Selection),
     /// A button press occurred while the widget was capturing the mouse.
@@ -90,9 +77,9 @@ pub enum Event {
 #[derive(Clone, Debug)]
 pub enum Selection {
     /// Items which have been added to the selection.
-    Add(std::collection::HashSet<usize>),
+    Add(std::collections::HashSet<usize>),
     /// Items which have been removed from the selection.
-    Remove(std::collection::HashSet<usize>),
+    Remove(std::collections::HashSet<usize>),
 }
 
 impl Selection {
@@ -127,16 +114,14 @@ impl Selection {
 
 }
 
-impl<'a, T> ListSelect<'a, T>
-    where T: Display,
-{
+impl ListSelect {
 
     /// Internal constructor
-    fn new(num_items: u32, item_height: Scalar, multiple_selection: bool) -> Self {
+    fn new(num_items: u32, item_h: Scalar, multiple_selection: bool) -> Self {
         ListSelect {
             common: widget::CommonBuilder::new(),
-            entries: entries,
-            selected: selected,
+            num_items: num_items,
+            item_h: item_h,
             multiple_selections: multiple_selection,
             style: widget::list::Style::new(),
         }
@@ -144,27 +129,27 @@ impl<'a, T> ListSelect<'a, T>
 
     /// Construct a new ListSelect, allowing one selected item at a time.
     /// Second parameter is a list reflecting which entries within the list are currently selected.
-    pub fn single(num_iterms: u32, item_height: Scalar) -> Self {
-        ListSelect::new(entries, selected, false)
+    pub fn single(num_items: u32, item_h: Scalar) -> Self {
+        ListSelect::new(num_items, item_h, false)
     }
 
     /// Construct a new ListSelect, allowing multiple selected items.
     /// Second parameter is a list reflecting which entries within the list are currently selected.
-    pub fn multiple(num_iterms: u32, item_height: Scalar) -> Self {
-        ListSelect::new(entries, selected, true)
+    pub fn multiple(num_items: u32, item_h: Scalar) -> Self {
+        ListSelect::new(num_items, item_h, true)
     }
 
     /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` to the
     /// right of the items.
     pub fn scrollbar_next_to(mut self) -> Self {
-        self.style.scrollbar_position = Some(Some(ScrollbarPosition::NextTo));
+        self.style.scrollbar_position = Some(Some(widget::list::ScrollbarPosition::NextTo));
         self.scroll_kids_vertically()
     }
 
     /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` that hovers
     /// above the right edge of the items and automatically hides when the user is not scrolling.
     pub fn scrollbar_on_top(mut self) -> Self {
-        self.style.scrollbar_position = Some(Some(ScrollbarPosition::OnTop));
+        self.style.scrollbar_position = Some(Some(widget::list::ScrollbarPosition::OnTop));
         self.scroll_kids_vertically()
     }
 
@@ -187,7 +172,7 @@ impl<'a, T> ListSelect<'a, T>
     /// We only recommend using this when absolutely necessary as large lists may cause unnecessary
     /// bloating within the widget graph, and in turn result in greater traversal times.
     pub fn instantiate_all_items(mut self) -> Self {
-        self.item_instantiation = ItemInstantiation::All;
+        self.item_instantiation = widget::list::ItemInstantiation::All;
         self
     }
 
@@ -197,18 +182,16 @@ impl<'a, T> ListSelect<'a, T>
     ///
     /// This is the default `List` behaviour.
     pub fn instantiate_only_visible_items(mut self) -> Self {
-        self.item_instantiation = ItemInstantiation::OnlyVisible;
+        self.item_instantiation = widget::list::ItemInstantiation::OnlyVisible;
         self
     }
 
 }
 
-impl<'a, T> Widget for ListSelect<'a, T>
-    where T: Display + 'a,
-{
+impl Widget for ListSelect {
     type State = State;
     type Style = widget::list::Style;
-    type Event = (Vec<Event>, widget::list::Items, Option<widget::list::Scrollbar>);
+    type Event = (Events, Option<widget::list::Scrollbar>);
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -231,10 +214,8 @@ impl<'a, T> Widget for ListSelect<'a, T>
 
     /// Update the state of the ListSelect.
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
-        use Sizeable;
-
         let widget::UpdateArgs { idx, mut state, style, mut ui, .. } = args;
-        let ListSelect { entries, selected, multiple_selections, .. } = self;
+        let ListSelect { num_items, item_h, multiple_selections, .. } = self;
 
         // Make sure that `last_selected_entry` refers to an actual selected value in the list.
         // If not push first selected item, if any.
@@ -252,198 +233,178 @@ impl<'a, T> Widget for ListSelect<'a, T>
             }
         }
 
-        // // Given an index, find the first and last indices of the enclosing selection.
-        // //
-        // // This is used when expanding an existing selection with the shift key.
-        // fn selected_range(selected: &[bool], ix: usize) -> (usize, usize) {
-        //     let mut first = ix;
-        //     while selected[first] && first > 0 {
-        //         first -= 1;
-        //     }
-        //     if !selected[first] {
-        //         first += 1;
-        //     }
-        //     let mut last = ix;
-        //     while selected[last] && last < selected.len() - 1 {
-        //         last += 1;
-        //     }
-        //     if !selected[last] {
-        //         last -= 1;
-        //     }
-        //     (first, last)
-        // }
-
-        // Collect all relevant events that have occurred.
-        let mut events = Vec::new();
-
         let list_idx = state.list_idx.get(&mut ui);
-        let num_items = self.entries.len() as u32;
-        let (mut list_items, list_scrollbar) = widget::List::new(num_items, rect_h)
-            .scrollbar_on_top()
-            .middle_of(idx)
-            .wh_of(idx)
-            .set(list_idx, &mut ui);
+        let mut list = widget::List::new(num_items, item_h);
+        list.style = style;
+        let (items, scrollbar) = list.middle_of(idx).wh_of(idx).set(list_idx, &mut ui);
 
-        while let Some(item) = list_items.next(&ui) {
-            let i = item.i;
+        let events = Events {
+            items: items,
+            pending_events: std::collections::VecDeque::new(),
+        };
 
-            // Check for any events that may have occurred to this widget.
-            for widget_event in ui.widget_input(item.widget_idx).events() {
-                use {event, input};
+        (events, scrollbar)
+    }
+}
 
-                match widget_event {
+impl Events {
 
-                    // Check if the entry has been `DoubleClick`ed.
-                    event::Widget::DoubleClick(click) => {
-                        if let input::MouseButton::Left = click.button {
-                            events.push(Event::DoubleClick(click));
-                        }
-                    },
+    /// Yield the next `Event`.
+    pub fn next<F>(&mut self, ui: &Ui, is_selected: F) -> Option<Event>
+        where F: FnMut(usize) -> bool,
+    {
+        let Events { list_select_idx, ref mut items, ref mut pending_events } = *self;
 
-                    // Check if the entry has been `Click`ed.
-                    event::Widget::Click(click) => {
-                        let is_shift_down = click.modifiers.contains(input::keyboard::SHIFT);
+        if let Some(event) = pending_events.pop_front() {
+            return Some(event);
+        }
 
-                        // On Mac ALT is use for adding to selection, on Windows it's CTRL
-                        let is_alt_down = click.modifiers.contains(input::keyboard::ALT) ||
-                                          click.modifiers.contains(input::keyboard::CTRL);
+        let item = match items.next(ui) {
+            Some(item) => item,
+            None => return None,
+        };
 
-                        let selection_event = match state.last_selected_entry {
+        // Borrow the `ListSelect::State` from the `Ui`'s widget graph.
+        fn state(list_select_idx: widget::Index, ui: &Ui) -> &State {
+            ui.widget_graph().widget(list_select_idx)
+        }
 
-                            // If there is already a currently selected item and shift is
-                            // held, extend the selection to this one.
-                            Some(idx) if is_shift_down && multiple_selections => {
+        let i = item.i;
 
-                                // Default range
-                                let mut start_idx_range = std::cmp::min(idx, i);
-                                let mut end_idx_range = std::cmp::max(idx, i);
+        // Check for any events that may have occurred to this widget.
+        for widget_event in ui.widget_input(item.widget_idx).events() {
+            use {event, input};
 
-                                // Get continous block selected from last selected idx
-                                // so the block can be extended up or down
-                                let (first, last) = selected_range(selected, idx);
+            match widget_event {
 
-                                if i < first {
-                                    start_idx_range = i;
-                                    end_idx_range = last;
-                                }
-                                if i > last {
-                                    start_idx_range = first;
-                                    end_idx_range = i;
-                                }
+                // Check if the entry has been `DoubleClick`ed.
+                event::Widget::DoubleClick(click) => {
+                    if let input::MouseButton::Left = click.button {
+                        pending_events.push_back(Event::DoubleClick(click));
+                    }
+                },
 
+                // Check if the entry has been `Click`ed.
+                event::Widget::Click(click) => {
+                    let is_shift_down = click.modifiers.contains(input::keyboard::SHIFT);
+
+                    // On Mac ALT is use for adding to selection, on Windows it's CTRL
+                    let is_alt_down = click.modifiers.contains(input::keyboard::ALT) ||
+                                      click.modifiers.contains(input::keyboard::CTRL);
+
+                    let selection_event = match state.last_selected_entry {
+
+                        // If there is already a currently selected item and shift is
+                        // held, extend the selection to this one.
+                        Some(idx) if is_shift_down && multiple_selections => {
+
+                            // Default range
+                            let mut start_idx_range = std::cmp::min(idx, i);
+                            let mut end_idx_range = std::cmp::max(idx, i);
+
+                            // Get continous block selected from last selected idx
+                            // so the block can be extended up or down
+                            let (first, last) = selected_range(selected, idx);
+
+                            if i < first {
+                                start_idx_range = i;
+                                end_idx_range = last;
+                            }
+                            if i > last {
+                                start_idx_range = first;
+                                end_idx_range = i;
+                            }
+
+                            state.update(|state| state.last_selected_entry = Some(i));
+                            let selection = (start_idx_range..end_idx_range + 1).collect();
+                            Event::Selection(selection)
+                        },
+
+                        // If alt is down, additively select or deselect this item.
+                        Some(_) | None if is_alt_down && multiple_selections => {
+                            let mut selection: std::collections::HashSet<_> = selected.iter()
+                                .enumerate()
+                                .filter_map(|(i, &s)| if s { Some(i) } else { None })
+                                .collect();
+                            if !selected[i] {
+                                selection.insert(i);
                                 state.update(|state| state.last_selected_entry = Some(i));
-                                let selection = (start_idx_range..end_idx_range + 1).collect();
-                                Event::Selection(selection)
-                            },
+                            } else {
+                                selection.remove(&i);
+                            };
+                            Event::Selection(selection)
+                        },
 
-                            // If alt is down, additively select or deselect this item.
-                            Some(_) | None if is_alt_down && multiple_selections => {
-                                let mut selection: std::collections::HashSet<_> = selected.iter()
-                                    .enumerate()
-                                    .filter_map(|(i, &s)| if s { Some(i) } else { None })
-                                    .collect();
-                                if !selected[i] {
-                                    selection.insert(i);
-                                    state.update(|state| state.last_selected_entry = Some(i));
-                                } else {
-                                    selection.remove(&i);
+                        // Otherwise, no shift/ctrl/alt, select just this one
+                        // Clear all others
+                        _ => {
+                            let selection = std::iter::once(i).collect();
+                            state.update(|state| state.last_selected_entry = Some(i));
+                            Event::Selection(selection)
+                        },
+                    };
+
+                    pending_events.push_back(Event::Click(click));
+                    pending_events.push_back(selection_event);
+                },
+
+                // Check for whether or not the item should be selected.
+                event::Widget::Press(press) => {
+                    pending_events.push_back(Event::Press(press));
+                    match press.button {
+
+                        // Keyboard check whether the selection has been bumped up or down.
+                        event::Button::Keyboard(key) => {
+                            if let Some(i) = state.last_selected_entry {
+                                let event = match key {
+
+                                    // Bump the selection up the list.
+                                    input::Key::Up => {
+                                        let i = if i == 0 { 0 } else { i - 1 };
+                                        state.update(|state| state.last_selected_entry = Some(i));
+                                        let selection = std::iter::once(i).collect();
+                                        Event::Selection(selection)
+                                    },
+
+                                    // Bump the selection down the list.
+                                    input::Key::Down => {
+                                        let last_idx = entries.len() - 1;
+                                        let i = if i < last_idx { i + 1 } else { last_idx };
+                                        state.update(|state| state.last_selected_entry = Some(i));
+                                        let selection = std::iter::once(i).collect();
+                                        Event::Selection(selection)
+                                    },
+
+                                    _ => continue,
                                 };
-                                Event::Selection(selection)
-                            },
 
-                            // Otherwise, no shift/ctrl/alt, select just this one
-                            // Clear all others
-                            _ => {
-                                let selection = std::iter::once(i).collect();
-                                state.update(|state| state.last_selected_entry = Some(i));
-                                Event::Selection(selection)
-                            },
-                        };
+                                pending_events.push_back(event);
+                            }
+                        },
 
-                        events.push(Event::Click(click));
-                        events.push(selection_event);
-                    },
+                        _ => (),
+                    }
+                },
 
-                    // Check for whether or not the item should be selected.
-                    event::Widget::Press(press) => {
-                        events.push(Event::Press(press));
-                        match press.button {
+                event::Widget::Release(release) => {
+                    let event = Event::Release(release);
+                    pending_events.push_back(event);
+                },
 
-                            // Keyboard check whether the selection has been bumped up or down.
-                            event::Button::Keyboard(key) => {
-                                if let Some(i) = state.last_selected_entry {
-                                    let event = match key {
-
-                                        // Bump the selection up the list.
-                                        input::Key::Up => {
-                                            let i = if i == 0 { 0 } else { i - 1 };
-                                            state.update(|state| state.last_selected_entry = Some(i));
-                                            let selection = std::iter::once(i).collect();
-                                            Event::Selection(selection)
-                                        },
-
-                                        // Bump the selection down the list.
-                                        input::Key::Down => {
-                                            let last_idx = entries.len() - 1;
-                                            let i = if i < last_idx { i + 1 } else { last_idx };
-                                            state.update(|state| state.last_selected_entry = Some(i));
-                                            let selection = std::iter::once(i).collect();
-                                            Event::Selection(selection)
-                                        },
-
-                                        _ => continue,
-                                    };
-
-                                    events.push(event);
-                                }
-                            },
-
-                            _ => (),
-                        }
-                    },
-
-                    event::Widget::Release(release) => {
-                        let event = Event::Release(release);
-                        events.push(event);
-                    },
-
-                    _ => (),
-                }
+                _ => (),
             }
-
-            let label = format!("{}", self.entries[i].to_string());
-
-            // Button colors, depending if selected or not.
-            let (rect_color, text_color) =  match selected[i] {
-                true => (sel_rect_color, sel_text_color),
-                false => (unsel_rect_color, unsel_text_color),
-            };
-
-            let button = widget::Button::new()
-                .label(&label)
-                .label_color(text_color)
-                .color(rect_color)
-                .label_font_size(font_size)
-                .border(0.0);
-            item.set(button, &mut ui);
         }
 
-        if let Some(scrollbar) = list_scrollbar {
-            scrollbar.set(&mut ui);
+        let item_event = Event::Item(item);
+
+        // If we can avoid causing `pending_events` to allocate, do so.
+        match pending_events.pop_front() {
+            Some(event) => {
+                pending_events.push_back(item_event);
+                Some(event)
+            },
+            None => Some(item_event),
         }
-
-        events
     }
 
-}
-
-impl<'a, T> Colorable for ListSelect<'a, T> {
-    builder_method!(color { style.color = Some(Color) });
-}
-
-impl<'a, T> Borderable for ListSelect<'a, T> {
-    builder_methods!{
-        border { style.border = Some(Scalar) }
-        border_color { style.border_color = Some(Color) }
-    }
 }


### PR DESCRIPTION
A follow up to #778, this refactors `ListSelect` to properly take advantage of the new event API introduced in #786 and to behave more similarly to the `List` widget. This should increase the flexibility of the widget, allowing users to instantiate whatever widget type they like for each `Item` and to track the currently selected items however they wish (i.e. `Vec<bool>`, `HashSet<usize>`, etc).

This should pave the way for #759.

cc @Hyperchaotic 