### PR TITLE
Make Widget::State and Style Send

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -74,7 +74,7 @@ pub struct UniqueWidgetState<State, Style> where
 #[derive(Debug)]
 pub struct Container {
     /// Dynamically stored widget state.
-    pub maybe_state: Option<Box<Any>>,
+    pub maybe_state: Option<Box<Any + Send>>,
     /// The unique `TypeId` associated with the `Widget::State`.
     ///
     /// This is equal to `std::any::TypeId::of::<Widget::State>()`.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -52,7 +52,7 @@ pub struct Theme {
 /// The defaults for a specific widget.
 pub struct WidgetDefault {
     /// The unique style of a widget.
-    pub style: Box<Any>,
+    pub style: Box<Any + Send>,
     /// The attributes commonly shared between widgets.
     pub common: widget::CommonStyle,
 }
@@ -68,7 +68,7 @@ pub struct UniqueDefault<'a, T: 'a> {
 
 impl WidgetDefault {
     /// Constructor for a WidgetDefault.
-    pub fn new(style: Box<Any>) -> WidgetDefault {
+    pub fn new(style: Box<Any + Send>) -> WidgetDefault {
         WidgetDefault {
             style: style,
             common: widget::CommonStyle::new(),

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -459,7 +459,7 @@ pub trait Widget: Sized {
     /// calls to `update`.
     ///
     /// Conrod will never clone the state, it will only ever be moved.
-    type State: std::any::Any;
+    type State: std::any::Any + Send;
     /// Every widget is required to have its own associated `Style` type. This type is intended to
     /// contain high-level styling information for the widget that can be *optionally specified* by
     /// a user of the widget.
@@ -515,7 +515,7 @@ pub trait Widget: Sized {
     /// style retrieval method implementations.
     ///
     /// [1]: ./macro.widget_style!.html
-    type Style: Style;
+    type Style: Style + Send;
     /// The type of event yielded by the widget, returned via the `Widget::set` function.
     ///
     /// For a `Toggle` widget, this might be a `bool`.


### PR DESCRIPTION
I'd like to use the Ui from another thread sometimes, but it's not Send because of the various Anys. How about requiring Send for Widget::State and Style? It doesn't look like it should cause any problem, but I don't know anything about the conrod internals...