### PR TITLE
Fix relative links for macros

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -96,7 +96,7 @@ impl<Idx, Img> std::iter::Extend<(Idx, Img)> for Map<Img>
 
 /// A macro for simplifying the instantiation of an `image::Map`.
 ///
-/// See the [**Map**](./struct.Map.html) documentation for an example.
+/// See the [**Map**](./image/struct.Map.html) documentation for an example.
 #[macro_export]
 macro_rules! image_map {
     ($(($idx:expr, $img:expr)),* $(,)*) => {{

--- a/src/widget/style.rs
+++ b/src/widget/style.rs
@@ -159,7 +159,7 @@ macro_rules! impl_widget_style_retrieval_methods {
 /// `Style` type.
 ///
 /// For more information on the purpose of this `Style` type, see the associated `type Style` docs
-/// in the [`Widget` trait documentation](./trait.Widget.html).
+/// in the [`Widget` trait documentation](./widget/trait.Widget.html).
 ///
 /// Using the macro looks like this:
 ///


### PR DESCRIPTION
I was getting a couple of `404` while browsing the docs.