### PR TITLE
Fix missed TextBox::new constructor signature update

### DIFF
--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -65,7 +65,7 @@ pub struct State {
 impl<'a> TextBox<'a> {
 
     /// Construct a TextBox widget.
-    pub fn new(text: &'a mut String) -> Self {
+    pub fn new(text: &'a str) -> Self {
         TextBox {
             common: widget::CommonBuilder::new(),
             text: text,


### PR DESCRIPTION
This argument should have been updated to `&'a str` when changing over to the new `Widget::Event` system but was missed.