### PR TITLE
Add support for attributes and fix warnings for struct generated by `widget_ids`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.42.1"
+version = "0.43.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -170,7 +170,7 @@ fn main() {
 // with a unique `widget::Id` field for each identifier given in the list. See the `widget_ids!`
 // documentation for more details.
 widget_ids! {
-    Ids {
+    struct Ids {
         canvas,
         canvas_x_scrollbar,
         canvas_y_scrollbar,

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -151,7 +151,7 @@ const COLS: usize = 24;
 
 // Generate a unique `WidgetId` for each widget.
 widget_ids! {
-    Ids {
+    struct Ids {
         master,
         header,
         body,

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut ui = conrod::UiBuilder::new().build();
 
     // Generate the widget identifiers.
-    widget_ids!(Ids { canvas, counter });
+    widget_ids!(struct Ids { canvas, counter });
     let ids = Ids::new(ui.widget_id_generator());
 
     // Add a `Font` to the `Ui`'s `font::Map` from file.

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -55,7 +55,7 @@ mod circular_button {
     //
     // Here is where we generate the type that will produce these identifiers.
     widget_ids! {
-        Ids {
+        struct Ids {
             circle,
             text,
         }
@@ -247,7 +247,7 @@ pub fn main() {
 
     // The `widget_ids` macro is a easy, safe way of generating a type for producing `widget::Id`s.
     widget_ids! {
-        Ids {
+        struct Ids {
             // An ID for the background widget, upon which we'll place our custom button.
             background,
             // The WidgetId we'll use to plug our widget into the `Ui`.

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -24,7 +24,7 @@ fn main() {
     let mut ui = conrod::UiBuilder::new().build();
 
     // A unique identifier for each widget.
-    widget_ids!(Ids { canvas, file_navigator });
+    widget_ids!(struct Ids { canvas, file_navigator });
     let ids = Ids::new(ui.widget_id_generator());
 
     // Add a `Font` to the `Ui`'s `font::Map` from file.

--- a/examples/glutin_glium.rs
+++ b/examples/glutin_glium.rs
@@ -279,7 +279,7 @@ mod feature {
 
     // Generate a type which may produce unique identifier for each widget.
     widget_ids! {
-        Ids {
+        struct Ids {
             canvas,
             text,
         }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -29,7 +29,7 @@ fn main() {
     let mut text_texture_cache = conrod::backend::piston_window::GlyphCache::new(&mut window, 0, 0);
 
     // The `WidgetId` for our background and `Image` widgets.
-    widget_ids!(Ids { background, rust_logo });
+    widget_ids!(struct Ids { background, rust_logo });
     let ids = Ids::new(ui.widget_id_generator());
 
     // Create our `conrod::image::Map` which describes each of our widget->image mappings.

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -40,7 +40,7 @@ fn main() {
         conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // Declare the ID for each of our widgets.
-    widget_ids!(Ids { canvas, button, rust_logo });
+    widget_ids!(struct Ids { canvas, button, rust_logo });
     let ids = Ids::new(ui.widget_id_generator());
 
     // Create our `conrod::image::Map` which describes each of our widget->image mappings.

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -7,7 +7,7 @@ extern crate piston_window;
 use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 widget_ids! {
-    Ids { canvas, list }
+    struct Ids { canvas, list }
 }
 
 fn main() {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -5,7 +5,7 @@ extern crate piston_window;
 use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 widget_ids! {
-    Ids { canvas, list_select }
+    struct Ids { canvas, list_select }
 }
 
 fn main() {

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -5,7 +5,7 @@ extern crate piston_window;
 use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
 
 widget_ids! {
-    Ids { canvas, plot }
+    struct Ids { canvas, plot }
 }
 
 fn main() {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -7,7 +7,7 @@ use piston_window::*;
 
 // Generate a type that will produce a unique `widget::Id` for each widget.
 widget_ids! {
-    Ids {
+    struct Ids {
         canvas,
         line,
         point_path,

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -8,7 +8,7 @@ use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
 
 
 widget_ids! { 
-    Ids { canvas, oval, range_slider }
+    struct Ids { canvas, oval, range_slider }
 }
 
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -66,7 +66,7 @@ fn main() {
 
 // Generate a unique const `WidgetId` for each widget.
 widget_ids!{
-    Ids {
+    struct Ids {
         master,
         left_col,
         middle_col,

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -5,7 +5,7 @@ extern crate piston_window;
 use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent};
 
 widget_ids! { 
-    Ids { canvas, text_edit }
+    struct Ids { canvas, text_edit }
 }
 
 fn main() {

--- a/src/widget/bordered_rectangle.rs
+++ b/src/widget/bordered_rectangle.rs
@@ -32,7 +32,7 @@ pub struct BorderedRectangle {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         border,
         rectangle,
     }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -48,7 +48,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         label,
     }

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -58,7 +58,7 @@ pub struct State {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         title_bar,
     }

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -57,7 +57,7 @@ widget_style! {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         closed_menu,
         list,
     }

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -63,7 +63,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         label,
         value_label,

--- a/src/widget/file_navigator/directory_view.rs
+++ b/src/widget/file_navigator/directory_view.rs
@@ -53,7 +53,7 @@ pub struct Entry {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         list_select,
     }

--- a/src/widget/file_navigator/mod.rs
+++ b/src/widget/file_navigator/mod.rs
@@ -77,7 +77,7 @@ pub struct Directory {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         scrollable_canvas,
         scrollbar,
         directory_views[],

--- a/src/widget/id.rs
+++ b/src/widget/id.rs
@@ -174,6 +174,7 @@ macro_rules! widget_ids {
         impl $Ids {
 
             /// Construct a new `widget::Id` container.
+            #[allow(unused_mut, unused_variables)]
             pub fn new(mut generator: $crate::widget::id::Generator) -> Self {
                 widget_ids! {
                     constructor $Ids, generator { {} $($id)* }

--- a/src/widget/id.rs
+++ b/src/widget/id.rs
@@ -23,6 +23,7 @@ pub type Id = daggy::NodeIndex<u32>;
 pub struct Generator<'a> { widget_graph: &'a mut Graph }
 
 /// A list of lazily generated `widget::Id`s.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct List(Vec<Id>);
 /// An iterator-like type for producing indices from a `List`.
 #[allow(missing_copy_implementations)]
@@ -269,7 +270,8 @@ macro_rules! widget_ids {
     };
 
     // The same as the previous branch, but private.
-    (define_struct [] $Ids:ident { { $($id:ident: $T:path,)* } }) => {
+    (define_struct $(#[$attr:meta])* [] $Ids:ident { { $($id:ident: $T:path,)* } }) => {
+        $(#[$attr])*
         struct $Ids {
             $(pub $id: $T,
             )*
@@ -361,7 +363,9 @@ fn test() {
     use widget::{self, Widget};
 
     widget_ids! {
-        struct Ids {
+        /// Testing generated Ids doc comments.
+        #[derive(Clone)]
+        pub struct Ids {
             button,
             toggles[],
         }

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -49,7 +49,7 @@ widget_style! {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         scroll_trigger,
         items[],
         scrollbar,

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -45,7 +45,7 @@ pub trait Mode {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         list,
     }
 }

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -54,7 +54,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         label,
     }

--- a/src/widget/plot_path.rs
+++ b/src/widget/plot_path.rs
@@ -31,7 +31,7 @@ widget_style! {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         point_path,
     }
 }

--- a/src/widget/range_slider.rs
+++ b/src/widget/range_slider.rs
@@ -45,7 +45,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         border,
         slider,
         label,

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -61,7 +61,7 @@ widget_style! {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         track,
         handle,
     }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -60,7 +60,7 @@ widget_style! {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         border,
         slider,
         label,

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -51,7 +51,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         text_edit,
         rectangle,
     }

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -55,7 +55,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         selected_rectangles[],
         text,
         cursor,

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -32,7 +32,7 @@ pub struct State {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         label,
     }

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -47,7 +47,7 @@ widget_style! {
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         label,
     }

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -50,7 +50,7 @@ widget_style!{
 }
 
 widget_ids! {
-    Ids {
+    struct Ids {
         rectangle,
         label,
         h_line,


### PR DESCRIPTION
This slightly changes the syntax of the `widget_ids!` macro:

Before:
```rust
widget_ids! { Ids { button, toggles[] } }
```
After:
```rust
widget_ids! { struct Ids { button, toggles[] } }
```

This change to the syntax is in order to allow for the `Ids` struct to have attributes applied to it (including doc comments).