### PR TITLE
Fix bug where the List's Scrollbar would display even when the list is not scrollable.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.43.1"
+version = "0.44.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -91,5 +91,5 @@ fn set_ui(ref mut ui: conrod::UiCell, list: &mut [bool], ids: &Ids) {
         }
     }
 
-    scrollbar.unwrap().set(ui);
+    if let Some(s) = scrollbar { s.set(ui) }
 }

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -89,7 +89,6 @@ fn main() {
                 .scrollbar_next_to()
                 .w_h(350.0, 220.0)
                 .top_left_with_margins_on(ids.canvas, 40.0, 40.0)
-                .scrollbar_next_to()
                 .set(ids.list_select, ui);
 
             // Handle the `ListSelect`s events.
@@ -126,7 +125,7 @@ fn main() {
             }
 
             // Instantiate the scrollbar for the list.
-            scrollbar.unwrap().set(ui);
+            if let Some(s) = scrollbar { s.set(ui); }
         });
 
         window.draw_2d(&event, |c, g| {

--- a/src/widget/file_navigator/directory_view.rs
+++ b/src/widget/file_navigator/directory_view.rs
@@ -348,7 +348,7 @@ impl<'a> Widget for DirectoryView<'a> {
             }
         }
 
-        scrollbar.map(|s| s.set(ui));
+        if let Some(s) = scrollbar { s.set(ui); }
 
         // If the scrollable `Rectangle` was pressed, deselect all entries.
         if ui.widget_input(id).presses().mouse().left().next().is_some() {

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -285,11 +285,11 @@ impl Widget for List {
             item_h: item_h,
         };
 
-        // Instantiate the `Scrollbar` if necessary.
-        let auto_hide = match scrollbar_position {
-            Some(ScrollbarPosition::NextTo) => false,
-            Some(ScrollbarPosition::OnTop) => true,
-            None => return (items, None),
+        // Instantiate the `Scrollbar` only if necessary.
+        let auto_hide = match (is_scrollable, scrollbar_position) {
+            (false, _) | (true, None) => return (items, None),
+            (_, Some(ScrollbarPosition::NextTo)) => false,
+            (_, Some(ScrollbarPosition::OnTop)) => true,
         };
         let scrollbar_color = style.scrollbar_color(&ui.theme);
         let scrollbar = widget::Scrollbar::y_axis(id)


### PR DESCRIPTION
Updates from **0.43.1** to **0.44.0** as this fix may break code that calls `unwrap` on the `Option<Scrollbar>` produced by the `List` and `ListSelect` widgets.