### PR TITLE
Added actions for Delete, Home and End to TextEdit widget

### DIFF
--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -651,13 +651,10 @@ impl<'a> Widget for TextEdit<'a> {
                                 Cursor::Idx(idx) => idx.line,
                                 Cursor::Selection {end, ..} => end.line, // use last line of selection
                             };
-                            match line_infos.nth(line) {
-                                Some(line_info) => {
-                                    let char = line_info.end_char() - line_info.start_char;
-                                    let new_cursor_idx = text::cursor::Index { line: line, char: char };
-                                    cursor = Cursor::Idx(new_cursor_idx);
-                                },
-                                _ => (),
+                            if let Some(line_info) = line_infos.nth(line) {
+                                let char = line_info.end_char() - line_info.start_char;
+                                let new_cursor_idx = text::cursor::Index { line: line, char: char };
+                                cursor = Cursor::Idx(new_cursor_idx);
                             }
                         },
 
@@ -667,13 +664,10 @@ impl<'a> Widget for TextEdit<'a> {
                                 Cursor::Idx(idx) => idx.line,
                                 Cursor::Selection {start, ..} => start.line, // use first line of selection
                             };
-                            match line_infos.nth(line) {
-                                Some(_) => {
-                                    let char = 0;
-                                    let new_cursor_idx = text::cursor::Index { line: line, char: char };
-                                    cursor = Cursor::Idx(new_cursor_idx);
-                                },
-                                _ => (),
+                            if line_infos.nth(line).is_some() {
+                                let char = 0;
+                                let new_cursor_idx = text::cursor::Index { line: line, char: char };
+                                cursor = Cursor::Idx(new_cursor_idx);
                             }
                         },
 


### PR DESCRIPTION
I added the following actions for Delete, Home and End to TextEdit widget:

Delete:
- no selection: delete char at cursor
- selection: delete selected text

Home:
- no selection: move cursor to beginning of line
- selection: go to beginning of the line where selection begins

End:
- no selection: move cursor to end of line
- selection: go to end of the line where selection ends

I'm not very familiar with the internals, I used the code from similar key actions and modified it.. Maybe the common code should be factored out into a function.

Other actions that I would still like to see:
- shift+left/right: select text by one char at a time
- ctrl+shift+left/right: select text by one word at a time (ctrl+left/right already moves cursor by one word)
- shift+home/end: select text until beginning/end of line
- ctrl+home/end: go to beginning/end of the whole text
- ctrl+shift+home/end: select text until beginning/end of whole text
- double click: select word
- triple click: select line / sentence / paragraph (in code editors it usually selects the line, in browsers the paragraph)