### PR TITLE
Waiting event loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,25 @@ rusttype = "0.2.0"
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston_window` module.
 # Note: Use the `piston` feature for `piston_window` event conversions.
+#
+# `event_loop`
+# Enables use of piston_window backend with a non-polling event loop
 glium = { version = "0.15.0", optional = true }
 glutin = { version = "0.6.1", optional = true }
 piston2d-graphics = { version = "0.17", optional = true }
-piston_window = { version = "0.52", optional = true }
+piston_window = { version = "0.53", optional = true }
+pistoncore-glutin_window = { version = "0.30.0", optional = true }
+pistoncore-window = { version = "0.22.0", optional = true }
+gfx = { version = "0.12.0", optional = true }
+gfx_core = { version = "0.4.0", optional = true }
+gfx_device_gl = { version = "0.11.0", optional = true }
+
+
+
 [features]
-default = ["piston", "piston_window"]
+default = ["piston", "piston_window", "event_loop"]
 piston = ["piston2d-graphics"]
+event_loop = ["pistoncore-window", "pistoncore-glutin_window", "glutin", "gfx", "gfx_core", "gfx_device_gl"]
 
 [dev-dependencies]
 find_folder = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,23 +51,18 @@ rusttype = "0.2.0"
 # Note: Use the `piston` feature for `piston_window` event conversions.
 #
 # `event_loop`
-# Enables use of piston_window backend with a non-polling event loop
+# Enables use of piston_window backend with a non-polling event loop, only compatible with glutin_window
 glium = { version = "0.15.0", optional = true }
 glutin = { version = "0.6.1", optional = true }
 piston2d-graphics = { version = "0.17", optional = true }
-piston_window = { version = "0.53", optional = true }
+piston_window = { version = "0.54.0", optional = true }
 pistoncore-glutin_window = { version = "0.30.0", optional = true }
 pistoncore-window = { version = "0.22.0", optional = true }
-gfx = { version = "0.12.0", optional = true }
-gfx_core = { version = "0.4.0", optional = true }
-gfx_device_gl = { version = "0.11.0", optional = true }
-
-
 
 [features]
 default = ["piston", "piston_window", "event_loop"]
 piston = ["piston2d-graphics"]
-event_loop = ["pistoncore-window", "pistoncore-glutin_window", "glutin", "gfx", "gfx_core", "gfx_device_gl"]
+event_loop = ["pistoncore-window", "pistoncore-glutin_window", "glutin"]
 
 [dev-dependencies]
 find_folder = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ pistoncore-window = { version = "0.22.0", optional = true }
 [features]
 default = ["piston", "piston_window", "event_loop"]
 piston = ["piston2d-graphics"]
-event_loop = ["pistoncore-window", "pistoncore-glutin_window", "glutin"]
+event_loop = ["pistoncore-window", "pistoncore-glutin_window"]
 
 [dev-dependencies]
 find_folder = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,20 +49,15 @@ rusttype = "0.2.0"
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston_window` module.
 # Note: Use the `piston` feature for `piston_window` event conversions.
-#
-# `event_loop`
-# Enables use of piston_window backend with a non-polling event loop, only compatible with glutin_window
 glium = { version = "0.15.0", optional = true }
 glutin = { version = "0.6.1", optional = true }
 piston2d-graphics = { version = "0.17", optional = true }
-piston_window = { version = "0.54.0", optional = true }
-pistoncore-glutin_window = { version = "0.30.0", optional = true }
-pistoncore-window = { version = "0.22.0", optional = true }
+piston_window = { version = "0.55.0", optional = true }
+pistoncore-window = { version = "0.23.0", optional = true }
 
 [features]
-default = ["piston", "piston_window", "event_loop"]
-piston = ["piston2d-graphics"]
-event_loop = ["pistoncore-window", "pistoncore-glutin_window"]
+default = ["piston", "piston_window"]
+piston = ["piston2d-graphics", "pistoncore-window"]
 
 [dev-dependencies]
 find_folder = "0.3.0"

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -42,7 +42,7 @@ fn main() {
     let ids = &mut Ids::new(ui.widget_id_generator());
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -4,7 +4,8 @@
 extern crate find_folder;
 extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 
 fn main() {
@@ -18,7 +19,9 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -39,7 +42,7 @@ fn main() {
     let ids = &mut Ids::new(ui.widget_id_generator());
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -8,7 +8,8 @@ fn main() {
     const HEIGHT: u32 = 200;
 
     use conrod::{widget, Labelable, Positionable, Sizeable, Widget};
-    use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+    use piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+    use conrod::backend::events::{WindowEvents, EventWindow};
 
     // Change this to OpenGL::V2_1 if not working.
     let opengl = OpenGL::V3_2;
@@ -16,7 +17,9 @@ fn main() {
     // Construct the window.
     let mut window: PistonWindow = WindowSettings::new("Click me!", [WIDTH, HEIGHT])
         .opengl(opengl).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -40,7 +43,7 @@ fn main() {
     let mut count = 0;
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
@@ -62,6 +65,8 @@ fn main() {
                 .set(ids.counter, ui)
             {
                 count += 1;
+                // Update the UI to reflect the new count
+                events.update();
             }
         });
 

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -271,7 +271,7 @@ pub fn main() {
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
 
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -223,7 +223,8 @@ mod circular_button {
 
 pub fn main() {
     use conrod::{self, widget, Colorable, Labelable, Positionable, Sizeable, Widget};
-    use piston_window::{EventLoop, PistonWindow, OpenGL, UpdateEvent, WindowSettings};
+    use piston_window::{PistonWindow, OpenGL, UpdateEvent, WindowSettings};
+    use conrod::backend::events::{WindowEvents, EventWindow};
     use self::circular_button::CircularButton;
 
     const WIDTH: u32 = 1200;
@@ -240,7 +241,9 @@ pub fn main() {
         .opengl(opengl)
         .exit_on_esc(true)
         .build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -268,7 +271,7 @@ pub fn main() {
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
 
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/glutin_glium.rs
+++ b/examples/glutin_glium.rs
@@ -7,8 +7,7 @@ fn main() {
     feature::main();
 }
 
-#[cfg(feature="glutin")]
-#[cfg(feature="glium")]
+#[cfg(all(feature="glutin", feature="glium"))]
 mod feature {
     extern crate find_folder;
     use conrod;
@@ -312,8 +311,7 @@ mod feature {
     }
 }
 
-#[cfg(not(feature="glutin"))]
-#[cfg(not(feature="glium"))]
+#[cfg(not(all(feature="glutin", feature="glium")))]
 mod feature {
     pub fn main() {
         println!("This example requires the `glutin` and `glium` features. \

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -7,7 +7,8 @@ extern crate find_folder;
 extern crate piston_window;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
-use piston_window::{EventLoop, Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
+use piston_window::{Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 fn main() {
     const WIDTH: u32 = 800;
@@ -20,7 +21,9 @@ fn main() {
     let mut window: PistonWindow =
         piston_window::WindowSettings::new("Image Widget Demonstration", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).samples(4).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -42,7 +45,7 @@ fn main() {
     let (w, h) = image_map.get(&ids.rust_logo).unwrap().get_size();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
         ui.handle_event(event.clone());
 
         window.draw_2d(&event, |c, g| {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -45,7 +45,7 @@ fn main() {
     let (w, h) = image_map.get(&ids.rust_logo).unwrap().get_size();
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
         ui.handle_event(event.clone());
 
         window.draw_2d(&event, |c, g| {

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -36,7 +36,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -2,7 +2,8 @@
 extern crate find_folder;
 extern crate piston_window;
 
-use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 widget_ids! {
     struct Ids { canvas, plot }
@@ -18,7 +19,9 @@ fn main() {
             .exit_on_esc(true)
             .build()
             .unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -33,7 +36,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -2,7 +2,8 @@
 extern crate find_folder;
 extern crate piston_window;
 
-use piston_window::*;
+use piston_window::{PistonWindow, UpdateEvent, WindowSettings, OpenGL};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 
 // Generate a type that will produce a unique `widget::Id` for each widget.
@@ -30,7 +31,9 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("Primitives Demo", [400, 720])
             .opengl(opengl).samples(4).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -45,7 +48,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -48,7 +48,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -4,7 +4,8 @@
 extern crate find_folder;
 extern crate piston_window;
 
-use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 
 widget_ids! { 
@@ -21,7 +22,9 @@ fn main() {
         WindowSettings::new("RangeSlider Demo", [WIDTH, HEIGHT])
             .opengl(piston_window::OpenGL::V3_2)
             .exit_on_esc(true).samples(4).vsync(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -44,7 +47,7 @@ fn main() {
     let mut oval_range = (0.25, 0.75);
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -47,7 +47,7 @@ fn main() {
     let mut oval_range = (0.25, 0.75);
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -44,7 +44,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -2,7 +2,8 @@
 extern crate find_folder;
 extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 
 fn main() {
@@ -16,7 +17,9 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -41,7 +44,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -49,7 +49,7 @@ fn main() {
         magna est, efficitur suscipit dolor eu, consectetur consectetur urna.".to_owned();
 
     // Poll events from the window.
-    while let Some(event) = window.next_event(&mut events, false) {
+    while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -2,7 +2,8 @@
 extern crate find_folder;
 extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent};
+use piston_window::{OpenGL, PistonWindow, UpdateEvent};
+use conrod::backend::events::{WindowEvents, EventWindow};
 
 widget_ids! { 
     struct Ids { canvas, text_edit }
@@ -16,7 +17,9 @@ fn main() {
     let mut window: PistonWindow =
         piston_window::WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
             .opengl(OpenGL::V3_2).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -46,7 +49,7 @@ fn main() {
         magna est, efficitur suscipit dolor eu, consectetur consectetur urna.".to_owned();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = window.next_event(&mut events, false) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/src/backend/events.rs
+++ b/src/backend/events.rs
@@ -1,0 +1,205 @@
+//! A event loop for a typical UI application, adapted from the standard piston event loop.
+//! Unlike the piston event loop, this event loop will block and wait for input rather than continuously poll, unless an animation is running.
+
+#![deny(missing_docs)]
+#![deny(missing_copy_implementations)]
+
+extern crate glutin_window;
+extern crate glutin;
+extern crate window;
+extern crate piston_window;
+extern crate gfx;
+extern crate gfx_core;
+extern crate gfx_device_gl;
+
+use std::thread;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use self::window::Window;
+use piston_input::*;
+use self::glutin_window::*;
+
+use self::gfx_core::Device;
+use self::gfx_core::factory::Typed;
+
+use self::piston_window::PistonWindow;
+
+enum State {
+    Rendered,
+    Updated,
+    Waiting,
+}
+
+/// An event loop iterator
+///
+/// *Warning: Because the iterator polls events from the window back-end,
+/// it must be used on the same thread as the window back-end (usually main thread),
+/// unless the window back-end supports multi-thread event polling.*
+//#[derive(Copy, Clone)]
+pub struct WindowEvents {
+    state: State,
+    /// if true, an update should be triggered in time for the next frame,
+    /// either because an input event happened, or the UI is animating
+    idle: bool,
+    last_frame_time: Instant,
+    next_frame_time: Instant,
+    dt_frame: Duration,
+}
+
+static BILLION: u64 = 1_000_000_000;
+fn ns_to_duration(ns: u64) -> Duration {
+    let secs = ns / BILLION;
+    let nanos = (ns % BILLION) as u32;
+    Duration::new(secs, nanos)
+}
+fn duration_to_f64(dur: Duration) -> f64 {
+    dur.as_secs() as f64 + dur.subsec_nanos() as f64 / 1000_000_000.0
+}
+fn duration_to_seconds(dur: Duration) -> f64 {
+    duration_to_f64(dur) / BILLION as f64
+}
+
+/// The default maximum frames per second.
+pub const DEFAULT_MAX_FPS: u64 = 60;
+
+fn render_args(window: &GlutinWindow, duration: f64) -> RenderArgs {
+    RenderArgs {
+        ext_dt: duration,
+        width: window.size().width,
+        height: window.size().height,
+        draw_width: window.draw_size().width,
+        draw_height: window.draw_size().height,
+    }
+}
+
+impl WindowEvents
+{
+    /// Creates a new event iterator
+    pub fn new_with_fps(max_fps: u64) -> WindowEvents {
+        let start = Instant::now();
+        let frame_length = ns_to_duration(BILLION / max_fps);
+        WindowEvents {
+            state: State::Waiting,
+            idle: true,
+            last_frame_time: start,
+            next_frame_time: start + frame_length,
+            dt_frame: frame_length,
+        }
+    }
+    /// Creates a new event iterator with default FPS settings.
+    pub fn new() -> WindowEvents {
+        WindowEvents::new_with_fps(DEFAULT_MAX_FPS)
+    }
+
+    /// Returns the next event.
+    pub fn next(&mut self, window: &mut GlutinWindow, animating: bool) -> Option<Event>
+    {
+        if window.should_close() { return None; }
+
+        match self.state {
+            State::Rendered => {
+                window.swap_buffers();
+                self.last_frame_time = Instant::now();
+                self.next_frame_time = self.last_frame_time + self.dt_frame;
+                self.state = State::Waiting;
+                // never go idle as long as an animation is running
+                self.idle = !animating;
+                return Some(Event::AfterRender(AfterRenderArgs));
+            },
+            State::Updated => {
+                let size = window.size();
+                if size.width != 0 && size.height != 0 {
+                    self.state = State::Rendered;
+                    let duration = duration_to_seconds(Instant::now() - self.last_frame_time);
+                    return Some(Event::Render(render_args(window, duration)));
+                }
+            }, _ => ()
+        }
+        loop {
+            // handle any pending input before updating
+            if let Some(e) = window.poll_event() {
+                self.idle = false;
+                return Some(Event::Input(e));
+            }
+            if !self.idle {
+                let current_time = Instant::now();
+                if current_time >= self.next_frame_time {
+                    self.state = State::Updated;
+                    let duration = duration_to_seconds(current_time - self.last_frame_time);
+                    return Some(Event::Update(UpdateArgs{ dt: duration }));
+                } else {
+                    // schedule wake up from `wait_event` in time for the next frame
+                    let window_proxy = window.window.create_window_proxy();
+                    let sleep_time = self.next_frame_time - current_time;
+                    thread::spawn(move || {
+                        sleep(sleep_time);
+                        window_proxy.wakeup_event_loop();
+                    });
+                }
+            }
+            // block and wait until an event is received, or it's time to update
+            let event = window.wait_event();
+            if let Some(e) = event {
+                self.idle = false;
+                return Some(Event::Input(e));
+            }
+        }
+    }
+}
+
+// TODO: below code can be cleaned up/removed if piston_window is refactored
+fn create_main_targets(dim: gfx::tex::Dimensions) ->
+(gfx::handle::RenderTargetView<
+    gfx_device_gl::Resources, gfx::format::Srgba8>,
+ gfx::handle::DepthStencilView<
+    gfx_device_gl::Resources, gfx::format::DepthStencil>) {
+    use self::gfx_core::factory::Typed;
+    use self::gfx::format::{DepthStencil, Format, Formatted, Srgba8};
+
+    let color_format: Format = <Srgba8 as Formatted>::get_format();
+    let depth_format: Format = <DepthStencil as Formatted>::get_format();
+    let (output_color, output_stencil) =
+        gfx_device_gl::create_main_targets_raw(dim,
+                                               color_format.0,
+                                               depth_format.0);
+    let output_color = Typed::new(output_color);
+    let output_stencil = Typed::new(output_stencil);
+    (output_color, output_stencil)
+}
+
+/// Allows a window to use an external event loop
+pub trait EventWindow {
+    /// receive next event from event loop and handle it
+    fn next_event(&mut self, events: &mut WindowEvents, animating: bool) -> Option<Event>;
+    /// handle new event and update window
+    fn handle_event(&mut self, event: &Event);
+}
+
+impl EventWindow for PistonWindow {
+    fn next_event(&mut self, events: &mut WindowEvents, animating: bool) -> Option<Event> {
+        let event = events.next(&mut self.window, animating);
+        if let Some(e) = event {
+            self.handle_event(&e);
+            Some(e)
+        } else { None }
+    }
+    fn handle_event(&mut self, event: &Event) {
+        if let Some(_) = event.after_render_args() {
+            // After swapping buffers.
+            self.device.cleanup();
+        }
+        // Check whether window has resized and update the output.
+        let dim = self.output_color.raw().get_dimensions();
+        let (w, h) = (dim.0, dim.1);
+        let draw_size = self.window.draw_size();
+        if w != draw_size.width as u16 || h != draw_size.height as u16 {
+            let dim = (draw_size.width as u16,
+                       draw_size.height as u16,
+                       dim.2, dim.3);
+            let (output_color, output_stencil) = create_main_targets(dim);
+            self.output_color = output_color;
+            self.output_stencil = output_stencil;
+        }
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,3 +11,4 @@
 #[cfg(feature="glutin")] pub mod glutin;
 #[cfg(feature="piston")] pub mod piston;
 #[cfg(feature="piston")] #[cfg(feature="piston_window")] pub mod piston_window;
+#[cfg(feature="piston")] #[cfg(feature="piston_window")] #[cfg(feature="event_loop")] pub mod events;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,4 +11,4 @@
 #[cfg(feature="glutin")] pub mod glutin;
 #[cfg(feature="piston")] pub mod piston;
 #[cfg(feature="piston")] #[cfg(feature="piston_window")] pub mod piston_window;
-#[cfg(feature="piston")] #[cfg(feature="piston_window")] #[cfg(feature="event_loop")] pub mod events;
+#[cfg(feature="piston")] #[cfg(feature="piston_window")] pub mod events;


### PR DESCRIPTION
This adds an optional waiting event loop that can be used with the `piston_window` backend, allowing apps to go completely idle when no events are being handled, saving background resources. See #802 

The new event loop takes a boolean parameter that indicates an animation is in progress, to trigger an update whether an event happens or not. By setting it to always true, the new event loop should have the same behaviour as the default piston event loop.

It works with piston_window but doesn't integrate perfectly with it, that is, it duplicates some code from piston_window, pulls in extra dependencies, and piston_window will still instantiate the old event loop and not use it.

The proper solution seems to be to either change the API of piston_window, which would be a breaking change, or include a forked version with conrod, since it seems like piston_window itself is not necessarily intended to be completely extensible. Not sure what the best thing to do is.
This works for now, but fixing up piston_window could remove some of the dependencies, although they are optional, and they will be pulled in by piston_window regardless.

Right now, it only works with `GlutinWindow`, until `wait_event` (blocking analog to `poll_event`) is added to the other piston back ends.

I modified some examples to use the new event loop, but there are some issues with the other ones, so I left those ones alone.
The issues seem to be caused is caused by code like this:

```
for _click in widget::Button::new()
    ...
    .label(&count.to_string())
    .set(ids.counter, ui)
{
    count += 1;
}
```

It seems that the widget layout is set, and then the click event is handled. This means that it takes one more update event before it displays the correct value.
This only manifests when you click the button and try not to move the mouse at all, because moving the mouse still triggers an update so it will update the widget anyway. 
As a side note, ideally events that don't cause any changes to state (most mouse move events) shouldn't be able to modify the UI.

I can hack around it by setting animation to true for one frame after the click happens, but I think the proper solution should be to make event handling and widget updating happening on the same frame, in one atomic event, so I left those examples alone for now.
