### PR TITLE
PistonWindow fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,32 @@ rusttype = "0.2.0"
 #
 # `piston_window`
 # Provides functions for:
+# - A convenience wrapper around the various piston window backends,
+# (by default, GlutinWindow), and 2d drawing functionality.
+# Contains code adapted from the `piston_window` crate.
 # - Text cache `G2dTexture` construction.
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
-# Enables the `conrod::backend::piston_window` module.
 # Note: Use the `piston` feature for `piston_window` event conversions.
 glium = { version = "0.15.0", optional = true }
 glutin = { version = "0.6.1", optional = true }
 piston2d-graphics = { version = "0.17", optional = true }
-piston_window = { version = "0.52", optional = true }
+
+gfx = { version = "0.12.0", optional = true }
+gfx_core = { version = "0.4.0", optional = true }
+gfx_device_gl = { version = "0.11.0", optional = true }
+pistoncore-window = { version = "0.23.0", optional = true }
+pistoncore-event_loop = { version = "0.26.0", optional = true }
+piston2d-gfx_graphics = { version = "0.31.1", optional = true }
+piston-texture = { version = "0.5.0", optional = true }
+shader_version = { version = "0.2.0", optional = true }
+pistoncore-glutin_window = { version = "0.31.0", optional = true }
+
 [features]
 default = ["piston", "piston_window"]
 piston = ["piston2d-graphics"]
+piston_window = ["pistoncore-window", "pistoncore-event_loop", "gfx", "gfx_core",
+                 "gfx_device_gl", "piston2d-gfx_graphics", "shader_version",
+                 "pistoncore-glutin_window", "piston-texture"]
 
 [dev-dependencies]
 gfx = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,6 @@ rusttype = "0.2.0"
 # - Converting piston `GenericEvent` types to `conrod::event::Raw`s.
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston` module.
-#
-# `piston_window`
-# Provides functions for:
 # - A convenience wrapper around the various piston window backends,
 # (by default, GlutinWindow), and 2d drawing functionality.
 # Contains code adapted from the `piston_window` crate.
@@ -66,11 +63,10 @@ shader_version = { version = "0.2.0", optional = true }
 pistoncore-glutin_window = { version = "0.31.0", optional = true }
 
 [features]
-default = ["piston", "piston_window"]
-piston = ["piston2d-graphics"]
-piston_window = ["pistoncore-window", "pistoncore-event_loop", "gfx", "gfx_core",
-                 "gfx_device_gl", "piston2d-gfx_graphics", "shader_version",
-                 "pistoncore-glutin_window", "piston-texture"]
+default = ["piston"]
+piston = ["piston2d-graphics", "pistoncore-window", "pistoncore-event_loop", "gfx",
+          "gfx_core", "gfx_device_gl", "piston2d-gfx_graphics", "shader_version",
+          "pistoncore-glutin_window", "piston-texture"]
 
 [dev-dependencies]
 gfx = "0.12.0"

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -2,11 +2,12 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-use conrod::backend::piston_window::{self, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
 
 mod support;
+
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 
 fn main() {
@@ -14,9 +15,9 @@ fn main() {
     const HEIGHT: u32 = support::WIN_H;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
-            .opengl(OpenGL::V3_2) // If not working, try `OpenGL::V2_1`.
+    let mut window: Window =
+        piston_window::WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
+            .opengl(piston_window::OpenGL::V3_2) // If not working, try `OpenGL::V2_1`.
             .samples(4)
             .exit_on_esc(true)
             .vsync(true)
@@ -39,8 +40,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // Instantiate the generated list of widget identifiers.
     let ids = support::Ids::new(ui.widget_id_generator());
@@ -55,7 +55,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -67,17 +67,17 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }
 }
 
 // Load the Rust logo from our assets folder.
-fn load_rust_logo(window: &mut PistonWindow) -> piston_window::G2dTexture<'static> {
+fn load_rust_logo(window: &mut Window) -> piston_window::G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");
     let factory = &mut window.factory;

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -2,9 +2,7 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
-
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 mod support;
 

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -2,7 +2,9 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-use conrod::backend::piston_window::{self, EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+
 
 mod support;
 
@@ -20,7 +22,10 @@ fn main() {
             .vsync(true)
             .build()
             .unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // A demonstration of some state that we'd like to control with the App.
     let mut app = support::DemoApp::new();
@@ -47,7 +52,7 @@ fn main() {
     };
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -6,8 +6,8 @@ extern crate find_folder;
 mod support;
 
 use conrod::backend::piston::gfx::*;
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 
@@ -18,7 +18,7 @@ fn main() {
     // Construct the window.
     let mut window: Window =
         piston_window::WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
-            .opengl(piston_window::OpenGL::V3_2) // If not working, try `OpenGL::V2_1`.
+            .opengl(OpenGL::V3_2) // If not working, try `OpenGL::V2_1`.
             .samples(4)
             .exit_on_esc(true)
             .vsync(true)

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -5,6 +5,7 @@ extern crate find_folder;
 
 mod support;
 
+use conrod::backend::piston::gfx::*;
 use conrod::backend::piston::{Window, UpdateEvent};
 use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
@@ -48,7 +49,7 @@ fn main() {
     // Create our `conrod::image::Map` which describes each of our widget->image mappings.
     // In our case we only have one image, however the macro may be used to list multiple.
     let image_map = image_map! {
-        (ids.rust_logo, load_rust_logo(&mut window)),
+        (ids.rust_logo, load_rust_logo(&mut window.context)),
     };
 
     // Poll events from the window.
@@ -77,10 +78,10 @@ fn main() {
 }
 
 // Load the Rust logo from our assets folder.
-fn load_rust_logo(window: &mut Window) -> piston_window::G2dTexture<'static> {
+fn load_rust_logo(context: &mut GfxContext) -> G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");
-    let factory = &mut window.factory;
-    let settings = piston_window::TextureSettings::new();
-    piston_window::Texture::from_path(factory, &path, piston_window::Flip::None, &settings).unwrap()
+    let factory = &mut context.factory;
+    let settings = TextureSettings::new();
+    Texture::from_path(factory, &path, Flip::None, &settings).unwrap()
 }

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -3,7 +3,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 
 fn main() {
@@ -17,7 +18,10 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -38,7 +42,7 @@ fn main() {
     let ids = &mut Ids::new(ui.widget_id_generator());
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -2,9 +2,8 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 
 fn main() {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -3,20 +3,20 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 fn main() {
     const WIDTH: u32 = 800;
     const HEIGHT: u32 = 600;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = OpenGL::V3_2;
+    let opengl = piston_window::OpenGL::V3_2;
     
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
+    let mut window: Window =
+        piston_window::WindowSettings::new("Canvas Demo", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
 
     // Create the event loop.
@@ -32,8 +32,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -45,7 +44,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -56,10 +55,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -3,8 +3,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 fn main() {
@@ -12,7 +12,7 @@ fn main() {
     const HEIGHT: u32 = 600;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
     
     // Construct the window.
     let mut window: Window =

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,14 +7,16 @@ fn main() {
     const HEIGHT: u32 = 200;
 
     use conrod::{widget, Labelable, Positionable, Sizeable, Widget};
-    use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
-    use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+
+    use conrod::backend::piston::{Window, UpdateEvent};
+    use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+    use conrod::backend::piston::window as piston_window;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = OpenGL::V3_2;
+    let opengl = piston_window::OpenGL::V3_2;
     
     // Construct the window.
-    let mut window: PistonWindow = WindowSettings::new("Click me!", [WIDTH, HEIGHT])
+    let mut window: Window = piston_window::WindowSettings::new("Click me!", [WIDTH, HEIGHT])
         .opengl(opengl).exit_on_esc(true).build().unwrap();
 
     // Create the event loop.
@@ -34,8 +36,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -46,7 +47,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -72,10 +73,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -8,12 +8,12 @@ fn main() {
 
     use conrod::{widget, Labelable, Positionable, Sizeable, Widget};
 
-    use conrod::backend::piston::{Window, UpdateEvent};
-    use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+    use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+    use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
     use conrod::backend::piston::window as piston_window;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
     
     // Construct the window.
     let mut window: Window = piston_window::WindowSettings::new("Click me!", [WIDTH, HEIGHT])

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,7 +7,8 @@ fn main() {
     const HEIGHT: u32 = 200;
 
     use conrod::{widget, Labelable, Positionable, Sizeable, Widget};
-    use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+    use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+    use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
     // Change this to OpenGL::V2_1 if not working.
     let opengl = OpenGL::V3_2;
@@ -15,7 +16,10 @@ fn main() {
     // Construct the window.
     let mut window: PistonWindow = WindowSettings::new("Click me!", [WIDTH, HEIGHT])
         .opengl(opengl).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -39,7 +43,7 @@ fn main() {
     let mut count = 0;
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,6 +1,5 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
 
 fn main() {
@@ -8,7 +7,7 @@ fn main() {
     const HEIGHT: u32 = 200;
 
     use conrod::{widget, Labelable, Positionable, Sizeable, Widget};
-    use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+    use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
     // Change this to OpenGL::V2_1 if not working.
     let opengl = OpenGL::V3_2;

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -222,7 +222,8 @@ mod circular_button {
 
 pub fn main() {
     use conrod::{self, widget, Colorable, Labelable, Positionable, Sizeable, Widget};
-    use conrod::backend::piston_window::{EventLoop, PistonWindow, OpenGL, UpdateEvent, WindowSettings};
+    use conrod::backend::piston_window::{PistonWindow, OpenGL, UpdateEvent, WindowSettings};
+    use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
     use self::circular_button::CircularButton;
 
     const WIDTH: u32 = 1200;
@@ -239,7 +240,10 @@ pub fn main() {
         .opengl(opengl)
         .exit_on_esc(true)
         .build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -267,7 +271,7 @@ pub fn main() {
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
 
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -222,21 +222,23 @@ mod circular_button {
 
 pub fn main() {
     use conrod::{self, widget, Colorable, Labelable, Positionable, Sizeable, Widget};
-    use conrod::backend::piston_window::{PistonWindow, OpenGL, UpdateEvent, WindowSettings};
-    use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+    use conrod::backend::piston::{Window, UpdateEvent};
+    use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+    use conrod::backend::piston::window as piston_window;
+
     use self::circular_button::CircularButton;
 
     const WIDTH: u32 = 1200;
     const HEIGHT: u32 = 800;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = OpenGL::V3_2;
+    let opengl = piston_window::OpenGL::V3_2;
 
     // PistonWindow has two type parameters, but the default type is
     // PistonWindow<T = (), W: Window = GlutinWindow>. To change the Piston backend,
     // specify a different type in the let binding, e.g.
     // let window: PistonWindow<(), Sdl2Window>.
-    let mut window: PistonWindow = WindowSettings::new("Control Panel", [WIDTH, HEIGHT])
+    let mut window: Window = piston_window::WindowSettings::new("Control Panel", [WIDTH, HEIGHT])
         .opengl(opengl)
         .exit_on_esc(true)
         .build().unwrap();
@@ -265,8 +267,7 @@ pub fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -274,7 +275,7 @@ pub fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -303,10 +304,10 @@ pub fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -13,7 +13,6 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
 
 /// The module in which we'll implement our own custom circular button.
@@ -223,7 +222,7 @@ mod circular_button {
 
 pub fn main() {
     use conrod::{self, widget, Colorable, Labelable, Positionable, Sizeable, Widget};
-    use piston_window::{EventLoop, PistonWindow, OpenGL, UpdateEvent, WindowSettings};
+    use conrod::backend::piston_window::{EventLoop, PistonWindow, OpenGL, UpdateEvent, WindowSettings};
     use self::circular_button::CircularButton;
 
     const WIDTH: u32 = 1200;

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -222,8 +222,8 @@ mod circular_button {
 
 pub fn main() {
     use conrod::{self, widget, Colorable, Labelable, Positionable, Sizeable, Widget};
-    use conrod::backend::piston::{Window, UpdateEvent};
-    use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+    use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+    use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
     use conrod::backend::piston::window as piston_window;
 
     use self::circular_button::CircularButton;
@@ -232,7 +232,7 @@ pub fn main() {
     const HEIGHT: u32 = 800;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
 
     // PistonWindow has two type parameters, but the default type is
     // PistonWindow<T = (), W: Window = GlutinWindow>. To change the Piston backend,

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -1,17 +1,17 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 fn main() {
     const WIDTH: u32 = 600;
     const HEIGHT: u32 = 300;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("FileNavigator Demo", [WIDTH, HEIGHT])
+    let mut window: Window =
+        piston_window::WindowSettings::new("FileNavigator Demo", [WIDTH, HEIGHT])
             .opengl(piston_window::OpenGL::V3_2)
             .vsync(true)
             .samples(4)
@@ -36,8 +36,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -48,7 +47,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -76,10 +75,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, EventLoop, PistonWindow, UpdateEvent, WindowSettings};
 
 
 fn main() {

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -1,7 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 
 fn main() {
@@ -17,7 +18,10 @@ fn main() {
             .exit_on_esc(true)
             .build()
             .unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -41,7 +45,7 @@ fn main() {
     let directory = find_folder::Search::KidsThenParents(3, 5).for_folder("conrod").unwrap();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 fn main() {
@@ -12,7 +12,7 @@ fn main() {
     // Construct the window.
     let mut window: Window =
         piston_window::WindowSettings::new("FileNavigator Demo", [WIDTH, HEIGHT])
-            .opengl(piston_window::OpenGL::V3_2)
+            .opengl(OpenGL::V3_2)
             .vsync(true)
             .samples(4)
             .exit_on_esc(true)

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -6,8 +6,10 @@
 extern crate find_folder;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
-use conrod::backend::piston_window::{self, Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window::{ImageSize, Flip, G2dTexture, Texture};
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 fn main() {
     const WIDTH: u32 = 800;
@@ -17,7 +19,7 @@ fn main() {
     let opengl = piston_window::OpenGL::V3_2;
 
     // Construct the window.
-    let mut window: PistonWindow =
+    let mut window: Window =
         piston_window::WindowSettings::new("Image Widget Demonstration", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).samples(4).build().unwrap();
 
@@ -29,7 +31,7 @@ fn main() {
     let mut ui = conrod::UiBuilder::new().build();
 
     // Create an empty texture to pass for the text cache as we're not drawing any text.
-    let mut text_texture_cache = conrod::backend::piston_window::GlyphCache::new(&mut window, 0, 0);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, 0, 0);
 
     // The `WidgetId` for our background and `Image` widgets.
     widget_ids!(struct Ids { background, rust_logo });
@@ -51,10 +53,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
 
@@ -69,7 +71,7 @@ fn main() {
 }
 
 // Load the Rust logo from our assets folder.
-fn load_rust_logo(window: &mut PistonWindow) -> G2dTexture<'static> {
+fn load_rust_logo(window: &mut Window) -> G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");
     let factory = &mut window.factory;

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -7,8 +7,8 @@ extern crate find_folder;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
 use conrod::backend::piston::gfx::*;
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 fn main() {
@@ -16,7 +16,7 @@ fn main() {
     const HEIGHT: u32 = 600;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
 
     // Construct the window.
     let mut window: Window =

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -6,7 +6,7 @@
 extern crate find_folder;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
-use conrod::backend::piston::window::{ImageSize, Flip, G2dTexture, Texture};
+use conrod::backend::piston::gfx::*;
 use conrod::backend::piston::{Window, UpdateEvent};
 use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
@@ -40,7 +40,7 @@ fn main() {
     // Create our `conrod::image::Map` which describes each of our widget->image mappings.
     // In our case we only have one image, however the macro may be used to list multiple.
     let image_map = image_map! {
-        (ids.rust_logo, load_rust_logo(&mut window)),
+        (ids.rust_logo, load_rust_logo(&mut window.context)),
     };
 
     // We'll instantiate the `Image` at its full size, so we'll retrieve its dimensions.
@@ -71,10 +71,10 @@ fn main() {
 }
 
 // Load the Rust logo from our assets folder.
-fn load_rust_logo(window: &mut Window) -> G2dTexture<'static> {
+fn load_rust_logo(context: &mut GfxContext) -> G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");
-    let factory = &mut window.factory;
-    let settings = piston_window::TextureSettings::new();
+    let factory = &mut context.factory;
+    let settings = TextureSettings::new();
     Texture::from_path(factory, &path, Flip::None, &settings).unwrap()
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -6,7 +6,8 @@
 extern crate find_folder;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
-use conrod::backend::piston_window::{self, EventLoop, Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
+use conrod::backend::piston_window::{self, Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 fn main() {
     const WIDTH: u32 = 800;
@@ -19,7 +20,10 @@ fn main() {
     let mut window: PistonWindow =
         piston_window::WindowSettings::new("Image Widget Demonstration", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).samples(4).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -41,7 +45,7 @@ fn main() {
     let (w, h) = image_map.get(&ids.rust_logo).unwrap().get_size();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
         ui.handle_event(event.clone());
 
         window.draw_2d(&event, |c, g| {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -4,10 +4,9 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
-use piston_window::{EventLoop, Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
+use conrod::backend::piston_window::{self, EventLoop, Flip, ImageSize, G2dTexture, PistonWindow, Texture, UpdateEvent};
 
 fn main() {
     const WIDTH: u32 = 800;

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -11,7 +11,8 @@
 extern crate find_folder;
 extern crate rand; // for making a random color.
 
-use conrod::backend::piston_window::{self, EventLoop, ImageSize, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, ImageSize, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 
 fn main() {
@@ -25,6 +26,9 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("A button with an image", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -54,10 +58,10 @@ fn main() {
     // Our demonstration app that we'll control with our GUI.
     let mut bg_color = conrod::color::LIGHT_BLUE;
 
-    window.set_ups(60);
+    events.set_ups(60);
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -11,7 +11,7 @@
 extern crate find_folder;
 extern crate rand; // for making a random color.
 
-use conrod::backend::piston::window::{ImageSize, Flip, G2dTexture, Texture};
+use conrod::backend::piston::gfx::*;
 use conrod::backend::piston::{Window, UpdateEvent};
 use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
@@ -40,8 +40,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // Declare the ID for each of our widgets.
     widget_ids!(struct Ids { canvas, button, rust_logo });
@@ -50,7 +49,7 @@ fn main() {
     // Create our `conrod::image::Map` which describes each of our widget->image mappings.
     // In our case we only have one image, however the macro may be used to list multiple.
     let image_map = image_map! {
-        (ids.rust_logo, load_rust_logo(&mut window)),
+        (ids.rust_logo, load_rust_logo(&mut window.context)),
     };
 
     // We'll instantiate the `Button` at the logo's full size, so we'll retrieve its dimensions.
@@ -107,10 +106,10 @@ fn main() {
 }
 
 // Load the Rust logo from our assets folder.
-fn load_rust_logo(window: &mut Window) -> G2dTexture<'static> {
+fn load_rust_logo(context: &mut GfxContext) -> G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");
-    let factory = &mut window.factory;
-    let settings = piston_window::TextureSettings::new();
+    let factory = &mut context.factory;
+    let settings = TextureSettings::new();
     Texture::from_path(factory, &path, Flip::None, &settings).unwrap()
 }

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -12,8 +12,8 @@ extern crate find_folder;
 extern crate rand; // for making a random color.
 
 use conrod::backend::piston::gfx::*;
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 fn main() {
@@ -21,7 +21,7 @@ fn main() {
     const HEIGHT: u32 = 560;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
 
     // Construct the window.
     let mut window: Window =
@@ -40,7 +40,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache = GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // Declare the ID for each of our widgets.
     widget_ids!(struct Ids { canvas, button, rust_logo });

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -11,9 +11,10 @@
 extern crate find_folder;
 extern crate rand; // for making a random color.
 
-use conrod::backend::piston_window::{self, ImageSize, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
+use conrod::backend::piston::window::{ImageSize, Flip, G2dTexture, Texture};
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 fn main() {
     const WIDTH: u32 = 1100;
@@ -23,8 +24,8 @@ fn main() {
     let opengl = piston_window::OpenGL::V3_2;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("A button with an image", [WIDTH, HEIGHT])
+    let mut window: Window =
+        piston_window::WindowSettings::new("A button with an image", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).vsync(true).build().unwrap();
 
     // Create the event loop.
@@ -40,7 +41,7 @@ fn main() {
 
     // Create a texture to use for efficiently caching text on the GPU.
     let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+        piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // Declare the ID for each of our widgets.
     widget_ids!(struct Ids { canvas, button, rust_logo });
@@ -64,7 +65,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -96,19 +97,17 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }
 }
 
-
 // Load the Rust logo from our assets folder.
-use conrod::backend::piston_window::{Flip, G2dTexture, Texture};
-fn load_rust_logo(window: &mut PistonWindow) -> G2dTexture<'static> {
+fn load_rust_logo(window: &mut Window) -> G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");
     let factory = &mut window.factory;

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -9,10 +9,9 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 extern crate rand; // for making a random color.
 
-use piston_window::{EventLoop, ImageSize, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, EventLoop, ImageSize, PistonWindow, UpdateEvent, WindowSettings};
 
 
 fn main() {
@@ -104,7 +103,7 @@ fn main() {
 
 
 // Load the Rust logo from our assets folder.
-use piston_window::{Flip, G2dTexture, Texture};
+use conrod::backend::piston_window::{Flip, G2dTexture, Texture};
 fn load_rust_logo(window: &mut PistonWindow) -> G2dTexture<'static> {
     let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
     let path = assets.join("images/rust.png");

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -3,8 +3,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 widget_ids! {
@@ -18,7 +18,7 @@ fn main() {
     const HEIGHT: u32 = 600;
     let mut window: Window =
         piston_window::WindowSettings::new("List Demo", [WIDTH, HEIGHT])
-            .opengl(piston_window::OpenGL::V3_2).exit_on_esc(true).samples(4).vsync(true).build().unwrap();
+            .opengl(OpenGL::V3_2).exit_on_esc(true).samples(4).vsync(true).build().unwrap();
 
     // Create the event loop.
     let mut events = WindowEvents::new();

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -3,8 +3,9 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 widget_ids! {
     struct Ids { canvas, list }
@@ -15,9 +16,9 @@ fn main() {
     // Construct the window.
     const WIDTH: u32 = 150;
     const HEIGHT: u32 = 600;
-    let mut window: PistonWindow =
-        WindowSettings::new("List Demo", [WIDTH, HEIGHT])
-            .opengl(OpenGL::V3_2).exit_on_esc(true).samples(4).vsync(true).build().unwrap();
+    let mut window: Window =
+        piston_window::WindowSettings::new("List Demo", [WIDTH, HEIGHT])
+            .opengl(piston_window::OpenGL::V3_2).exit_on_esc(true).samples(4).vsync(true).build().unwrap();
 
     // Create the event loop.
     let mut events = WindowEvents::new();
@@ -35,8 +36,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // No text to draw, so we'll just create an empty text texture cache.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -47,7 +47,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -58,10 +58,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -3,7 +3,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 widget_ids! {
     struct Ids { canvas, list }
@@ -17,7 +18,10 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("List Demo", [WIDTH, HEIGHT])
             .opengl(OpenGL::V3_2).exit_on_esc(true).samples(4).vsync(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -40,7 +44,7 @@ fn main() {
     let mut list = vec![true; 16];
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -2,9 +2,8 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 widget_ids! {
     struct Ids { canvas, list }

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 widget_ids! {
@@ -17,7 +17,7 @@ fn main() {
     // Construct the window.
     let mut window: Window =
         piston_window::WindowSettings::new("ListSelect Demo", [WIDTH, HEIGHT])
-            .opengl(piston_window::OpenGL::V3_2)
+            .opengl(OpenGL::V3_2)
             .vsync(true)
             .samples(4)
             .exit_on_esc(true)

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -1,7 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 widget_ids! {
     struct Ids { canvas, list_select }
@@ -22,7 +23,9 @@ fn main() {
             .build()
             .unwrap();
 
-    window.set_ups(60);
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -66,7 +69,7 @@ fn main() {
     let mut list_selected = std::collections::HashSet::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 widget_ids! {
     struct Ids { canvas, list_select }

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -1,8 +1,9 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 widget_ids! {
     struct Ids { canvas, list_select }
@@ -14,9 +15,9 @@ fn main() {
     const HEIGHT: u32 = 300;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("ListSelect Demo", [WIDTH, HEIGHT])
-            .opengl(OpenGL::V3_2)
+    let mut window: Window =
+        piston_window::WindowSettings::new("ListSelect Demo", [WIDTH, HEIGHT])
+            .opengl(piston_window::OpenGL::V3_2)
             .vsync(true)
             .samples(4)
             .exit_on_esc(true)
@@ -39,8 +40,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // No text to draw, so we'll just create an empty text texture cache.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -72,7 +72,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -133,10 +133,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -11,8 +11,8 @@
 extern crate find_folder;
 extern crate rand; // for making a random color.
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 /// This struct holds all of the variables used to demonstrate application data being passed
@@ -98,7 +98,7 @@ fn main() {
     const HEIGHT: u32 = 560;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
     
     // Construct the window.
     let mut window: Window =

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -1,7 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 widget_ids! {
     struct Ids { canvas, plot }
@@ -17,7 +18,10 @@ fn main() {
             .exit_on_esc(true)
             .build()
             .unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -32,7 +36,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -1,8 +1,9 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 widget_ids! {
     struct Ids { canvas, plot }
@@ -11,8 +12,8 @@ widget_ids! {
 fn main() {
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("PlotPath Demo", [720, 360])
+    let mut window: Window =
+        piston_window::WindowSettings::new("PlotPath Demo", [720, 360])
             .opengl(piston_window::OpenGL::V3_2)
             .samples(4)
             .exit_on_esc(true)
@@ -30,7 +31,7 @@ fn main() {
     let ids = Ids::new(ui.widget_id_generator());
 
     // No text to draw, so we'll just create an empty text texture cache.
-    let mut text_texture_cache = conrod::backend::piston_window::GlyphCache::new(&mut window, 0, 0);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, 0, 0);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -39,7 +40,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -64,10 +65,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 widget_ids! {
@@ -14,7 +14,7 @@ fn main() {
     // Construct the window.
     let mut window: Window =
         piston_window::WindowSettings::new("PlotPath Demo", [720, 360])
-            .opengl(piston_window::OpenGL::V3_2)
+            .opengl(OpenGL::V3_2)
             .samples(4)
             .exit_on_esc(true)
             .build()

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, EventLoop, PistonWindow, UpdateEvent, WindowSettings};
 
 widget_ids! {
     struct Ids { canvas, plot }

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::*;
+use conrod::backend::piston_window::*;
 
 
 // Generate a type that will produce a unique `widget::Id` for each widget.

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -1,9 +1,9 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::*;
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 // Generate a type that will produce a unique `widget::Id` for each widget.
 widget_ids! {
@@ -24,11 +24,11 @@ widget_ids! {
 fn main() {
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = OpenGL::V3_2;
+    let opengl = piston_window::OpenGL::V3_2;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("Primitives Demo", [400, 720])
+    let mut window: Window =
+        piston_window::WindowSettings::new("Primitives Demo", [400, 720])
             .opengl(opengl).samples(4).exit_on_esc(true).build().unwrap();
 
     // Create the event loop.
@@ -42,7 +42,7 @@ fn main() {
     let ids = Ids::new(ui.widget_id_generator());
 
     // No text to draw, so we'll just create an empty text texture cache.
-    let mut text_texture_cache = conrod::backend::piston_window::GlyphCache::new(&mut window, 0, 0);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, 0, 0);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -51,7 +51,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -62,10 +62,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 // Generate a type that will produce a unique `widget::Id` for each widget.
@@ -24,7 +24,7 @@ widget_ids! {
 fn main() {
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
 
     // Construct the window.
     let mut window: Window =

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -2,6 +2,7 @@
 extern crate find_folder;
 
 use conrod::backend::piston_window::*;
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 
 // Generate a type that will produce a unique `widget::Id` for each widget.
@@ -29,7 +30,10 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("Primitives Demo", [400, 720])
             .opengl(opengl).samples(4).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -44,7 +48,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -2,9 +2,8 @@
 
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, EventLoop, PistonWindow, UpdateEvent, WindowSettings};
 
 
 widget_ids! { 

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -3,7 +3,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, EventLoop, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{self, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 
 widget_ids! { 
@@ -20,7 +21,10 @@ fn main() {
         WindowSettings::new("RangeSlider Demo", [WIDTH, HEIGHT])
             .opengl(piston_window::OpenGL::V3_2)
             .exit_on_esc(true).samples(4).vsync(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -43,7 +47,7 @@ fn main() {
     let mut oval_range = (0.25, 0.75);
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -3,9 +3,9 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 widget_ids! { 
     struct Ids { canvas, oval, range_slider }
@@ -17,8 +17,8 @@ fn main() {
     const HEIGHT: u32 = 360;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("RangeSlider Demo", [WIDTH, HEIGHT])
+    let mut window: Window =
+        piston_window::WindowSettings::new("RangeSlider Demo", [WIDTH, HEIGHT])
             .opengl(piston_window::OpenGL::V3_2)
             .exit_on_esc(true).samples(4).vsync(true).build().unwrap();
 
@@ -38,8 +38,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -50,7 +49,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -61,10 +60,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -3,8 +3,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 widget_ids! { 
@@ -19,7 +19,7 @@ fn main() {
     // Construct the window.
     let mut window: Window =
         piston_window::WindowSettings::new("RangeSlider Demo", [WIDTH, HEIGHT])
-            .opengl(piston_window::OpenGL::V3_2)
+            .opengl(OpenGL::V3_2)
             .exit_on_esc(true).samples(4).vsync(true).build().unwrap();
 
     // Create the event loop.

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
 
 
 fn main() {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 fn main() {
@@ -10,7 +10,7 @@ fn main() {
     const HEIGHT: u32 = 720;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = piston_window::OpenGL::V3_2;
+    let opengl = OpenGL::V3_2;
 
     // Construct the window.
     let mut window: Window =

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,20 +1,20 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
-
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 fn main() {
     const WIDTH: u32 = 1080;
     const HEIGHT: u32 = 720;
 
     // Change this to OpenGL::V2_1 if not working.
-    let opengl = OpenGL::V3_2;
+    let opengl = piston_window::OpenGL::V3_2;
 
     // Construct the window.
-    let mut window: PistonWindow =
-        WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
+    let mut window: Window =
+        piston_window::WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).build().unwrap();
 
     // Create the event loop.
@@ -37,8 +37,7 @@ fn main() {
     // Note that the dimensions of the `GlyphCache` don't need to be the dimensions of the window,
     // they just need to be at least large enough to cache the maximum amount of text that might be
     // drawn in a single frame.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -47,7 +46,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -57,10 +56,10 @@ fn main() {
             // Only re-draw if there was some change in the `Ui`.
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,7 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::{OpenGL, PistonWindow, UpdateEvent, WindowSettings};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 
 fn main() {
@@ -15,7 +16,10 @@ fn main() {
     let mut window: PistonWindow =
         WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
             .opengl(opengl).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -40,7 +44,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -1,7 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, EventLoop, OpenGL, PistonWindow, UpdateEvent};
+use conrod::backend::piston_window::{self, OpenGL, PistonWindow, UpdateEvent};
+use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
 
 widget_ids! { 
     struct Ids { canvas, text_edit }
@@ -15,7 +16,10 @@ fn main() {
     let mut window: PistonWindow =
         piston_window::WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
             .opengl(OpenGL::V3_2).exit_on_esc(true).build().unwrap();
-    window.set_ups(60);
+
+    // Create the event loop.
+    let mut events = WindowEvents::new();
+    events.set_ups(60);
 
     // Construct our `Ui`.
     let mut ui = conrod::UiBuilder::new().build();
@@ -45,7 +49,7 @@ fn main() {
         magna est, efficitur suscipit dolor eu, consectetur consectetur urna.".to_owned();
 
     // Poll events from the window.
-    while let Some(event) = window.next() {
+    while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
-extern crate piston_window;
 
-use piston_window::{EventLoop, OpenGL, PistonWindow, UpdateEvent};
+use conrod::backend::piston_window::{self, EventLoop, OpenGL, PistonWindow, UpdateEvent};
 
 widget_ids! { 
     struct Ids { canvas, text_edit }

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -1,8 +1,9 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston_window::{self, OpenGL, PistonWindow, UpdateEvent};
-use conrod::backend::piston_window::piston_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent};
+use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::window as piston_window;
 
 widget_ids! { 
     struct Ids { canvas, text_edit }
@@ -13,9 +14,9 @@ fn main() {
     const HEIGHT: u32 = 720;
 
     // Construct the window.
-    let mut window: PistonWindow =
+    let mut window: Window =
         piston_window::WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
-            .opengl(OpenGL::V3_2).exit_on_esc(true).build().unwrap();
+            .opengl(piston_window::OpenGL::V3_2).exit_on_esc(true).build().unwrap();
 
     // Create the event loop.
     let mut events = WindowEvents::new();
@@ -33,8 +34,7 @@ fn main() {
     ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
-    let mut text_texture_cache =
-        conrod::backend::piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
+    let mut text_texture_cache = piston_window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
@@ -52,7 +52,7 @@ fn main() {
     while let Some(event) = events.next(&mut window) {
 
         // Convert the piston event to a conrod event.
-        if let Some(e) = conrod::backend::piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 
@@ -61,10 +61,10 @@ fn main() {
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {
                 fn texture_from_image<T>(img: &T) -> &T { img };
-                conrod::backend::piston_window::draw(c, g, primitives,
-                                                     &mut text_texture_cache,
-                                                     &image_map,
-                                                     texture_from_image);
+                piston_window::draw(c, g, primitives,
+                                    &mut text_texture_cache,
+                                    &image_map,
+                                    texture_from_image);
             }
         });
     }

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent};
-use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
 widget_ids! { 
@@ -16,7 +16,7 @@ fn main() {
     // Construct the window.
     let mut window: Window =
         piston_window::WindowSettings::new("Text Demo", [WIDTH, HEIGHT])
-            .opengl(piston_window::OpenGL::V3_2).exit_on_esc(true).build().unwrap();
+            .opengl(OpenGL::V3_2).exit_on_esc(true).build().unwrap();
 
     // Create the event loop.
     let mut events = WindowEvents::new();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,4 +10,3 @@
 #[cfg(feature="glium")] pub mod glium;
 #[cfg(feature="glutin")] pub mod glutin;
 #[cfg(feature="piston")] pub mod piston;
-#[cfg(feature="piston")] #[cfg(feature="piston_window")] pub mod piston_window;

--- a/src/backend/piston/gfx.rs
+++ b/src/backend/piston/gfx.rs
@@ -9,6 +9,7 @@ extern crate gfx_graphics;
 extern crate shader_version;
 extern crate texture;
 
+use self::shader_version::OpenGL;
 use self::gfx_graphics::{Gfx2d, GfxGraphics};
 use self::gfx_core::factory::Typed;
 use self::gfx::Device;
@@ -22,8 +23,7 @@ use render;
 use text;
 
 pub use self::piston_graphics::{Context, DrawState, Graphics, ImageSize, Transformed};
-pub use self::gfx_graphics::{ GlyphError, Texture, TextureSettings, Flip };
-pub use self::shader_version::OpenGL;
+pub use self::gfx_graphics::{GlyphError, Texture, TextureSettings, Flip};
 
 /// Actual gfx::Stream implementation carried by the window.
 pub type GfxEncoder = gfx::Encoder<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer>;

--- a/src/backend/piston/gfx.rs
+++ b/src/backend/piston/gfx.rs
@@ -1,0 +1,279 @@
+//! Contains the GfxContext wrapper for convenient integration with `backend::piston::Window`
+
+extern crate window as pistoncore_window;
+extern crate graphics as piston_graphics;
+extern crate gfx;
+extern crate gfx_core;
+extern crate gfx_device_gl;
+extern crate gfx_graphics;
+extern crate shader_version;
+extern crate texture;
+
+use self::gfx_graphics::{Gfx2d, GfxGraphics};
+use self::gfx_core::factory::Typed;
+use self::gfx::Device;
+
+use self::pistoncore_window::{OpenGLWindow, Size};
+use piston_input::RenderArgs;
+
+use super::draw;
+use image;
+use render;
+use text;
+
+pub use self::piston_graphics::{Context, DrawState, Graphics, ImageSize, Transformed};
+pub use self::gfx_graphics::{ GlyphError, Texture, TextureSettings, Flip };
+pub use self::shader_version::OpenGL;
+
+/// Actual gfx::Stream implementation carried by the window.
+pub type GfxEncoder = gfx::Encoder<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer>;
+/// Glyph cache.
+pub type Glyphs = gfx_graphics::GlyphCache<gfx_device_gl::Resources, gfx_device_gl::Factory>;
+/// 2D graphics.
+pub type G2d<'a> = GfxGraphics<'a, gfx_device_gl::Resources, gfx_device_gl::CommandBuffer>;
+/// Texture type compatible with `G2d`.
+pub type G2dTexture<'a> = Texture<gfx_device_gl::Resources>;
+
+/// Contains state used by Gfx to draw. Can be stored within a window.
+pub struct GfxContext {
+    /// GFX encoder.
+    pub encoder: GfxEncoder,
+    /// GFX device.
+    pub device: gfx_device_gl::Device,
+    /// Output frame buffer.
+    pub output_color: gfx::handle::RenderTargetView<
+        gfx_device_gl::Resources, gfx::format::Srgba8>,
+    /// Output stencil buffer.
+    pub output_stencil: gfx::handle::DepthStencilView<
+        gfx_device_gl::Resources, gfx::format::DepthStencil>,
+    /// Gfx2d.
+    pub g2d: Gfx2d<gfx_device_gl::Resources>,
+    /// The factory that was created along with the device.
+    pub factory: gfx_device_gl::Factory,
+}
+
+fn create_main_targets(dim: gfx::tex::Dimensions) ->
+    (gfx::handle::RenderTargetView<gfx_device_gl::Resources, gfx::format::Srgba8>,
+     gfx::handle::DepthStencilView<gfx_device_gl::Resources, gfx::format::DepthStencil>)
+ {
+    use self::gfx_core::factory::Typed;
+    use self::gfx::format::{DepthStencil, Format, Formatted, Srgba8};
+
+    let color_format: Format = <Srgba8 as Formatted>::get_format();
+    let depth_format: Format = <DepthStencil as Formatted>::get_format();
+    let (output_color, output_stencil) =
+        gfx_device_gl::create_main_targets_raw(dim,
+                                               color_format.0,
+                                               depth_format.0);
+    let output_color = Typed::new(output_color);
+    let output_stencil = Typed::new(output_stencil);
+    (output_color, output_stencil)
+}
+
+impl GfxContext {
+    /// Constructor for a new `GfxContext`
+    pub fn new<W>(window: &mut W, opengl: OpenGL, samples: u8) -> Self
+        where W: OpenGLWindow 
+    {
+        let (device, mut factory) = gfx_device_gl::create(|s| window.get_proc_address(s) as *const _);
+
+        let draw_size = window.draw_size();
+        let (output_color, output_stencil) = {
+            let aa = samples as gfx::tex::NumSamples;
+            let dim = (draw_size.width as u16, draw_size.height as u16,
+                       1, aa.into());
+            create_main_targets(dim)
+        };
+
+        let g2d = Gfx2d::new(opengl, &mut factory);
+        let encoder = factory.create_command_buffer().into();
+        GfxContext {
+            encoder: encoder,
+            device: device,
+            output_color: output_color,
+            output_stencil: output_stencil,
+            g2d: g2d,
+            factory: factory,
+        }
+    }
+
+    /// Renders 2D graphics.
+    pub fn draw_2d<F, U>(&mut self, f: F, args: RenderArgs) -> U where
+        F: FnOnce(draw::Context, &mut G2d) -> U
+    {
+        let res = self.g2d.draw(
+            &mut self.encoder,
+            &self.output_color,
+            &self.output_stencil,
+            args.viewport(),
+            f
+        );
+        self.encoder.flush(&mut self.device);
+        res
+    }
+
+    /// Called after frame is rendered to cleanup after gfx device.
+    pub fn after_render(&mut self) {
+        self.device.cleanup();
+    }
+
+    /// Check whether window has resized and update the output.
+    pub fn check_resize(&mut self, draw_size: Size) {
+        let dim = self.output_color.raw().get_dimensions();
+        let (w, h) = (dim.0, dim.1);
+        if w != draw_size.width as u16 || h != draw_size.height as u16 {
+            let dim = (draw_size.width as u16,
+                       draw_size.height as u16,
+                       dim.2, dim.3);
+            let (output_color, output_stencil) = create_main_targets(dim);
+            self.output_color = output_color;
+            self.output_stencil = output_stencil;
+        }
+    }
+}
+
+/// A wrapper around a `G2dTexture` and a rusttype GPU `Cache`
+///
+/// Using a wrapper simplifies the construction of both caches and ensures that they maintain
+/// identical dimensions.
+pub struct GlyphCache {
+    cache: text::GlyphCache,
+    texture: G2dTexture<'static>,
+    vertex_data: Vec<u8>,
+}
+
+impl GlyphCache {
+    /// Constructor for a new `GlyphCache`.
+    ///
+    /// The `width` and `height` arguments are in pixel values.
+    ///
+    /// If you need to resize the `GlyphCache`, construct a new one and discard the old one.
+    pub fn new_from_factory(factory: &mut gfx_device_gl::Factory, width: u32, height: u32) -> GlyphCache {
+
+        // Construct the rusttype GPU cache with the tolerances recommended by their documentation.
+        const SCALE_TOLERANCE: f32 = 0.1;
+        const POSITION_TOLERANCE: f32 = 0.1;
+        let cache = text::GlyphCache::new(width, height, SCALE_TOLERANCE, POSITION_TOLERANCE);
+
+        // Construct a `G2dTexture`
+        let buffer_len = width as usize * height as usize;
+        let init = vec![128; buffer_len];
+        let settings = TextureSettings::new();
+        let texture = G2dTexture::from_memory_alpha(factory, &init, width, height, &settings).unwrap();
+
+        GlyphCache {
+            cache: cache,
+            texture: texture,
+            vertex_data: Vec::new(),
+        }
+    }
+}
+
+/// Renders the given sequence of conrod primitives.
+pub fn draw<'a, 'b, P, Img, F>(context: draw::Context,
+                               graphics: &'a mut G2d<'b>,
+                               primitives: P,
+                               glyph_cache: &'a mut GlyphCache,
+                               image_map: &'a image::Map<Img>,
+                               texture_from_image: F)
+    where P: render::PrimitiveWalker,
+          F: FnMut(&Img) -> &G2dTexture<'static>,
+{
+    let GlyphCache { ref mut texture, ref mut cache, ref mut vertex_data } = *glyph_cache;
+
+    // A function used for caching glyphs from `Text` widgets.
+    let cache_queued_glyphs_fn = |graphics: &mut G2d,
+                                  cache: &mut G2dTexture<'static>,
+                                  rect: text::rt::Rect<u32>,
+                                  data: &[u8]|
+    {
+        cache_queued_glyphs(graphics, cache, rect, data, vertex_data);
+    };
+
+    draw::primitives(
+        primitives,
+        context,
+        graphics,
+        texture,
+        cache,
+        image_map,
+        cache_queued_glyphs_fn,
+        texture_from_image,
+    );
+}
+
+/// Draw a single `Primitive` to the screen.
+///
+/// This is useful if the user requires rendering primitives individually, perhaps to perform their
+/// own rendering in between, etc.
+pub fn draw_primitive<'a, 'b, Img, F>(context: draw::Context,
+                                      graphics: &'a mut G2d<'b>,
+                                      primitive: render::Primitive,
+                                      glyph_cache: &'a mut GlyphCache,
+                                      image_map: &'a image::Map<Img>,
+                                      glyph_rectangles: &mut Vec<([f64; 4], [i32; 4])>,
+                                      texture_from_image: F)
+    where F: FnMut(&Img) -> &G2dTexture<'static>,
+{
+    let GlyphCache { ref mut texture, ref mut cache, ref mut vertex_data } = *glyph_cache;
+
+    // A function used for caching glyphs from `Text` widgets.
+    let cache_queued_glyphs_fn = |graphics: &mut G2d,
+                                  cache: &mut G2dTexture<'static>,
+                                  rect: text::rt::Rect<u32>,
+                                  data: &[u8]|
+    {
+        cache_queued_glyphs(graphics, cache, rect, data, vertex_data);
+    };
+
+    draw::primitive(
+        primitive,
+        context,
+        graphics,
+        texture,
+        cache,
+        image_map,
+        glyph_rectangles,
+        cache_queued_glyphs_fn,
+        texture_from_image,
+    );
+}
+
+fn cache_queued_glyphs(graphics: &mut G2d,
+                       cache: &mut G2dTexture<'static>,
+                       rect: text::rt::Rect<u32>,
+                       data: &[u8],
+                       vertex_data: &mut Vec<u8>)
+{
+    use self::texture::UpdateTexture;
+
+    // An iterator that efficiently maps the `byte`s yielded from `data` to `[r, g, b, byte]`;
+    //
+    // This is only used within the `cache_queued_glyphs` below, however due to a bug in rustc we
+    // are unable to declare types inside the closure scope.
+    struct Bytes { b: u8, i: u8 }
+    impl Iterator for Bytes {
+        type Item = u8;
+        fn next(&mut self) -> Option<Self::Item> {
+            let b = match self.i {
+                0 => 255,
+                1 => 255,
+                2 => 255,
+                3 => self.b,
+                _ => return None,
+            };
+            self.i += 1;
+            Some(b)
+        }
+    }
+
+    let offset = [rect.min.x, rect.min.y];
+    let size = [rect.width(), rect.height()];
+    let format = self::texture::Format::Rgba8;
+    let encoder = &mut graphics.encoder;
+
+    vertex_data.clear();
+    vertex_data.extend(data.iter().flat_map(|&b| Bytes { b: b, i: 0 }));
+    UpdateTexture::update(cache, encoder, format, &vertex_data[..], offset, size)
+        .expect("Failed to update texture");
+}

--- a/src/backend/piston/mod.rs
+++ b/src/backend/piston/mod.rs
@@ -3,8 +3,9 @@
 pub mod draw;
 pub mod event;
 pub mod window;
+pub mod gfx;
 pub use self::window::Window;
-pub use self::window::UpdateEvent;
+pub use piston_input::UpdateEvent;
 
 /// This module allows use of the default piston game event loop from `pistoncore_event_loop` with `Window`
 pub mod core_event_loop {

--- a/src/backend/piston/mod.rs
+++ b/src/backend/piston/mod.rs
@@ -1,14 +1,18 @@
 //! Functionality for simplifying the work involved when using conrod along-side piston.
 
+extern crate shader_version;
+
 pub mod draw;
 pub mod event;
 pub mod window;
 pub mod gfx;
+
 pub use self::window::Window;
+pub use self::shader_version::OpenGL;
 pub use piston_input::UpdateEvent;
 
 /// This module allows use of the default piston game event loop from `pistoncore_event_loop` with `Window`
-pub mod core_event_loop {
+pub mod core_events {
     extern crate event_loop;
 
     pub use self::event_loop::{WindowEvents, EventLoop};

--- a/src/backend/piston/mod.rs
+++ b/src/backend/piston/mod.rs
@@ -2,3 +2,24 @@
 
 pub mod draw;
 pub mod event;
+pub mod window;
+pub use self::window::Window;
+pub use self::window::UpdateEvent;
+
+/// This module allows use of the default piston game event loop from `pistoncore_event_loop` with `Window`
+pub mod core_event_loop {
+    extern crate event_loop;
+
+    pub use self::event_loop::{WindowEvents, EventLoop};
+    use super::window::{Window, EventWindow};
+    use piston_input::Event;
+
+    impl EventWindow for WindowEvents {
+        fn next(&mut self, window: &mut Window) -> Option<Event> {
+            if let Some(e) = self.next(window) {
+                window.event(&e);
+                Some(e)
+            } else { None }
+        }
+    }
+}

--- a/src/backend/piston/window.rs
+++ b/src/backend/piston/window.rs
@@ -20,7 +20,7 @@
 //!
 //! use conrod::backend::piston::Window;
 //! use conrod::backend::piston::window as piston_window;
-//! use conrod::backend::piston::core_event_loop::{EventLoop, WindowEvents};
+//! use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 //! use graphics::*;
 //!
 //! fn main() {
@@ -74,7 +74,6 @@
 //! https://github.com/PistonDevelopers/piston/issues/1014
 
 extern crate window as pistoncore_window;
-extern crate shader_version;
 extern crate glutin_window;
 
 use std::time::Duration;
@@ -86,12 +85,12 @@ use self::pistoncore_window::Window as BasicWindow;
 
 use super::draw;
 use super::gfx::{GfxContext, G2d};
+use super::shader_version::OpenGL;
 use event;
 
 pub use self::pistoncore_window::{AdvancedWindow, Position, Size, OpenGLWindow, 
                                   WindowSettings, BuildFromWindowSettings};
 pub use super::gfx::{draw, GlyphCache};
-pub use self::shader_version::OpenGL;
 
 /// Contains everything required for controlling window, graphics, event loop.
 pub struct Window<W: BasicWindow = GlutinWindow> {

--- a/src/backend/piston/window.rs
+++ b/src/backend/piston/window.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 //! This code is adapted from the `piston_window` crate for convenience when
 //! using the piston window API with a conrod app.
 //!
@@ -74,74 +72,33 @@
 //!
 //! For more information about sRGB, see
 //! https://github.com/PistonDevelopers/piston/issues/1014
-//!
-//! ### Library dependencies
-//!
-//! This library is meant to be used in applications only.
-//! It is not meant to be depended on by generic libraries.
-//! Instead, libraries should depend on the lower abstractions,
-//! such as the [Piston core](https://github.com/pistondevelopers/piston).
 
 extern crate window as pistoncore_window;
-extern crate event_loop as pistoncore_event_loop;
-extern crate gfx;
-extern crate gfx_core;
-extern crate gfx_device_gl;
-extern crate gfx_graphics;
-extern crate graphics;
 extern crate shader_version;
 extern crate glutin_window;
-pub extern crate texture;
 
-use self::glutin_window::GlutinWindow;
-pub use self::shader_version::OpenGL;
-pub use self::graphics::{ImageSize};
-use self::pistoncore_window::Window as BasicWindow;
-pub use self::pistoncore_window::{AdvancedWindow, Position, Size, OpenGLWindow, 
-                                  WindowSettings, BuildFromWindowSettings};
-pub use piston_input::*;
-pub use self::gfx_graphics::{ GlyphError, Texture, TextureSettings, Flip };
-
-use self::gfx_graphics::{ Gfx2d, GfxGraphics };
 use std::time::Duration;
 
-use super::draw;
-use event;
-use image;
-use render;
-use text;
+use piston_input::{Event, GenericEvent, AfterRenderEvent};
 
-/// Actual gfx::Stream implementation carried by the window.
-pub type GfxEncoder = gfx::Encoder<gfx_device_gl::Resources,
-    gfx_device_gl::CommandBuffer>;
-/// Glyph cache.
-pub type Glyphs = gfx_graphics::GlyphCache<gfx_device_gl::Resources,
-    gfx_device_gl::Factory>;
-/// 2D graphics.
-pub type G2d<'a> = GfxGraphics<'a,
-    gfx_device_gl::Resources,
-    gfx_device_gl::CommandBuffer>;
-/// Texture type compatible with `G2d`.
-pub type G2dTexture<'a> = Texture<gfx_device_gl::Resources>;
+use self::glutin_window::GlutinWindow;
+use self::pistoncore_window::Window as BasicWindow;
+
+use super::draw;
+use super::gfx::{GfxContext, G2d};
+use event;
+
+pub use self::pistoncore_window::{AdvancedWindow, Position, Size, OpenGLWindow, 
+                                  WindowSettings, BuildFromWindowSettings};
+pub use super::gfx::{draw, GlyphCache};
+pub use self::shader_version::OpenGL;
 
 /// Contains everything required for controlling window, graphics, event loop.
 pub struct Window<W: BasicWindow = GlutinWindow> {
     /// The window.
     pub window: W,
-    /// GFX encoder.
-    pub encoder: GfxEncoder,
-    /// GFX device.
-    pub device: gfx_device_gl::Device,
-    /// Output frame buffer.
-    pub output_color: gfx::handle::RenderTargetView<
-        gfx_device_gl::Resources, gfx::format::Srgba8>,
-    /// Output stencil buffer.
-    pub output_stencil: gfx::handle::DepthStencilView<
-        gfx_device_gl::Resources, gfx::format::DepthStencil>,
-    /// Gfx2d.
-    pub g2d: Gfx2d<gfx_device_gl::Resources>,
-    /// The factory that was created along with the device.
-    pub factory: gfx_device_gl::Factory,
+    /// Stores state associated with Gfx.
+    pub context: GfxContext,
 }
 
 impl<W> BuildFromWindowSettings for Window<W>
@@ -152,63 +109,25 @@ impl<W> BuildFromWindowSettings for Window<W>
         // Turn on sRGB.
         let settings = settings.clone().srgb(true);
 
-        // Use OpenGL 3.2 by default, because this is what window backends
-        // usually do.
+        let mut window: W = try!(settings.build());
+        // Use OpenGL 3.2 by default, because this is what window backends usually do.
         let opengl = settings.get_maybe_opengl().unwrap_or(OpenGL::V3_2);
         let samples = settings.get_samples();
-
-        Ok(Window::new(opengl, samples, try!(settings.build())))
+        let context = GfxContext::new(&mut window, opengl, samples);
+        Ok(Window::new(window, context))
     }
-}
-
-fn create_main_targets(dim: gfx::tex::Dimensions) ->
-(gfx::handle::RenderTargetView<
-    gfx_device_gl::Resources, gfx::format::Srgba8>,
- gfx::handle::DepthStencilView<
-    gfx_device_gl::Resources, gfx::format::DepthStencil>) {
-    use self::gfx_core::factory::Typed;
-    use self::gfx::format::{DepthStencil, Format, Formatted, Srgba8};
-
-    let color_format: Format = <Srgba8 as Formatted>::get_format();
-    let depth_format: Format = <DepthStencil as Formatted>::get_format();
-    let (output_color, output_stencil) =
-        gfx_device_gl::create_main_targets_raw(dim,
-                                               color_format.0,
-                                               depth_format.0);
-    let output_color = Typed::new(output_color);
-    let output_stencil = Typed::new(output_stencil);
-    (output_color, output_stencil)
 }
 
 impl<W> Window<W>
     where W: BasicWindow, W::Event: GenericEvent
 {
     /// Creates a new piston window.
-    pub fn new(opengl: OpenGL, samples: u8, mut window: W) -> Self
+    pub fn new(window: W, context: GfxContext) -> Self
         where W: OpenGLWindow
     {
-        let (device, mut factory) =
-            gfx_device_gl::create(|s|
-                window.get_proc_address(s) as *const _);
-
-        let (output_color, output_stencil) = {
-            let aa = samples as gfx::tex::NumSamples;
-            let draw_size = window.draw_size();
-            let dim = (draw_size.width as u16, draw_size.height as u16,
-                       1, aa.into());
-            create_main_targets(dim)
-        };
-
-        let g2d = Gfx2d::new(opengl, &mut factory);
-        let encoder = factory.create_command_buffer().into();
         Window {
             window: window,
-            encoder: encoder,
-            device: device,
-            output_color: output_color,
-            output_stencil: output_stencil,
-            g2d: g2d,
-            factory: factory,
+            context: context,
         }
     }
 
@@ -220,60 +139,18 @@ impl<W> Window<W>
     {
         self.window.make_current();
         if let Some(args) = e.render_args() {
-            let res = self.g2d.draw(
-                &mut self.encoder,
-                &self.output_color,
-                &self.output_stencil,
-                args.viewport(),
-                f
-            );
-            self.encoder.flush(&mut self.device);
-            Some(res)
-        } else {
-            None
-        }
-    }
-
-    /// Renders 3D graphics.
-    pub fn draw_3d<E, F, U>(&mut self, e: &E, f: F) -> Option<U> where
-        W: OpenGLWindow,
-        E: GenericEvent,
-        F: FnOnce(&mut Self) -> U
-    {
-        self.window.make_current();
-        if let Some(_) = e.render_args() {
-            let res = f(self);
-            self.encoder.flush(&mut self.device);
-            Some(res)
+            Some(self.context.draw_2d(f, args))
         } else {
             None
         }
     }
 
     /// Let window handle new event.
-    /// Cleans up after rendering and resizes frame buffers.
-    pub fn event(&mut self, event: &Event<<W as BasicWindow>::Event>) {
-        use piston_input::*;
-        use self::gfx_core::factory::Typed;
-        use self::gfx::Device;
-
+    pub fn event(&mut self, event: &Event) {
         if let Some(_) = event.after_render_args() {
-            // After swapping buffers.
-            self.device.cleanup();
+            self.context.after_render();
         }
-
-        // Check whether window has resized and update the output.
-        let dim = self.output_color.raw().get_dimensions();
-        let (w, h) = (dim.0, dim.1);
-        let draw_size = self.window.draw_size();
-        if w != draw_size.width as u16 || h != draw_size.height as u16 {
-            let dim = (draw_size.width as u16,
-                       draw_size.height as u16,
-                       dim.2, dim.3);
-            let (output_color, output_stencil) = create_main_targets(dim);
-            self.output_color = output_color;
-            self.output_stencil = output_stencil;
-        }
+        self.context.check_resize(self.window.draw_size());
     }
 }
 
@@ -324,57 +201,19 @@ impl<W> AdvancedWindow for Window<W>
     }
 }
 
+impl GlyphCache {
+    /// Constructor for a new `GlyphCache`, using the factory associated with a `Window`
+    pub fn new(window: &mut Window, width: u32, height: u32) -> GlyphCache {
+        GlyphCache::new_from_factory(&mut window.context.factory, width, height)
+    }
+}
+
 /// Used to integrate `PistonWindow` with an event loop, enables
 /// `PistonWindow` to handle some events, if necessary
 pub trait EventWindow {
     /// receive next event from event loop and handle it
     fn next(&mut self, events: &mut Window) -> Option<Event>;
 }
-
-/// A wrapper around a `G2dTexture` and a rusttype GPU `Cache`
-///
-/// Using a wrapper simplifies the construction of both caches and ensures that they maintain
-/// identical dimensions.
-pub struct GlyphCache {
-    cache: text::GlyphCache,
-    texture: G2dTexture<'static>,
-    vertex_data: Vec<u8>,
-}
-
-
-impl GlyphCache {
-
-    /// Constructor for a new `GlyphCache`.
-    ///
-    /// The `PistonWindow` provides the `Factory` argument to the `G2dTexture` constructor.
-    ///
-    /// The `width` and `height` arguments are in pixel values.
-    ///
-    /// If you need to resize the `GlyphCache`, construct a new one and discard the old one.
-    pub fn new<B>(window: &mut Window<B>, width: u32, height: u32) -> GlyphCache 
-        where B: BasicWindow {
-
-        // Construct the rusttype GPU cache with the tolerances recommended by their documentation.
-        const SCALE_TOLERANCE: f32 = 0.1;
-        const POSITION_TOLERANCE: f32 = 0.1;
-        let cache = text::GlyphCache::new(width, height, SCALE_TOLERANCE, POSITION_TOLERANCE);
-
-        // Construct a `G2dTexture`
-        let buffer_len = width as usize * height as usize;
-        let init = vec![128; buffer_len];
-        let settings = TextureSettings::new();
-        let factory = &mut window.factory;
-        let texture = G2dTexture::from_memory_alpha(factory, &init, width, height, &settings).unwrap();
-
-        GlyphCache {
-            cache: cache,
-            texture: texture,
-            vertex_data: Vec::new(),
-        }
-    }
-
-}
-
 
 /// Converts any `GenericEvent` to a `Raw` conrod event.
 pub fn convert_event<E, B>(event: E, window: &Window<B>) -> Option<event::Raw>
@@ -386,114 +225,4 @@ pub fn convert_event<E, B>(event: E, window: &Window<B>) -> Option<event::Raw>
     let size = window.size();
     let (w, h) = (size.width as Scalar, size.height as Scalar);
     super::event::convert(event, w, h)
-}
-
-
-/// Renders the given sequence of conrod primitives.
-pub fn draw<'a, 'b, P, Img, F>(context: draw::Context,
-                               graphics: &'a mut G2d<'b>,
-                               primitives: P,
-                               glyph_cache: &'a mut GlyphCache,
-                               image_map: &'a image::Map<Img>,
-                               texture_from_image: F)
-    where P: render::PrimitiveWalker,
-          F: FnMut(&Img) -> &G2dTexture<'static>,
-{
-    let GlyphCache { ref mut texture, ref mut cache, ref mut vertex_data } = *glyph_cache;
-
-    // A function used for caching glyphs from `Text` widgets.
-    let cache_queued_glyphs_fn = |graphics: &mut G2d,
-                                  cache: &mut G2dTexture<'static>,
-                                  rect: text::rt::Rect<u32>,
-                                  data: &[u8]|
-    {
-        cache_queued_glyphs(graphics, cache, rect, data, vertex_data);
-    };
-
-    draw::primitives(
-        primitives,
-        context,
-        graphics,
-        texture,
-        cache,
-        image_map,
-        cache_queued_glyphs_fn,
-        texture_from_image,
-    );
-}
-
-/// Draw a single `Primitive` to the screen.
-///
-/// This is useful if the user requires rendering primitives individually, perhaps to perform their
-/// own rendering in between, etc.
-pub fn draw_primitive<'a, 'b, Img, F>(context: draw::Context,
-                                      graphics: &'a mut G2d<'b>,
-                                      primitive: render::Primitive,
-                                      glyph_cache: &'a mut GlyphCache,
-                                      image_map: &'a image::Map<Img>,
-                                      glyph_rectangles: &mut Vec<([f64; 4], [i32; 4])>,
-                                      texture_from_image: F)
-    where F: FnMut(&Img) -> &G2dTexture<'static>,
-{
-    let GlyphCache { ref mut texture, ref mut cache, ref mut vertex_data } = *glyph_cache;
-
-    // A function used for caching glyphs from `Text` widgets.
-    let cache_queued_glyphs_fn = |graphics: &mut G2d,
-                                  cache: &mut G2dTexture<'static>,
-                                  rect: text::rt::Rect<u32>,
-                                  data: &[u8]|
-    {
-        cache_queued_glyphs(graphics, cache, rect, data, vertex_data);
-    };
-
-    draw::primitive(
-        primitive,
-        context,
-        graphics,
-        texture,
-        cache,
-        image_map,
-        glyph_rectangles,
-        cache_queued_glyphs_fn,
-        texture_from_image,
-    );
-}
-
-fn cache_queued_glyphs(graphics: &mut G2d,
-                       cache: &mut G2dTexture<'static>,
-                       rect: text::rt::Rect<u32>,
-                       data: &[u8],
-                       vertex_data: &mut Vec<u8>)
-{
-    use self::texture::UpdateTexture;
-
-    // An iterator that efficiently maps the `byte`s yielded from `data` to `[r, g, b, byte]`;
-    //
-    // This is only used within the `cache_queued_glyphs` below, however due to a bug in rustc we
-    // are unable to declare types inside the closure scope.
-    struct Bytes { b: u8, i: u8 }
-    impl Iterator for Bytes {
-        type Item = u8;
-        fn next(&mut self) -> Option<Self::Item> {
-            let b = match self.i {
-                0 => 255,
-                1 => 255,
-                2 => 255,
-                3 => self.b,
-                _ => return None,
-            };
-            self.i += 1;
-            Some(b)
-        }
-    }
-
-    let offset = [rect.min.x, rect.min.y];
-    let size = [rect.width(), rect.height()];
-    let format = self::texture::Format::Rgba8;
-    let encoder = &mut graphics.encoder;
-
-    vertex_data.clear();
-    vertex_data.extend(data.iter().flat_map(|&b| Bytes { b: b, i: 0 }));
-    UpdateTexture::update(cache, encoder, format, &vertex_data[..], offset, size)
-        .expect("Failed to update texture");
 }

--- a/src/backend/piston_window.rs
+++ b/src/backend/piston_window.rs
@@ -1,16 +1,356 @@
-//! Helper functions for using conrod with the `piston_window` crate.
+#![deny(missing_docs)]
+
+//! This code is adapted from the `piston_window` crate for convenience when
+//! using the piston window API with a conrod app.
 //!
-//! the `piston_window` crate attempts to provide a simple API over the gfx graphics backend and
-//! the glutin window context and events.
+//! Provides a simple API over the gfx graphics backend and the glutin window
+//! context and events.
+//!
+//! Sets up:
+//!
+//! - [Gfx](https://github.com/gfx-rs/gfx) with an OpenGL back-end.
+//! - [gfx_graphics](https://github.com/pistondevelopers/gfx_graphics)
+//! for 2D rendering.
+//! - [glutin_window](https://github.com/pistondevelopers/glutin_window)
+//! as default window back-end, but this can be swapped (see below).
+//!
+//! ### Example
+//!
+//! ```no_run
+//! extern crate conrod;
+//!
+//! use conrod::backend::piston_window::*;
+//!
+//! fn main() {
+//!     let mut window: PistonWindow =
+//!         WindowSettings::new("Hello World!", [512; 2])
+//!             .build().unwrap();
+//!     while let Some(e) = window.next() {
+//!         window.draw_2d(&e, |c, g| {
+//!             clear([0.5, 0.5, 0.5, 1.0], g);
+//!             rectangle([1.0, 0.0, 0.0, 1.0], // red
+//!                       [0.0, 0.0, 100.0, 100.0], // rectangle
+//!                       c.transform, g);
+//!         });
+//!     }
+//! }
+//! ```
+//!
+//! ### Swap to another window back-end
+//!
+//! Change the generic parameter to the window back-end you want to use.
+//!
+//! ```ignore
+//! extern crate conrod;
+//! extern crate sdl2_window;
+//!
+//! use conrod::backend::piston_window::*;
+//! use sdl2_window::Sdl2Window;
+//!
+//! # fn main() {
+//!
+//! let window: PistonWindow<Sdl2Window> =
+//!     WindowSettings::new("title", [512; 2])
+//!         .build().unwrap();
+//!
+//! # }
+//! ```
+//!
+//! ### sRGB
+//!
+//! The impl of `BuildFromWindowSettings` in this library turns on
+//! `WindowSettings::srgb`, because it is required by gfx_graphics.
+//!
+//! Most images such as those found on the internet uses sRGB,
+//! that has a non-linear gamma corrected space.
+//! When rendering 3D, make sure textures and colors are in linear gamma space.
+//! Alternative is to use `Srgb8` and `Srgba8` formats for textures.
+//!
+//! For more information about sRGB, see
+//! https://github.com/PistonDevelopers/piston/issues/1014
+//!
+//! ### Library dependencies
+//!
+//! This library is meant to be used in applications only.
+//! It is not meant to be depended on by generic libraries.
+//! Instead, libraries should depend on the lower abstractions,
+//! such as the [Piston core](https://github.com/pistondevelopers/piston).
 
-extern crate piston_window;
+extern crate window as pistoncore_window;
+extern crate event_loop as pistoncore_event_loop;
+extern crate gfx;
+extern crate gfx_core;
+extern crate gfx_device_gl;
+extern crate gfx_graphics;
+extern crate graphics;
+extern crate shader_version;
+extern crate glutin_window;
+pub extern crate texture;
 
+use self::glutin_window::GlutinWindow;
+pub use self::shader_version::OpenGL;
+pub use self::graphics::{ImageSize};
+pub use self::pistoncore_window::*;
+pub use self::pistoncore_event_loop::*;
+pub use piston_input::*;
+pub use self::gfx_graphics::{ GlyphError, Texture, TextureSettings, Flip };
+
+use self::gfx_graphics::{ Gfx2d, GfxGraphics };
+use std::time::Duration;
+
+use super::piston::draw;
 use event;
 use image;
-use self::piston_window::{G2dTexture, PistonWindow};
 use render;
 use text;
 
+/// Actual gfx::Stream implementation carried by the window.
+pub type GfxEncoder = gfx::Encoder<gfx_device_gl::Resources,
+    gfx_device_gl::CommandBuffer>;
+/// Glyph cache.
+pub type Glyphs = gfx_graphics::GlyphCache<gfx_device_gl::Resources,
+    gfx_device_gl::Factory>;
+/// 2D graphics.
+pub type G2d<'a> = GfxGraphics<'a,
+    gfx_device_gl::Resources,
+    gfx_device_gl::CommandBuffer>;
+/// Texture type compatible with `G2d`.
+pub type G2dTexture<'a> = Texture<gfx_device_gl::Resources>;
+
+/// Contains everything required for controlling window, graphics, event loop.
+pub struct PistonWindow<W: Window = GlutinWindow> {
+    /// The window.
+    pub window: W,
+    /// GFX encoder.
+    pub encoder: GfxEncoder,
+    /// GFX device.
+    pub device: gfx_device_gl::Device,
+    /// Output frame buffer.
+    pub output_color: gfx::handle::RenderTargetView<
+        gfx_device_gl::Resources, gfx::format::Srgba8>,
+    /// Output stencil buffer.
+    pub output_stencil: gfx::handle::DepthStencilView<
+        gfx_device_gl::Resources, gfx::format::DepthStencil>,
+    /// Gfx2d.
+    pub g2d: Gfx2d<gfx_device_gl::Resources>,
+    /// Event loop state.
+    pub events: WindowEvents,
+    /// The factory that was created along with the device.
+    pub factory: gfx_device_gl::Factory,
+}
+
+impl<W> BuildFromWindowSettings for PistonWindow<W>
+    where W: Window + OpenGLWindow + BuildFromWindowSettings,
+          W::Event: GenericEvent
+{
+    fn build_from_window_settings(settings: &WindowSettings) -> Result<PistonWindow<W>, String> {
+        // Turn on sRGB.
+        let settings = settings.clone().srgb(true);
+
+        // Use OpenGL 3.2 by default, because this is what window backends
+        // usually do.
+        let opengl = settings.get_maybe_opengl().unwrap_or(OpenGL::V3_2);
+        let samples = settings.get_samples();
+
+        Ok(PistonWindow::new(opengl, samples, try!(settings.build())))
+    }
+}
+
+fn create_main_targets(dim: gfx::tex::Dimensions) ->
+(gfx::handle::RenderTargetView<
+    gfx_device_gl::Resources, gfx::format::Srgba8>,
+ gfx::handle::DepthStencilView<
+    gfx_device_gl::Resources, gfx::format::DepthStencil>) {
+    use self::gfx_core::factory::Typed;
+    use self::gfx::format::{DepthStencil, Format, Formatted, Srgba8};
+
+    let color_format: Format = <Srgba8 as Formatted>::get_format();
+    let depth_format: Format = <DepthStencil as Formatted>::get_format();
+    let (output_color, output_stencil) =
+        gfx_device_gl::create_main_targets_raw(dim,
+                                               color_format.0,
+                                               depth_format.0);
+    let output_color = Typed::new(output_color);
+    let output_stencil = Typed::new(output_stencil);
+    (output_color, output_stencil)
+}
+
+impl<W> PistonWindow<W>
+    where W: Window, W::Event: GenericEvent
+{
+    /// Creates a new piston window.
+    pub fn new(opengl: OpenGL, samples: u8, mut window: W) -> Self
+        where W: OpenGLWindow
+    {
+        let (device, mut factory) =
+            gfx_device_gl::create(|s|
+                window.get_proc_address(s) as *const _);
+
+        let (output_color, output_stencil) = {
+            let aa = samples as gfx::tex::NumSamples;
+            let draw_size = window.draw_size();
+            let dim = (draw_size.width as u16, draw_size.height as u16,
+                       1, aa.into());
+            create_main_targets(dim)
+        };
+
+        let g2d = Gfx2d::new(opengl, &mut factory);
+        let encoder = factory.create_command_buffer().into();
+        let events = window.events();
+        PistonWindow {
+            window: window,
+            encoder: encoder,
+            device: device,
+            output_color: output_color,
+            output_stencil: output_stencil,
+            g2d: g2d,
+            events: events,
+            factory: factory,
+        }
+    }
+
+    /// Renders 2D graphics.
+    pub fn draw_2d<E, F, U>(&mut self, e: &E, f: F) -> Option<U> where
+        W: OpenGLWindow,
+        E: GenericEvent,
+        F: FnOnce(draw::Context, &mut G2d) -> U
+    {
+        self.window.make_current();
+        if let Some(args) = e.render_args() {
+            let res = self.g2d.draw(
+                &mut self.encoder,
+                &self.output_color,
+                &self.output_stencil,
+                args.viewport(),
+                f
+            );
+            self.encoder.flush(&mut self.device);
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    /// Renders 3D graphics.
+    pub fn draw_3d<E, F, U>(&mut self, e: &E, f: F) -> Option<U> where
+        W: OpenGLWindow,
+        E: GenericEvent,
+        F: FnOnce(&mut Self) -> U
+    {
+        self.window.make_current();
+        if let Some(_) = e.render_args() {
+            let res = f(self);
+            self.encoder.flush(&mut self.device);
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    /// Returns next event.
+    /// Cleans up after rendering and resizes frame buffers.
+    pub fn next(&mut self) -> Option<Event<<W as Window>::Event>> {
+        if let Some(e) = self.events.next(&mut self.window) {
+            self.event(&e);
+            Some(e)
+        } else {
+            None
+        }
+    }
+
+    /// Let window handle new event.
+    /// Cleans up after rendering and resizes frame buffers.
+    pub fn event(&mut self, event: &Event<<W as Window>::Event>) {
+        use piston_input::*;
+        use self::gfx_core::factory::Typed;
+        use self::gfx::Device;
+
+        if let Some(_) = event.after_render_args() {
+            // After swapping buffers.
+            self.device.cleanup();
+        }
+
+        // Check whether window has resized and update the output.
+        let dim = self.output_color.raw().get_dimensions();
+        let (w, h) = (dim.0, dim.1);
+        let draw_size = self.window.draw_size();
+        if w != draw_size.width as u16 || h != draw_size.height as u16 {
+            let dim = (draw_size.width as u16,
+                       draw_size.height as u16,
+                       dim.2, dim.3);
+            let (output_color, output_stencil) = create_main_targets(dim);
+            self.output_color = output_color;
+            self.output_stencil = output_stencil;
+        }
+    }
+}
+
+impl<W> Window for PistonWindow<W>
+    where W: Window
+{
+    type Event = <W as Window>::Event;
+
+    fn should_close(&self) -> bool { self.window.should_close() }
+    fn set_should_close(&mut self, value: bool) {
+        self.window.set_should_close(value)
+    }
+    fn size(&self) -> Size { self.window.size() }
+    fn draw_size(&self) -> Size { self.window.draw_size() }
+    fn swap_buffers(&mut self) { self.window.swap_buffers() }
+    fn wait_event(&mut self) -> Self::Event {
+        Window::wait_event(&mut self.window)
+    }
+    fn wait_event_timeout(&mut self, timeout: Duration) -> Option<Self::Event> {
+        Window::wait_event_timeout(&mut self.window, timeout)
+    }
+    fn poll_event(&mut self) -> Option<Self::Event> {
+        Window::poll_event(&mut self.window)
+    }
+}
+
+impl<W> AdvancedWindow for PistonWindow<W>
+    where W: AdvancedWindow
+{
+    fn get_title(&self) -> String { self.window.get_title() }
+    fn set_title(&mut self, title: String) {
+        self.window.set_title(title)
+    }
+    fn get_exit_on_esc(&self) -> bool { self.window.get_exit_on_esc() }
+    fn set_exit_on_esc(&mut self, value: bool) {
+        self.window.set_exit_on_esc(value)
+    }
+    fn set_capture_cursor(&mut self, value: bool) {
+        self.window.set_capture_cursor(value)
+    }
+    fn show(&mut self) { self.window.show() }
+    fn hide(&mut self) { self.window.hide() }
+    fn get_position(&self) -> Option<Position> {
+        self.window.get_position()
+    }
+    fn set_position<P: Into<Position>>(&mut self, pos: P) {
+        self.window.set_position(pos)
+    }
+}
+
+impl<W> EventLoop for PistonWindow<W>
+    where W: Window
+{
+    fn set_ups(&mut self, frames: u64) {
+        self.events.set_ups(frames);
+    }
+
+    fn set_max_fps(&mut self, frames: u64) {
+        self.events.set_max_fps(frames);
+    }
+
+    fn set_swap_buffers(&mut self, enable: bool) {
+        self.events.set_swap_buffers(enable);
+    }
+
+    fn set_bench_mode(&mut self, enable: bool) {
+        self.events.set_bench_mode(enable);
+    }
+}
 
 /// A wrapper around a `G2dTexture` and a rusttype GPU `Cache`
 ///
@@ -33,7 +373,7 @@ impl GlyphCache {
     ///
     /// If you need to resize the `GlyphCache`, construct a new one and discard the old one.
     pub fn new<B>(window: &mut PistonWindow<B>, width: u32, height: u32) -> GlyphCache 
-        where B: self::piston_window::Window {
+        where B: Window {
 
         // Construct the rusttype GPU cache with the tolerances recommended by their documentation.
         const SCALE_TOLERANCE: f32 = 0.1;
@@ -43,7 +383,7 @@ impl GlyphCache {
         // Construct a `G2dTexture`
         let buffer_len = width as usize * height as usize;
         let init = vec![128; buffer_len];
-        let settings = self::piston_window::TextureSettings::new();
+        let settings = TextureSettings::new();
         let factory = &mut window.factory;
         let texture = G2dTexture::from_memory_alpha(factory, &init, width, height, &settings).unwrap();
 
@@ -59,10 +399,9 @@ impl GlyphCache {
 
 /// Converts any `GenericEvent` to a `Raw` conrod event.
 pub fn convert_event<E, B>(event: E, window: &PistonWindow<B>) -> Option<event::Raw>
-    where E: super::piston::event::GenericEvent,
-          B: self::piston_window::Window,
+    where E: GenericEvent,
+          B: Window,
 {
-    use self::piston_window::Window;
     use Scalar;
 
     let size = window.size();
@@ -72,8 +411,8 @@ pub fn convert_event<E, B>(event: E, window: &PistonWindow<B>) -> Option<event::
 
 
 /// Renders the given sequence of conrod primitives.
-pub fn draw<'a, 'b, P, Img, F>(context: super::piston::draw::Context,
-                               graphics: &'a mut piston_window::G2d<'b>,
+pub fn draw<'a, 'b, P, Img, F>(context: draw::Context,
+                               graphics: &'a mut G2d<'b>,
                                primitives: P,
                                glyph_cache: &'a mut GlyphCache,
                                image_map: &'a image::Map<Img>,
@@ -84,7 +423,7 @@ pub fn draw<'a, 'b, P, Img, F>(context: super::piston::draw::Context,
     let GlyphCache { ref mut texture, ref mut cache, ref mut vertex_data } = *glyph_cache;
 
     // A function used for caching glyphs from `Text` widgets.
-    let cache_queued_glyphs_fn = |graphics: &mut piston_window::G2d,
+    let cache_queued_glyphs_fn = |graphics: &mut G2d,
                                   cache: &mut G2dTexture<'static>,
                                   rect: text::rt::Rect<u32>,
                                   data: &[u8]|
@@ -92,7 +431,7 @@ pub fn draw<'a, 'b, P, Img, F>(context: super::piston::draw::Context,
         cache_queued_glyphs(graphics, cache, rect, data, vertex_data);
     };
 
-    super::piston::draw::primitives(
+    draw::primitives(
         primitives,
         context,
         graphics,
@@ -108,8 +447,8 @@ pub fn draw<'a, 'b, P, Img, F>(context: super::piston::draw::Context,
 ///
 /// This is useful if the user requires rendering primitives individually, perhaps to perform their
 /// own rendering in between, etc.
-pub fn draw_primitive<'a, 'b, Img, F>(context: super::piston::draw::Context,
-                                      graphics: &'a mut piston_window::G2d<'b>,
+pub fn draw_primitive<'a, 'b, Img, F>(context: draw::Context,
+                                      graphics: &'a mut G2d<'b>,
                                       primitive: render::Primitive,
                                       glyph_cache: &'a mut GlyphCache,
                                       image_map: &'a image::Map<Img>,
@@ -120,7 +459,7 @@ pub fn draw_primitive<'a, 'b, Img, F>(context: super::piston::draw::Context,
     let GlyphCache { ref mut texture, ref mut cache, ref mut vertex_data } = *glyph_cache;
 
     // A function used for caching glyphs from `Text` widgets.
-    let cache_queued_glyphs_fn = |graphics: &mut piston_window::G2d,
+    let cache_queued_glyphs_fn = |graphics: &mut G2d,
                                   cache: &mut G2dTexture<'static>,
                                   rect: text::rt::Rect<u32>,
                                   data: &[u8]|
@@ -128,7 +467,7 @@ pub fn draw_primitive<'a, 'b, Img, F>(context: super::piston::draw::Context,
         cache_queued_glyphs(graphics, cache, rect, data, vertex_data);
     };
 
-    super::piston::draw::primitive(
+    draw::primitive(
         primitive,
         context,
         graphics,
@@ -141,13 +480,13 @@ pub fn draw_primitive<'a, 'b, Img, F>(context: super::piston::draw::Context,
     );
 }
 
-fn cache_queued_glyphs(graphics: &mut piston_window::G2d,
+fn cache_queued_glyphs(graphics: &mut G2d,
                        cache: &mut G2dTexture<'static>,
                        rect: text::rt::Rect<u32>,
                        data: &[u8],
                        vertex_data: &mut Vec<u8>)
 {
-    use self::piston_window::texture::UpdateTexture;
+    use self::texture::UpdateTexture;
 
     // An iterator that efficiently maps the `byte`s yielded from `data` to `[r, g, b, byte]`;
     //
@@ -171,7 +510,7 @@ fn cache_queued_glyphs(graphics: &mut piston_window::G2d,
 
     let offset = [rect.min.x, rect.min.y];
     let size = [rect.width(), rect.height()];
-    let format = self::piston_window::texture::Format::Rgba8;
+    let format = self::texture::Format::Rgba8;
     let encoder = &mut graphics.encoder;
 
     vertex_data.clear();


### PR DESCRIPTION
This copies the `piston_window` into `backend`, as discussed here https://github.com/PistonDevelopers/piston_window/issues/170

It replaces the `piston_window` optional dependency with a `piston_window` feature.

This also makes the change to the `PistonWindow` that necessitated the fork, that is, decoupling the default piston event loop. If this is merged I can clean up https://github.com/PistonDevelopers/conrod/pull/831

Hopefully this also enables other future changes to `PistonWindow` as well. My thoughts are this forked version of `PistonWindow` can be made more configurable in general, rather than just as simple as possible for the common case.

The new window was originally going to be called `ConrodWindow` but I agree the prefix shouldn't be necessary, (see https://github.com/PistonDevelopers/piston_window/issues/170) so I just left it as `PistonWindow`. It is a better description of what it is, although it does duplicate the name in `piston_window`. I'm hoping that won't be too confusing, but I'm open to alternative names if it is.