### PR TITLE
Remove `event::Raw` in favour of using `event::Input`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ pistoncore-event_loop = { version = "0.26.0", optional = true }
 piston2d-gfx_graphics = { version = "0.31.1", optional = true }
 piston-texture = { version = "0.5.0", optional = true }
 shader_version = { version = "0.2.0", optional = true }
-pistoncore-glutin_window = { version = "0.31.0", optional = true }
+pistoncore-glutin_window = { version = "0.32.0", optional = true }
 
 [features]
 default = ["piston"]

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -31,7 +31,9 @@ fn main() {
     let mut app = support::DemoApp::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().theme(support::theme()).build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64])
+        .theme(support::theme())
+        .build();
 
     // Add a `Font` to the `Ui`'s `font::Map` from file.
     let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // Add a `Font` to the `Ui`'s `font::Map` from file.
     let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -21,7 +21,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // Generate the widget identifiers.
     widget_ids!(struct Ids { canvas, counter });

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -247,7 +247,7 @@ pub fn main() {
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // The `widget_ids` macro is a easy, safe way of generating a type for producing `widget::Id`s.
     widget_ids! {

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     widget_ids!(struct Ids { canvas, file_navigator });

--- a/examples/glutin_gfx.rs
+++ b/examples/glutin_gfx.rs
@@ -168,7 +168,7 @@ mod feature {
         let mut app = support::DemoApp::new();
 
         // Create Ui and Ids of widgets to instantiate
-        let mut ui = conrod::UiBuilder::new().theme(support::theme()).build();
+        let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
         let ids = support::Ids::new(ui.widget_id_generator());
 
         // Load font from file
@@ -208,9 +208,6 @@ mod feature {
             };
 
             let dpi_factor = window.hidpi_factor();
-
-            let dt_secs = 0.0;
-            ui.handle_event(conrod::event::render(dt_secs, win_w, win_h, dpi_factor as conrod::Scalar));
 
             if let Some(mut primitives) = ui.draw_if_changed() {
                 let (screen_width, screen_height) = (win_w as f32 * dpi_factor, win_h as f32 * dpi_factor);

--- a/examples/glutin_glium.rs
+++ b/examples/glutin_glium.rs
@@ -39,7 +39,7 @@ mod feature {
         let mut app = support::DemoApp::new();
 
         // Construct our `Ui`.
-        let mut ui = conrod::UiBuilder::new().theme(support::theme()).build();
+        let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
 
         // The `widget::Id` of each widget instantiated in `support::gui`.
         let ids = support::Ids::new(ui.widget_id_generator());
@@ -81,12 +81,6 @@ mod feature {
         // - Repeat.
         'main: loop {
 
-            // Construct a render event for conrod at the beginning of rendering.
-            // NOTE: This will be removed in a future version of conrod as Render events shouldn't
-            // be necessary.
-            let window = display.get_window().unwrap();
-            ui.handle_event(conrod::backend::glutin::render_event(window).unwrap());
-
             // Poll for events.
             for event in display.poll_events() {
 
@@ -115,7 +109,7 @@ mod feature {
                 let (win_w, win_h) = (win_rect.w() as u32, win_rect.h() as u32);
                 let (w, h) = display.get_window().unwrap().get_inner_size_points().unwrap();
                 if w != win_w || h != win_h {
-                    let event: conrod::event::Raw = conrod::event::Input::Resize(w, h).into();
+                    let event = conrod::event::Input::Resize(w, h);
                     ui.handle_event(event);
                 }
             }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -27,7 +27,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // Create an empty texture to pass for the text cache as we're not drawing any text.
     let mut text_texture_cache = piston::window::GlyphCache::new(&mut window, 0, 0);
@@ -47,7 +47,11 @@ fn main() {
 
     // Poll events from the window.
     while let Some(event) = window.next_event(&mut events) {
-        ui.handle_event(event.clone());
+
+        // Convert the piston event to a conrod input event.
+        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
+            ui.handle_event(e);
+        }
 
         window.draw_2d(&event, |c, g| {
             if let Some(primitives) = ui.draw_if_changed() {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -49,7 +49,7 @@ fn main() {
     while let Some(event) = window.next_event(&mut events) {
 
         // Convert the piston event to a conrod input event.
-        if let Some(e) = piston_window::convert_event(event.clone(), &window) {
+        if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
         }
 

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -32,7 +32,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // Add a `Font` to the `Ui`'s `font::Map` from file.
     let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -23,7 +23,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // Unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -27,7 +27,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -108,7 +108,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // Identifiers used for instantiating our widgets.
     let mut ids = Ids::new(ui.widget_id_generator());

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -9,10 +9,12 @@ widget_ids! {
 }
 
 fn main() {
+    const WIDTH: u32 = 720;
+    const HEIGHT: u32 = 360;
 
     // Construct the window.
     let mut window: Window =
-        piston::window::WindowSettings::new("PlotPath Demo", [720, 360])
+        piston::window::WindowSettings::new("PlotPath Demo", [WIDTH, HEIGHT])
             .opengl(OpenGL::V3_2)
             .samples(4)
             .exit_on_esc(true)
@@ -23,7 +25,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -21,20 +21,22 @@ widget_ids! {
 
 
 fn main() {
+    const WIDTH: u32 = 400;
+    const HEIGHT: u32 = 720;
 
     // Change this to OpenGL::V2_1 if not working.
     let opengl = OpenGL::V3_2;
 
     // Construct the window.
     let mut window: Window =
-        piston::window::WindowSettings::new("Primitives Demo", [400, 720])
+        piston::window::WindowSettings::new("Primitives Demo", [WIDTH, HEIGHT])
             .opengl(opengl).samples(4).exit_on_esc(true).build().unwrap();
 
     // Create the event loop.
     let mut events = WindowEvents::new();
 
     // construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -25,7 +25,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -20,7 +20,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -21,7 +21,7 @@ fn main() {
     let mut events = WindowEvents::new();
 
     // Construct our `Ui`.
-    let mut ui = conrod::UiBuilder::new().build();
+    let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A unique identifier for each widget.
     let ids = Ids::new(ui.widget_id_generator());

--- a/src/backend/glutin.rs
+++ b/src/backend/glutin.rs
@@ -1,16 +1,16 @@
-//! A function for converting a `glutin::Event` to a `conrod::event::Raw`.
+//! A function for converting a `glutin::Event` to a `conrod::event::Input`.
 //!
 //! The following is adapted from the piston `glutin_window` crate.
 
 extern crate glutin;
 
 use Scalar;
-use event::{self, Input, Motion};
+use event::{Input, Motion};
 use input;
 use std;
 
-/// A function for converting a `glutin::Event` to a `conrod::event::Raw`.
-pub fn convert<W>(e: glutin::Event, window: W) -> Option<event::Raw>
+/// A function for converting a `glutin::Event` to a `conrod::event::Input`.
+pub fn convert<W>(e: glutin::Event, window: W) -> Option<Input>
     where W: std::ops::Deref<Target=glutin::Window>,
 {
 
@@ -94,21 +94,6 @@ pub fn convert<W>(e: glutin::Event, window: W) -> Option<event::Raw>
 
         _ => None,
     }
-}
-
-/// Creates a `event::Raw::Render`.
-///
-/// Returns `None` if the window is no longer open.
-///
-/// NOTE: This will be removed in a future version of conrod as Render events shouldn't be
-/// necessary.
-pub fn render_event<W>(window: W) -> Option<event::Raw>
-    where W: std::ops::Deref<Target=glutin::Window>,
-{
-    window.get_inner_size_pixels().map(|(win_w, win_h)| {
-        let dpi_factor = window.hidpi_factor();
-        event::render(0.0, win_w, win_h, dpi_factor as Scalar)
-    })
 }
 
 /// Maps Glutin's key to a conrod `Key`.

--- a/src/backend/piston/event.rs
+++ b/src/backend/piston/event.rs
@@ -1,67 +1,60 @@
-//! A backend for converting piston events to conrod's `event::Raw` type.
-//!
-//! The module also allows provides an `EventWindow` impl for the default piston game event loop
-//! from pistoncore-event_loop, allowing compatibility with conrod's custom piston `Window`.
+//! A backend for converting piston events to conrod's `Input` type.
 
 use {Point, Scalar};
-use event::{self, Input, Motion, RawEvent};
-
+use event::{Input, Motion};
 pub use piston_input::{GenericEvent, UpdateEvent};
 
-
-/// Converts any `GenericEvent` to a `Raw` conrod event.
-pub fn convert<E>(event: E, win_w: Scalar, win_h: Scalar) -> Option<event::Raw>
+/// Converts any `GenericEvent` to an `Input` event for conrod.
+///
+/// The given `width` and `height` must be `Scalar` (DPI agnostic) values.
+pub fn convert<E>(event: E, win_w: Scalar, win_h: Scalar) -> Option<Input>
     where E: GenericEvent,
 {
     // Translate the coordinates from top-left-origin-with-y-down to centre-origin-with-y-up.
     let translate_coords = |xy: Point| (xy[0] - win_w / 2.0, -(xy[1] - win_h / 2.0));
 
-    if let Some(args) = event.render_args() {
-        return Some(RawEvent::Render(args));
-    }
-
     if let Some(xy) = event.mouse_cursor_args() {
         let (x, y) = translate_coords(xy);
-        return Some(Input::Move(Motion::MouseCursor(x, y)).into());
+        return Some(Input::Move(Motion::MouseCursor(x, y)));
     }
 
     if let Some(rel_xy) = event.mouse_relative_args() {
         let (rel_x, rel_y) = translate_coords(rel_xy);
-        return Some(Input::Move(Motion::MouseRelative(rel_x, rel_y)).into());
+        return Some(Input::Move(Motion::MouseRelative(rel_x, rel_y)));
     }
 
     if let Some(xy) = event.mouse_scroll_args() {
         // Invert the scrolling of the *y* axis as *y* is up in conrod.
         let (x, y) = (xy[0], -xy[1]);
-        return Some(Input::Move(Motion::MouseScroll(x, y)).into());
+        return Some(Input::Move(Motion::MouseScroll(x, y)));
     }
 
     if let Some(args) = event.controller_axis_args() {
-        return Some(Input::Move(Motion::ControllerAxis(args)).into());
+        return Some(Input::Move(Motion::ControllerAxis(args)));
     }
 
     if let Some(button) = event.press_args() {
-        return Some(Input::Press(button).into());
+        return Some(Input::Press(button));
     }
 
     if let Some(button) = event.release_args() {
-        return Some(Input::Release(button).into());
+        return Some(Input::Release(button));
     }
 
     if let Some(text) = event.text_args() {
-        return Some(Input::Text(text).into());
+        return Some(Input::Text(text));
     }
 
     if let Some(dim) = event.resize_args() {
-        return Some(Input::Resize(dim[0], dim[1]).into());
+        return Some(Input::Resize(dim[0], dim[1]));
     }
 
     if let Some(b) = event.focus_args() {
-        return Some(Input::Focus(b).into());
+        return Some(Input::Focus(b));
     }
 
     if let Some(b) = event.cursor_args() {
-        return Some(Input::Cursor(b).into());
+        return Some(Input::Cursor(b));
     }
 
     None

--- a/src/backend/piston/window.rs
+++ b/src/backend/piston/window.rs
@@ -228,7 +228,7 @@ impl EventWindow<WindowEvents> for Window {
 }
 
 /// Converts any `GenericEvent` to a `Raw` conrod event.
-pub fn convert_event<E, B>(event: E, window: &Window<B>) -> Option<event::Raw>
+pub fn convert_event<E, B>(event: E, window: &Window<B>) -> Option<event::Input>
     where E: GenericEvent,
           B: BasicWindow,
 {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,73 +1,64 @@
-//! Contains all the structs and enums to describe all of the input events that `Widget`s
-//! can handle.
+//! Contains all types used to describe the input events that `Widget`s may handle.
 //!
-//! The core of this module is the `Event` enum, which encapsulates all of those events.
+//! The two primary types of this module are:
 //!
+//! - `Input`: conrod's input type passed by the user to `Ui::handle_event` in order to drive the
+//! `Ui`.
+//! - `Event`: enumerates all possible events interpreted by conrod that may be propagated to
+//! widgets.
 //!
-//!
-//! The backend for conrod's event system.
+//! The Event System
+//! ----------------
 //!
 //! Conrod's event system looks like this:
 //!
-//! *RawEvent -> Ui -> UiEvent -> Widget*
+//! *Input -> Ui -> Event -> Widget*
 //!
-//! The **Ui** receives **RawEvent**s such as `Press` and `Release` via the `Ui::handle_event`
-//! method. It interprets these **RawEvent**s to create higher-level **UiEvent**s such as
-//! `DoubleClick`, `WidgetCapturesKeyboard`, etc. These **UiEvent**s are stored and then fed to
-//! each **Widget** when `Ui::set_widgets` is called. At the end of `Ui::set_widgets` the stored
-//! **UiEvent**s are flushed ready for the next incoming **RawEvent**s.
+//! The **Ui** receives **Input**s such as `Press` and `Release` via the `Ui::handle_event` method.
+//! It interprets these **Input**s to create higher-level **Event**s such as `DoubleClick`,
+//! `WidgetCapturesKeyboard`, etc. These **Event**s are stored and then fed to each **Widget** when
+//! `Ui::set_widgets` is called. At the end of `Ui::set_widgets` the stored **Event**s are flushed
+//! ready for the next incoming **Input**s.
 //!
-//! Conrod uses the `pistoncore-input` crate's `Event` type as the [**RawEvent**
-//! type](./type.RawEvent.html). There are a few reasons for this:
+//! Conrod uses the `pistoncore-input` crate's `Input` type. There are a few reasons for this:
 //!
-//! 1. This `Event` type already provides a number of useful variants of events that we wish to
+//! 1. This `Input` type already provides a number of useful variants of events that we wish to
 //!    provide and handle within conrod, and we do not yet see any great need to re-write it and
 //!    duplicate code.
-//! 2. The `Event` type is already compatible with all `pistoncore-window` backends including
-//!    `glfw_window`, `sdl2_window` and `glutin_window`.
+//! 2. The `Input` type is already compatible with all `pistoncore-window` backends including
+//!    `glfw_window`, `sdl2_window` and `glutin_window`. That said, co-ordinates and scroll
+//!    directions may need to be translated to conrod's orientation.
 //! 3. The `pistoncore-input` crate also provides a `GenericEvent` trait which allows us to easily
 //!    provide a blanket implementation of `ToRawEvent` for all event types that already implement
 //!    this trait.
 //!
 //! Because we use the `pistoncore-input` `Event` type, we also re-export its associated data
 //! types (`Button`, `ControllerAxisArgs`, `Key`, etc).
-//!
-//! The [**ToRawEvent** trait](./trait.ToRawEvent.html) should be implemented for event types that
-//! are to be passed to the `Ui::handle_event` method. As mentioned above, a blanket implementation
-//! is already provided for all types that implement `pistoncore-input::GenericEvent`, so users of
-//! `glfw_window`, `sdl2_window` and `glutin_window` need not concern themselves with this trait.
 
 use input;
-use position::{Dimensions, Point, Scalar};
+use position::{Dimensions, Point};
 use utils::vec2_sub;
 use widget;
-
-use piston_input;
 
 
 /// The event type that is used by conrod to track inputs from the world. Events yielded by polling
 /// window backends should be converted to this type. This can be thought of as the event type
 /// which is supplied by the window backend to drive the state of the `Ui` forward.
 ///
-/// This type is solely used within the `Ui::handle_event` method which immediately converts
-/// given user events to `RawEvent`s via the [**ToRawEvent** trait](./trait.ToRawEvent.html) bound.
-/// The `RawEvent`s are interpreted to create higher level `Event`s (such as DoubleClick,
-/// WidgetCapturesKeyboard, etc) which are stored for later processing by `Widget`s, which will
-/// occur during the call to `Ui::set_widgets`.
+/// This type is solely used within the `Ui::handle_event` method.  The `Input` events are
+/// interpreted to create higher level `Event`s (such as DoubleClick, WidgetCapturesKeyboard, etc)
+/// which are stored for later processing by `Widget`s, which will occur during the call to
+/// `Ui::set_widgets`.
 ///
-/// **Note:** `Raw` events that contain co-ordinates must be oriented with (0, 0) at the middle of
-/// the window with the *y* axis pointing upwards (Cartesian co-ordinates). Many windows provide
-/// coordinates with the origin in the top left with *y* pointing down, so you might need to
-/// translate these co-ordinates when implementing this method. Also be sure to invert the *y* axis
-/// of MouseScroll events.
-pub type Raw = piston_input::Event<piston_input::Input>;
-
-/// Unfortunately we're unable to access variants of the `Event` enum via the `RawEvent` type
-/// alias above, thus we must also re-export `Event` itself so that a user may use it if they
-/// require accessing its variants.
-pub use piston_input::Event as RawEvent;
+/// **Note:** `Input` events that contain co-ordinates must be oriented with (0, 0) at the middle
+/// of the window with the *y* axis pointing upwards (Cartesian co-ordinates). All co-ordinates and
+/// dimensions must be given as `Scalar` (DPI agnostic) values. Many windows provide coordinates
+/// with the origin in the top left with *y* pointing down, so you might need to translate these
+/// co-ordinates when converting to this event. Also be sure to invert the *y* axis of MouseScroll
+/// events.
+pub use piston_input::Input;
 #[doc(inline)]
-pub use piston_input::{Input, Motion};
+pub use piston_input::Motion;
 
 
 /// Enum containing all the events that the `Ui` may provide.
@@ -304,17 +295,6 @@ pub struct Scroll {
     pub y: f64,
     /// Which modifier keys, if any, that were being held down while the scroll occured
     pub modifiers: input::keyboard::ModifierKey,
-}
-
-/// Constructor for a new `RawEvent::Render`.
-pub fn render(dt_secs: f64, w_px: u32, h_px: u32, dpi: Scalar) -> RawEvent {
-    RawEvent::Render(input::RenderArgs {
-        ext_dt: dt_secs,
-        width: (w_px as Scalar / dpi) as u32,
-        height: (h_px as Scalar / dpi) as u32,
-        draw_width: w_px,
-        draw_height: h_px,
-    })
 }
 
 impl Move {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,22 +1,19 @@
 //! This module contains all the logic for handling input events and providing them to widgets.
 //!
-//! All user input is provided to the `Ui` in the form of `input::Input` events, which are continuously
-//! polled from the backend window implementation. These raw input events tend to be fairly low level.
-//! The `Ui` passes each of these events off to it's `GlobalInput`, which keeps track of the state of
-//! affairs for the entire `Ui`. `GlobalInput` will also aggregate the low level events into higher
+//! All user input is provided to the `Ui` in the form of `input::Input` events, which are received
+//! via the `Ui::handle_event` method. These raw input events tend to be fairly low level. The `Ui`
+//! stores each of these `Input` events in it's `GlobalInput`, which keeps track of the state of
+//! input for the entire `Ui`. `GlobalInput` will also aggregate the low level events into higher
 //! level ones. For instance, two events indicating that a mouse button was pressed then released
 //! would cause a new `UiEvent::MouseClick` to be generated. This saves individual widgets from
 //! having to interpret these themselves, thus freeing them from also having to store input state.
 //!
 //! Whenever there's an update, all of the events that have occured since the last update will be
-//! available for widgets to process. This is where the `InputProvider` trait comes in. The
-//! `InputProvider` trait provides many methods for conveniently filtering events that a widget would
-//! like to handle. There are two things that implement this trait. The first is `GlobalInput`, and
-//! the second is `WidgetInput`. `WidgetInput` is used to provide input events to a specific widget.
-//! It filters events that don't apply to the widget, and all events provided by `WidgetIput` will
-//! have all coordinates in the widget's own local coordinate system. `GlobalInput`, on the other hand,
-//! will never filter out any events, and will always provide them with coordinates relative to the
-//! window.
+//! available for widgets to process. `WidgetInput` is used to provide input events to a specific
+//! widget. It filters events that do not apply to the widget. All events provided by `WidgetIput`
+//! will have all coordinates in the widget's own local coordinate system, where `(0, 0)` is the
+//! middle of the widget's bounding `Rect`. `GlobalInput`, on the other hand, will never filter out
+//! any events, and will always provide them with coordinates relative to the window.
 
 pub mod state;
 pub mod widget;

--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -65,7 +65,7 @@ fn to_window_coordinates(xy: Point, ui: &Ui) -> Point {
 }
 
 fn windowless_ui() -> Ui {
-    UiBuilder::new().build()
+    UiBuilder::new([800.0, 600.0]).build()
 }
 
 

--- a/src/widget/id.rs
+++ b/src/widget/id.rs
@@ -371,7 +371,7 @@ fn test() {
         }
     }
 
-    let mut ui = UiBuilder::new().build();
+    let mut ui = UiBuilder::new([800.0, 600.0]).build();
     let mut ids = Ids::new(ui.widget_id_generator());
 
     for _ in 0..10 {
@@ -402,7 +402,7 @@ fn test_invocation_variations() {
     widget_ids! { struct G { foo[], bar, } }
     widget_ids! { pub struct H { foo, bar[], } }
 
-    let mut ui = UiBuilder::new().build();
+    let mut ui = UiBuilder::new([800.0, 600.0]).build();
     let mut ui = ui.set_widgets();
     let a = A::new(ui.widget_id_generator());
     let b = B::new(ui.widget_id_generator());


### PR DESCRIPTION
From the commit message:

> Prior to this commit, conrod took `event::Raw` as the event type that
> drove forward the `Ui` and from which the `Ui` would generate
> higher-level `Event`s. It turns out we only ever really used the
> `event::Raw`'s `Input` variant, so to make our API more concise I
> thought we could remove the unnecessary indirection of `event::Raw`.
> 
> One problem this does raise is that on Mac OS, we use the `event::Raw`'s
> `Render` variant as a hack to track the window's size changes. This is
> only because glutin (winit) is unable to emit events during resizing on
> Mac OS. To get around the removal of this hack, I'm planning to submit a
> PR to glutin_window (used by the piston backend present in most of the
> examples) which will insert `Resize` events manually.
> 
> As a result of this change, we must also now pass the initial window
> dimensions to the `Ui`'s constructor.
> 
> This commit also updates the related event module docs.

Here is the PR that should fix the resize issues that appear on Mac OS when using the examples that depend on the piston feature: PistonDevelopers/glutin_window#99. Note that this is *not* related to the issue mentioned in #850 or #854.

Closes #820.