### PR TITLE
Fix window resizing bug

### DIFF
--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -6,7 +6,7 @@ extern crate find_folder;
 mod support;
 
 use conrod::backend::piston::gfx::*;
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -51,7 +51,7 @@ fn main() {
     let image_map = support::image_map(&ids, load_rust_logo(&mut window.context));
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -3,7 +3,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -41,7 +41,7 @@ fn main() {
     let ids = &mut Ids::new(ui.widget_id_generator());
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -8,7 +8,7 @@ fn main() {
 
     use conrod::{widget, Labelable, Positionable, Sizeable, Widget};
 
-    use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+    use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
     use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
     use conrod::backend::piston::window as piston_window;
 
@@ -44,7 +44,7 @@ fn main() {
     let mut count = 0;
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -222,7 +222,7 @@ mod circular_button {
 
 pub fn main() {
     use conrod::{self, widget, Colorable, Labelable, Positionable, Sizeable, Widget};
-    use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+    use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
     use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
     use conrod::backend::piston::window as piston_window;
 
@@ -272,7 +272,7 @@ pub fn main() {
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod::image::Map::new();
 
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -44,7 +44,7 @@ fn main() {
     let directory = find_folder::Search::KidsThenParents(3, 5).for_folder("conrod").unwrap();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -7,7 +7,7 @@ extern crate find_folder;
 
 use conrod::{widget, Colorable, Positionable, Sizeable, Widget, color};
 use conrod::backend::piston::gfx::*;
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -47,7 +47,7 @@ fn main() {
     let (w, h) = image_map.get(&ids.rust_logo).unwrap().get_size();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
         ui.handle_event(event.clone());
 
         window.draw_2d(&event, |c, g| {

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -12,7 +12,7 @@ extern crate find_folder;
 extern crate rand; // for making a random color.
 
 use conrod::backend::piston::gfx::*;
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -61,7 +61,7 @@ fn main() {
     events.set_ups(60);
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -3,7 +3,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -44,7 +44,7 @@ fn main() {
     let mut list = vec![true; 16];
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -69,7 +69,7 @@ fn main() {
     let mut list_selected = std::collections::HashSet::new();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -11,7 +11,7 @@
 extern crate find_folder;
 extern crate rand; // for making a random color.
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -130,7 +130,7 @@ fn main() {
     let mut app = DemoApp::new();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -37,7 +37,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -48,7 +48,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -3,7 +3,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -46,7 +46,7 @@ fn main() {
     let mut oval_range = (0.25, 0.75);
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -43,7 +43,7 @@ fn main() {
     let image_map = conrod::image::Map::new();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate conrod;
 extern crate find_folder;
 
-use conrod::backend::piston::{Window, UpdateEvent, OpenGL};
+use conrod::backend::piston::{Window, UpdateEvent, OpenGL, EventWindow};
 use conrod::backend::piston::core_events::{EventLoop, WindowEvents};
 use conrod::backend::piston::window as piston_window;
 
@@ -49,7 +49,7 @@ fn main() {
         magna est, efficitur suscipit dolor eu, consectetur consectetur urna.".to_owned();
 
     // Poll events from the window.
-    while let Some(event) = events.next(&mut window) {
+    while let Some(event) = window.next(&mut events) {
 
         // Convert the piston event to a conrod event.
         if let Some(e) = piston_window::convert_event(event.clone(), &window) {

--- a/src/backend/piston/mod.rs
+++ b/src/backend/piston/mod.rs
@@ -7,7 +7,7 @@ pub mod event;
 pub mod window;
 pub mod gfx;
 
-pub use self::window::Window;
+pub use self::window::{Window, EventWindow};
 pub use self::shader_version::OpenGL;
 pub use piston_input::UpdateEvent;
 
@@ -19,10 +19,10 @@ pub mod core_events {
     use super::window::{Window, EventWindow};
     use piston_input::Event;
 
-    impl EventWindow for WindowEvents {
-        fn next(&mut self, window: &mut Window) -> Option<Event> {
-            if let Some(e) = self.next(window) {
-                window.event(&e);
+    impl EventWindow<WindowEvents> for Window {
+        fn next(&mut self, events: &mut WindowEvents) -> Option<Event> {
+            if let Some(e) = events.next(&mut self.window) {
+                self.event(&e);
                 Some(e)
             } else { None }
         }

--- a/src/backend/piston/window.rs
+++ b/src/backend/piston/window.rs
@@ -145,7 +145,7 @@ impl<W> Window<W>
     }
 
     /// Let window handle new event.
-    pub fn event(&mut self, event: &Event) {
+    pub fn event(&mut self, event: &Event<W::Event>) {
         if let Some(_) = event.after_render_args() {
             self.context.after_render();
         }
@@ -207,11 +207,11 @@ impl GlyphCache {
     }
 }
 
-/// Used to integrate `PistonWindow` with an event loop, enables
-/// `PistonWindow` to handle some events, if necessary
-pub trait EventWindow {
+/// Used to integrate a window with an event loop, enables
+/// the window to handle some events, if necessary
+pub trait EventWindow<E>: BasicWindow {
     /// receive next event from event loop and handle it
-    fn next(&mut self, events: &mut Window) -> Option<Event>;
+    fn next(&mut self, events: &mut E) -> Option<Event>;
 }
 
 /// Converts any `GenericEvent` to a `Raw` conrod event.


### PR DESCRIPTION
This is a fix for https://github.com/PistonDevelopers/conrod/issues/854

Turns out there was some uncaught ambiguity between the `next` method on `WindowEvents` and on the `EventWindow` trait implemented by `WindowEvents`. So that the EventWindow `next` method wasn't getting called, which let's the window handle resize events.
If you're interested in what happened it's basically this: https://play.rust-lang.org/?gist=eb607b5104023ee89bb8ca9f8b6f00a1&version=stable&backtrace=0. It's a little interesting/surprising that rust doesn't complain at all in this case. I wonder if this type of thing would get caught by clippy, maybe I'll check when the build starts working on nightly again.

Anyway it could be disambiguated by replacing `events.next(&mut window)` with `EventWindow::next(&mut events, &mut window)`.
But I thought it was better to just change the API to make the ambiguity impossible, so this changes it to `window.next(&mut events)` which is actually closer to the old `piston_window` API.