### PR TITLE
Update dependencies. Publish 0.45.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.44.1"
+version = "0.45.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ rusttype = "0.2.0"
 # Note: Use the `piston` feature for `piston_window` event conversions.
 glium = { version = "0.15.0", optional = true }
 glutin = { version = "0.6.1", optional = true }
-piston2d-graphics = { version = "0.17", optional = true }
+piston2d-graphics = { version = "0.19", optional = true }
 
 gfx = { version = "0.12.0", optional = true }
 gfx_core = { version = "0.4.0", optional = true }
 gfx_device_gl = { version = "0.11.0", optional = true }
 pistoncore-window = { version = "0.23.0", optional = true }
 pistoncore-event_loop = { version = "0.26.0", optional = true }
-piston2d-gfx_graphics = { version = "0.31.1", optional = true }
+piston2d-gfx_graphics = { version = "0.33.1", optional = true }
 piston-texture = { version = "0.5.0", optional = true }
 shader_version = { version = "0.2.0", optional = true }
 pistoncore-glutin_window = { version = "0.32.0", optional = true }

--- a/examples/glutin_gfx.rs
+++ b/examples/glutin_gfx.rs
@@ -81,9 +81,9 @@ mod feature {
         }
 
         pipeline pipe {
-            vbuf: gfx::VertexBuffer<Vertex> = (),
-            color: gfx::TextureSampler<[f32; 4]> = "t_Color",
-            out: gfx::BlendTarget<ColorFormat> = ("f_Color", gfx::state::MASK_ALL, gfx::preset::blend::ALPHA),
+            vbuf: ::gfx::VertexBuffer<Vertex> = (),
+            color: ::gfx::TextureSampler<[f32; 4]> = "t_Color",
+            out: ::gfx::BlendTarget<ColorFormat> = ("f_Color", ::gfx::state::MASK_ALL, ::gfx::preset::blend::ALPHA),
         }
     }
 

--- a/src/backend/piston/draw.rs
+++ b/src/backend/piston/draw.rs
@@ -79,7 +79,7 @@ pub fn primitive<'a, Img, G, T, C, F>(
     text_texture_cache: &'a mut T,
     glyph_cache: &'a mut text::GlyphCache,
     image_map: &'a image::Map<Img>,
-    glyph_rectangles: &mut Vec<([f64; 4], [i32; 4])>,
+    glyph_rectangles: &mut Vec<([f64; 4], [f64; 4])>,
     mut cache_queued_glyphs: C,
     mut texture_from_image: F,
 )
@@ -169,10 +169,10 @@ pub fn primitive<'a, Img, G, T, C, F>(
                         [left, top, w, h]
                     };
                     let source_rectangle = {
-                        let x = (uv_rect.min.x * tex_w as f32).round() as i32;
-                        let y = (uv_rect.min.y * tex_h as f32).round() as i32;
-                        let w = ((uv_rect.max.x - uv_rect.min.x) * tex_w as f32).round() as i32;
-                        let h = ((uv_rect.max.y - uv_rect.min.y) * tex_h as f32).round() as i32;
+                        let x = (uv_rect.min.x * tex_w as f32) as f64;
+                        let y = (uv_rect.min.y * tex_h as f32) as f64;
+                        let w = ((uv_rect.max.x - uv_rect.min.x) * tex_w as f32) as f64;
+                        let h = ((uv_rect.max.y - uv_rect.min.y) * tex_h as f32) as f64;
                         [x, y, w, h]
                     };
                     (rectangle, source_rectangle)
@@ -193,7 +193,7 @@ pub fn primitive<'a, Img, G, T, C, F>(
                 image.color = color.map(|c| c.to_fsa());
                 if let Some(source_rect) = source_rect {
                     let (x, y, w, h) = source_rect.x_y_w_h();
-                    image.source_rectangle = Some([x as i32, y as i32, w as i32, h as i32]);
+                    image.source_rectangle = Some([x, y, w, h]);
                 }
                 let (left, top, w, h) = rect.l_t_w_h();
                 image.rectangle = Some([0.0, 0.0, w, h]);

--- a/src/backend/piston/gfx.rs
+++ b/src/backend/piston/gfx.rs
@@ -211,7 +211,7 @@ pub fn draw_primitive<'a, 'b, Img, F>(context: draw::Context,
                                       primitive: render::Primitive,
                                       glyph_cache: &'a mut GlyphCache,
                                       image_map: &'a image::Map<Img>,
-                                      glyph_rectangles: &mut Vec<([f64; 4], [i32; 4])>,
+                                      glyph_rectangles: &mut Vec<([f64; 4], [f64; 4])>,
                                       texture_from_image: F)
     where F: FnMut(&Img) -> &G2dTexture<'static>,
 {


### PR DESCRIPTION
Bump the minor version in order to publish several breaking changes:

- #850 removing the old piston_window feature in favour of a conrod-specific piston window
- #852 completes the glium backend and fixes the glutin event conversions
- #855 removes the unnecessary `event::Raw` type in favour of the more minimal `event::Input` type
- #849 added some slight features to `TextEdit` widget