### PR TITLE
Add builder method for specifying `font_id` to all widgets that display text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.45.0"
+version = "0.46.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -47,6 +47,8 @@ mod circular_button {
             - label_color: conrod::Color { theme.label_color }
             /// Font size of the button's label.
             - label_font_size: conrod::FontSize { theme.font_size_medium }
+            /// Specify a unique font for the label.
+            - label_font_id: Option<conrod::text::font::Id> { theme.font_id }
         }
     }
 
@@ -80,14 +82,21 @@ mod circular_button {
     }
 
     impl<'a> CircularButton<'a> {
+
         /// Create a button context to be built upon.
-        pub fn new() -> CircularButton<'a> {
+        pub fn new() -> Self {
             CircularButton {
                 common: widget::CommonBuilder::new(),
                 maybe_label: None,
                 style: Style::new(),
                 enabled: true,
             }
+        }
+
+        /// Specify the font used for displaying the label.
+        pub fn label_font_id(mut self, font_id: conrod::text::font::Id) -> Self {
+            self.style.label_font_id = Some(Some(font_id));
+            self
         }
 
         /// If true, will allow user inputs.  If false, will disallow user inputs.  Like
@@ -98,6 +107,7 @@ mod circular_button {
             self.enabled = flag;
             self
         }
+
     }
 
     /// A custom Conrod widget must implement the Widget trait. See the **Widget** trait
@@ -181,7 +191,9 @@ mod circular_button {
             if let Some(ref label) = self.maybe_label {
                 let label_color = style.label_color(&ui.theme);
                 let font_size = style.label_font_size(&ui.theme);
+                let font_id = style.label_font_id(&ui.theme).or(ui.fonts.ids().next());
                 widget::Text::new(label)
+                    .and_then(font_id, widget::Text::font_id)
                     .middle_of(id)
                     .font_size(font_size)
                     .graphics_for(id)
@@ -263,7 +275,7 @@ pub fn main() {
     // Add a `Font` to the `Ui`'s `font::Map` from file.
     let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();
     let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
-    ui.fonts.insert_from_file(font_path).unwrap();
+    let regular = ui.fonts.insert_from_file(font_path).unwrap();
 
     // Create a texture to use for efficiently caching text on the GPU.
     let mut text_texture_cache = piston::window::GlyphCache::new(&mut window, WIDTH, HEIGHT);
@@ -289,6 +301,7 @@ pub fn main() {
                 .color(conrod::color::rgb(0.0, 0.3, 0.1))
                 .middle_of(ids.background)
                 .w_h(256.0, 256.0)
+                .label_font_id(regular)
                 .label_color(conrod::color::WHITE)
                 .label("Circular Button")
                 // Add the widget to the conrod::Ui. This schedules the widget it to be

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -4,6 +4,7 @@ extern crate find_folder;
 use conrod::backend::piston::{self, Window, WindowEvents, OpenGL};
 use conrod::backend::piston::event::UpdateEvent;
 
+
 fn main() {
     const WIDTH: u32 = 1080;
     const HEIGHT: u32 = 720;
@@ -27,8 +28,19 @@ fn main() {
 
     // Add a `Font` to the `Ui`'s `font::Map` from file.
     let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();
-    let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
-    ui.fonts.insert_from_file(font_path).unwrap();
+    let noto_sans = assets.join("fonts/NotoSans");
+    let regular = ui.fonts.insert_from_file(noto_sans.join("NotoSans-Regular.ttf")).unwrap();
+    let italic = ui.fonts.insert_from_file(noto_sans.join("NotoSans-Italic.ttf")).unwrap();
+    let bold = ui.fonts.insert_from_file(noto_sans.join("NotoSans-Bold.ttf")).unwrap();
+
+    // Store our `font::Id`s in a list for easy access in the `set_ui` function.
+    let font_ids = [regular, italic, bold];
+
+    // Specify the default font to use when none is specified by the widget.
+    //
+    // By default, the theme's font_id field is `None`. In this case, the first font that is found
+    // within the `Ui`'s `font::Map` will be used.
+    ui.theme.font_id = Some(regular);
 
     // Create a texture cache in which we can cache text on the GPU.
     //
@@ -48,7 +60,7 @@ fn main() {
             ui.handle_event(e);
         }
 
-        event.update(|_| set_ui(ui.set_widgets(), &ids));
+        event.update(|_| set_ui(ui.set_widgets(), &ids, &font_ids));
 
         window.draw_2d(&event, |c, g| {
             // Only re-draw if there was some change in the `Ui`.
@@ -77,7 +89,7 @@ widget_ids!{
     }
 }
 
-fn set_ui(ref mut ui: conrod::UiCell, ids: &Ids) {
+fn set_ui(ref mut ui: conrod::UiCell, ids: &Ids, font_ids: &[conrod::text::font::Id; 3]) {
     use conrod::{color, widget, Colorable, Positionable, Scalar, Sizeable, Widget};
 
     // Our `Canvas` tree, upon which we will place our text widgets.
@@ -97,7 +109,12 @@ fn set_ui(ref mut ui: conrod::UiCell, ids: &Ids) {
 
     const PAD: Scalar = 20.0;
 
+    const FONT_REGULAR: usize = 0;
+    const FONT_ITALIC: usize = 1;
+    const FONT_BOLD: usize = 2;
+
     widget::Text::new(DEMO_TEXT)
+        .font_id(font_ids[FONT_REGULAR])
         .color(color::LIGHT_RED)
         .padded_w_of(ids.left_col, PAD)
         .mid_top_with_margin_on(ids.left_col, PAD)
@@ -106,6 +123,7 @@ fn set_ui(ref mut ui: conrod::UiCell, ids: &Ids) {
         .set(ids.left_text, ui);
 
     widget::Text::new(DEMO_TEXT)
+        .font_id(font_ids[FONT_ITALIC])
         .color(color::LIGHT_GREEN)
         .padded_w_of(ids.middle_col, PAD)
         .middle_of(ids.middle_col)
@@ -114,6 +132,7 @@ fn set_ui(ref mut ui: conrod::UiCell, ids: &Ids) {
         .set(ids.middle_text, ui);
 
     widget::Text::new(DEMO_TEXT)
+        .font_id(font_ids[FONT_BOLD])
         .color(color::LIGHT_BLUE)
         .padded_w_of(ids.right_col, PAD)
         .mid_bottom_with_margin_on(ids.right_col, PAD)

--- a/src/label.rs
+++ b/src/label.rs
@@ -53,4 +53,3 @@ pub trait Labelable<'a>: Sized {
     }
 
 }
-

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -13,6 +13,7 @@ use {
     UiCell,
     Widget,
 };
+use text;
 use widget;
 
 
@@ -44,6 +45,8 @@ widget_style!{
         - label_font_size: FontSize { theme.font_size_medium }
         /// The label's alignment over the *x* axis.
         - label_x_align: Align { Align::Middle }
+        /// The ID of the font used to display the label.
+        - label_font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -201,6 +204,12 @@ impl<'a, S> Button<'a, S> {
         }
     }
 
+    /// Specify the font used for displaying the label.
+    pub fn label_font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.label_font_id = Some(Some(font_id));
+        self
+    }
+
     builder_methods!{
         pub enabled { enabled = bool }
     }
@@ -268,7 +277,9 @@ impl<'a, S> Widget for Button<'a, S>
             let color = style.label_color(&ui.theme);
             let font_size = style.label_font_size(&ui.theme);
             let align = style.label_x_align(&ui.theme);
+            let font_id = style.label_font_id(&ui.theme).or(ui.fonts.ids().next());
             widget::Text::new(label)
+                .and_then(font_id, widget::Text::font_id)
                 .and(|b| match align {
                     Align::Start =>
                         b.mid_left_with_margin_on(state.ids.rectangle, font_size as Scalar),

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -11,6 +11,7 @@ use {
     Scalar,
     Sizeable,
 };
+use text;
 use utils;
 use widget::{self, Widget};
 
@@ -53,6 +54,8 @@ widget_style! {
         - scrollbar_position: Option<widget::list::ScrollbarPosition> { None }
         /// The width of the scrollbar in the case that the list is scrollable.
         - scrollbar_width: Option<Scalar> { None }
+        /// The ID of the font used to display the labels.
+        - label_font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -142,6 +145,13 @@ impl<'a, T> DropDownList<'a, T> {
         self.style.scrollbar_width = Some(Some(w));
         self
     }
+
+    /// Specify the font used for displaying the label.
+    pub fn label_font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.label_font_id = Some(Some(font_id));
+        self
+    }
+
 
 }
 
@@ -318,6 +328,7 @@ impl Style {
             label_color: self.label_color,
             label_font_size: self.label_font_size,
             label_x_align: self.label_x_align,
+            label_font_id: self.label_font_id,
         }
     }
 

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -142,6 +142,12 @@ impl<'a, T> NumberDialer<'a, T>
         }
     }
 
+    /// Specify the font used for displaying the label.
+    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.font_id = Some(Some(font_id));
+        self
+    }
+
     builder_methods!{
         pub enabled { enabled = bool }
     }
@@ -186,10 +192,7 @@ impl<'a, T> Widget for NumberDialer<'a, T>
         // Retrieve the `font_id`, as long as a valid `Font` for it still exists.
         //
         // If we've no font to use for text logic, bail out without updating.
-        let font_id = match style.font_id(&ui.theme)
-            .or(ui.fonts.ids().next())
-            .and_then(|id| ui.fonts.get(id).map(|_| id))
-        {
+        let font_id = match style.font_id(&ui.theme).or(ui.fonts.ids().next()) {
             Some(font_id) => font_id,
             None => return None,
         };
@@ -329,6 +332,7 @@ impl<'a, T> Widget for NumberDialer<'a, T>
         let font_size = style.label_font_size(ui.theme());
         if maybe_label.is_some() {
             widget::Text::new(&label_string)
+                .font_id(font_id)
                 .x_y_relative_to(id, label_rel_x, 0.0)
                 .graphics_for(id)
                 .color(label_color)
@@ -377,6 +381,7 @@ impl<'a, T> Widget for NumberDialer<'a, T>
 
             // Now a **Text** widget for the character itself.
             widget::Text::new(glyph_string)
+                .font_id(font_id)
                 .x_y_relative_to(id, rel_slot_x, 0.0)
                 .graphics_for(id)
                 .color(label_color)

--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -46,8 +46,6 @@ widget_style!{
         - text_align: Align { Align::Start }
         /// The id of the font to use for rendring and layout.
         - font_id: Option<text::font::Id> { theme.font_id }
-        // /// The typeface with which the Text is rendered.
-        // - typeface: Path,
         // /// The line styling for the text.
         // - line: Option<Line> { None },
     }
@@ -108,6 +106,12 @@ impl<'a> Text<'a> {
     /// Line wrap the **Text** at the beginning of the first character that exceeds the width.
     pub fn wrap_by_character(mut self) -> Self {
         self.style.maybe_wrap = Some(Some(Wrap::Character));
+        self
+    }
+
+    /// A method for specifying the `Font` used for displaying the `Text`.
+    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.font_id =  Some(Some(font_id));
         self
     }
 
@@ -233,7 +237,7 @@ impl<'a> Widget for Text<'a> {
         let maybe_wrap = style.maybe_wrap(ui.theme());
         let font_size = style.font_size(ui.theme());
 
-        let font = match self.style.font_id(&ui.theme)
+        let font = match style.font_id(&ui.theme)
             .or(ui.fonts.ids().next())
             .and_then(|id| ui.fonts.get(id))
         {

--- a/src/widget/range_slider.rs
+++ b/src/widget/range_slider.rs
@@ -14,6 +14,7 @@ use {
     Widget,
 };
 use num::{Float, NumCast, ToPrimitive};
+use text;
 use utils;
 use widget;
 
@@ -41,6 +42,8 @@ widget_style!{
         - label_color: Color { theme.label_color }
         /// The font-size for the Slider's label.
         - label_font_size: FontSize { theme.font_size_medium }
+        /// The ID of the font used to display the label.
+        - label_font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -113,6 +116,12 @@ impl<'a, T> RangeSlider<'a, T> {
             maybe_label: None,
             style: Style::new(),
         }
+    }
+
+    /// Specify the font used for displaying the label.
+    pub fn label_font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.label_font_id = Some(Some(font_id));
+        self
     }
 
 }
@@ -309,8 +318,10 @@ impl<'a, T> Widget for RangeSlider<'a, T>
         if let Some(label) = maybe_label {
             let label_color = style.label_color(ui.theme());
             let font_size = style.label_font_size(ui.theme());
+            let font_id = style.label_font_id(&ui.theme).or(ui.fonts.ids().next());
             //const TEXT_PADDING: f64 = 10.0;
             widget::Text::new(label)
+                .and_then(font_id, widget::Text::font_id)
                 .mid_left_of(id)
                 .graphics_for(id)
                 .color(label_color)

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -14,6 +14,7 @@ use {
     Widget,
 };
 use num::{Float, NumCast, ToPrimitive};
+use text;
 use widget;
 
 
@@ -56,6 +57,8 @@ widget_style! {
         - label_color: Color { theme.label_color }
         /// The font-size for the Slider's label.
         - label_font_size: FontSize { theme.font_size_medium }
+        /// The ID of the font used to display the label.
+        - label_font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -86,6 +89,12 @@ impl<'a, T> Slider<'a, T> {
             style: Style::new(),
             enabled: true,
         }
+    }
+
+    /// Specify the font used for displaying the label.
+    pub fn label_font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.label_font_id = Some(Some(font_id));
+        self
     }
 
     builder_methods!{
@@ -213,8 +222,10 @@ impl<'a, T> Widget for Slider<'a, T>
         if let Some(label) = maybe_label {
             let label_color = style.label_color(ui.theme());
             let font_size = style.label_font_size(ui.theme());
+            let font_id = style.label_font_id(&ui.theme).or(ui.fonts.ids().next());
             //const TEXT_PADDING: f64 = 10.0;
             widget::Text::new(label)
+                .and_then(font_id, widget::Text::font_id)
                 .and(|text| if is_horizontal { text.mid_left_of(id) }
                             else { text.mid_bottom_of(id) })
                 .graphics_for(id)

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -15,6 +15,7 @@ use {
 };
 use event;
 use input;
+use text;
 use widget;
 
 /// A widget for displaying and mutating a small, one-line field of text, given by the user in the
@@ -47,6 +48,8 @@ widget_style!{
         - font_size: FontSize { theme.font_size_medium }
         /// The horizontal alignment of the text.
         - x_align: Align { Align::Start }
+        /// The font used for the `Text`.
+        - font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -86,6 +89,12 @@ impl<'a> TextBox<'a> {
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
     pub fn align_text_right(self) -> Self {
         self.x_align_text(Align::End)
+    }
+
+    /// Specify the font used for displaying the text.
+    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.font_id = Some(Some(font_id));
+        self
     }
 
     builder_methods!{
@@ -161,7 +170,9 @@ impl<'a> Widget for TextBox<'a> {
         let mut events = Vec::new();
 
         let text_color = style.text_color(ui.theme());
+        let font_id = style.font_id(&ui.theme).or(ui.fonts.ids().next());
         if let Some(new_string) = widget::TextEdit::new(text)
+            .and_then(font_id, widget::TextEdit::font_id)
             .wh(text_rect.dim())
             .xy(text_rect.xy())
             .font_size(font_size)

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -162,6 +162,12 @@ impl<'a> TextEdit<'a> {
         self.align_text_x_middle().align_text_y_middle()
     }
 
+    /// Specify the font used for displaying the text.
+    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.font_id = Some(Some(font_id));
+        self
+    }
+
     builder_methods!{
         pub font_size { style.font_size = Some(FontSize) }
         pub x_align_text { style.x_align = Some(Align) }
@@ -715,6 +721,7 @@ impl<'a> Widget for TextEdit<'a> {
             Wrap::Whitespace => widget::Text::new(&text).wrap_by_word(),
             Wrap::Character => widget::Text::new(&text).wrap_by_character(),
         }
+            .font_id(font_id)
             .wh(text_rect.dim())
             .xy(text_rect.xy())
             .align_text_to(x_align)

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -13,6 +13,7 @@ use {
     Sizeable,
     Ui,
 };
+use text;
 use widget::{self, Widget};
 
 
@@ -58,6 +59,8 @@ widget_style!{
         - line_spacing: Scalar { 1.0 }
         /// The horizontal alignment of the title bar text.
         - text_align: Align { Align::Middle }
+        /// The font used for the `Text`.
+        - font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -93,6 +96,12 @@ impl<'a> TitleBar<'a> {
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
     pub fn align_text_right(mut self) -> Self {
         self.style.text_align = Some(Align::End);
+        self
+    }
+
+    /// Specify the font used for displaying the text.
+    pub fn font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.font_id = Some(Some(font_id));
         self
     }
 
@@ -161,11 +170,13 @@ impl<'a> Widget for TitleBar<'a> {
         let font_size = style.font_size(ui.theme());
         let line_spacing = style.line_spacing(ui.theme());
         let maybe_wrap = style.maybe_wrap(ui.theme());
+        let font_id = style.font_id(&ui.theme).or(ui.fonts.ids().next());
         widget::Text::new(label)
             .and_mut(|text| {
                 text.style.maybe_wrap = Some(maybe_wrap);
                 text.style.text_align = Some(text_align);
             })
+            .and_then(font_id, widget::Text::font_id)
             .padded_w_of(state.ids.rectangle, border)
             .middle_of(state.ids.rectangle)
             .color(text_color)

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -10,6 +10,7 @@ use {
     Scalar,
     Widget,
 };
+use text;
 use widget;
 
 
@@ -43,6 +44,8 @@ widget_style! {
         - label_color: Color { theme.label_color }
         /// The font size for the Toggle's Text label.
         - label_font_size: FontSize { theme.font_size_medium }
+        /// The ID of the font used to display the label.
+        - label_font_id: Option<text::font::Id> { theme.font_id }
     }
 }
 
@@ -95,6 +98,12 @@ impl<'a> Toggle<'a> {
             style: Style::new(),
             enabled: true,
         }
+    }
+
+    /// Specify the font used for displaying the label.
+    pub fn label_font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.label_font_id = Some(Some(font_id));
+        self
     }
 
     builder_methods!{
@@ -163,7 +172,9 @@ impl<'a> Widget for Toggle<'a> {
         if let Some(label) = maybe_label {
             let color = style.label_color(ui.theme());
             let font_size = style.label_font_size(ui.theme());
+            let font_id = style.label_font_id(&ui.theme).or(ui.fonts.ids().next());
             widget::Text::new(label)
+                .and_then(font_id, widget::Text::font_id)
                 .middle_of(state.ids.rectangle)
                 .graphics_for(id)
                 .color(color)

--- a/src/widget/xy_pad.rs
+++ b/src/widget/xy_pad.rs
@@ -11,8 +11,9 @@ use {
     Widget,
 };
 use num::Float;
-use widget;
+use text;
 use utils::{map_range, val_to_string};
+use widget;
 
 
 /// Used for displaying and controlling a 2D point on a cartesian plane within a given range.
@@ -42,6 +43,8 @@ widget_style!{
         - label_color: Color { theme.label_color }
         /// The font size for the XYPad's label.
         - label_font_size: FontSize { theme.font_size_medium }
+        /// The ID of the font used to display the label.
+        - label_font_id: Option<text::font::Id> { theme.font_id }
         /// The font size for the XYPad's *value* label.
         - value_font_size: FontSize { 14 }
         /// The thickness of the XYPad's crosshair lines.
@@ -77,6 +80,12 @@ impl<'a, X, Y> XYPad<'a, X, Y> {
             style: Style::new(),
             enabled: true,
         }
+    }
+
+    /// Specify the font used for displaying the label.
+    pub fn label_font_id(mut self, font_id: text::font::Id) -> Self {
+        self.style.label_font_id = Some(Some(font_id));
+        self
     }
 
     builder_methods!{
@@ -172,9 +181,11 @@ impl<'a, X, Y> Widget for XYPad<'a, X, Y>
 
         // Label **Text** widget.
         let label_color = style.label_color(ui.theme());
+        let font_id = style.label_font_id(&ui.theme).or(ui.fonts.ids().next());
         if let Some(label) = maybe_label {
             let label_font_size = style.label_font_size(ui.theme());
             widget::Text::new(label)
+                .and_then(font_id, widget::Text::font_id)
                 .middle_of(state.ids.rectangle)
                 .graphics_for(id)
                 .color(label_color)
@@ -227,6 +238,7 @@ impl<'a, X, Y> Widget for XYPad<'a, X, Y>
         };
         let value_font_size = style.value_font_size(ui.theme());
         widget::Text::new(&value_string)
+            .and_then(font_id, widget::Text::font_id)
             .x_direction_from(state.ids.v_line, x_direction, VALUE_TEXT_PAD)
             .y_direction_from(state.ids.h_line, y_direction, VALUE_TEXT_PAD)
             .color(line_color)


### PR DESCRIPTION
Also updates the `text.rs` example to demonstrate the use of multiple fonts and how to specify a font using the `font_id` builder method.

Closes #861.

cc @tl8roy