### PR TITLE
Waiting event loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "./src/lib.rs"
 [dependencies]
 daggy = "0.4.0"
 num = "0.1.30"
-pistoncore-input = "0.14.0"
+pistoncore-input = "0.15.0"
 rusttype = "0.2.0"
 
 # Optional dependencies and features
@@ -55,16 +55,15 @@ piston2d-graphics = { version = "0.19", optional = true }
 gfx = { version = "0.12.0", optional = true }
 gfx_core = { version = "0.4.0", optional = true }
 gfx_device_gl = { version = "0.11.0", optional = true }
-pistoncore-window = { version = "0.23.0", optional = true }
-pistoncore-event_loop = { version = "0.26.0", optional = true }
+pistoncore-window = { version = "0.24.0", optional = true }
 piston2d-gfx_graphics = { version = "0.33.1", optional = true }
 piston-texture = { version = "0.5.0", optional = true }
 shader_version = { version = "0.2.0", optional = true }
-pistoncore-glutin_window = { version = "0.32.0", optional = true }
+pistoncore-glutin_window = { version = "0.33.0", optional = true }
 
 [features]
 default = ["piston"]
-piston = ["piston2d-graphics", "pistoncore-window", "pistoncore-event_loop", "gfx",
+piston = ["piston2d-graphics", "pistoncore-window", "gfx",
           "gfx_core", "gfx_device_gl", "piston2d-gfx_graphics", "shader_version",
           "pistoncore-glutin_window", "piston-texture"]
 

--- a/examples/all_widgets.rs
+++ b/examples/all_widgets.rs
@@ -56,6 +56,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -44,6 +44,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -46,6 +46,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         // `Update` the widgets.

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -288,6 +288,7 @@ pub fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -47,6 +47,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -51,6 +51,7 @@ fn main() {
         // Convert the piston event to a conrod input event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         window.draw_2d(&event, |c, g| {

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -64,6 +64,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -47,6 +47,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -72,6 +72,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -133,6 +133,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         // We'll set all our widgets in a single function called `set_widgets`.

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -42,6 +42,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -53,6 +53,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         // Update the widgets.

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -49,6 +49,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -58,6 +58,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| set_ui(ui.set_widgets(), &ids, &font_ids));

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -52,6 +52,7 @@ fn main() {
         // Convert the piston event to a conrod event.
         if let Some(e) = piston::window::convert_event(event.clone(), &window) {
             ui.handle_event(e);
+            events.update();
         }
 
         event.update(|_| set_ui(ui.set_widgets(), &ids, &mut demo_text));

--- a/src/backend/piston/events.rs
+++ b/src/backend/piston/events.rs
@@ -148,9 +148,8 @@ impl WindowEvents
                 }
             },
             State::Rendered => {
-                // Just rendered, swap buffers, send `AfterRender`, initialize for next frame
+                // Just rendered, send `AfterRender`, initialize for next frame
                 // and resume `Waiting`
-                window.swap_buffers();
                 self.last_frame_time = Instant::now();
                 self.next_frame_time = self.last_frame_time + self.dt_frame;
                 self.state = State::Waiting;

--- a/src/backend/piston/events.rs
+++ b/src/backend/piston/events.rs
@@ -1,0 +1,163 @@
+//! A event loop for a typical UI application, which blocks and waits for user input when idle.
+//! Unlike `pistoncore_event_loop` it saves CPU cycles by not polling the window for new events
+//! continuously.
+//!
+//! To schedule the event loop to send a new `Update` event in time for the next frame, call `update`
+//! in between calls to `next`, otherwise the event loop will go idle until the next input event.
+//!
+//! `update` can be used to emulate the behaviour of the piston event loop if called every frame, or it 
+//! can be called only when an animation is currently running, to post updates in the absence of 
+//! user input.
+
+
+#![deny(missing_docs)]
+#![deny(missing_copy_implementations)]
+
+extern crate window as pistoncore_window;
+
+use std::time::{Duration, Instant};
+
+use self::pistoncore_window::Window as BasicWindow;
+use piston_input::{Event, UpdateArgs, RenderArgs, AfterRenderArgs, IdleArgs};
+
+use super::window::Window;
+
+enum State {
+    Rendered,
+    Updated,
+    Waiting,
+}
+
+/// An event loop iterator
+///
+/// *Warning: Because the iterator polls events from the window back-end,
+/// it must be used on the same thread as the window back-end (usually main thread),
+/// unless the window back-end supports multi-thread event polling.*
+//#[derive(Copy, Clone)]
+pub struct WindowEvents {
+    state: State,
+    /// if true, an update should be triggered in time for the next frame,
+    /// either because an input event happened, or the UI is animating
+    idle: bool,
+    /// set externally to prevent the event loop from setting `idle` to
+    /// true after the current frame, in case the UI needs to update or animate
+    updating: bool,
+    last_frame_time: Instant,
+    next_frame_time: Instant,
+    dt_frame: Duration,
+}
+
+static BILLION: u64 = 1_000_000_000;
+trait UpdateDuration {
+    fn from_freq(hz: u64) -> Duration;
+    fn as_secs_f64(self) -> f64;
+}
+impl UpdateDuration for Duration {
+    fn from_freq(hz: u64) -> Duration {
+        let secs = (1.0 / hz as f64).floor() as u64;
+        let nanos = ((BILLION / hz) % BILLION) as u32;
+        Duration::new(secs, nanos)
+    }
+    fn as_secs_f64(self) -> f64 {
+        self.as_secs() as f64 + self.subsec_nanos() as f64 / BILLION as f64
+    }
+}
+
+/// The default maximum frames per second.
+pub const DEFAULT_MAX_FPS: u64 = 60;
+
+fn render_args(window: &Window, duration: f64) -> RenderArgs {
+    RenderArgs {
+        ext_dt: duration,
+        width: window.size().width,
+        height: window.size().height,
+        draw_width: window.draw_size().width,
+        draw_height: window.draw_size().height,
+    }
+}
+
+impl WindowEvents
+{
+    /// Creates a new event iterator
+    pub fn new_with_fps(max_fps: u64) -> WindowEvents {
+        let start = Instant::now();
+        let frame_length = Duration::from_freq(max_fps);
+        WindowEvents {
+            state: State::Waiting,
+            idle: false,
+            updating: false,
+            last_frame_time: start,
+            next_frame_time: start,
+            dt_frame: frame_length,
+        }
+    }
+    /// Creates a new event iterator with default FPS settings.
+    pub fn new() -> WindowEvents {
+        WindowEvents::new_with_fps(DEFAULT_MAX_FPS)
+    }
+
+    /// Use to trigger an update event by preventing the event loop from going idle.
+    /// Call once per update loop for continuous animation, or call once to refresh the UI.
+    pub fn update(&mut self) {
+        self.updating = true;
+    }
+
+    /// Returns the next event.
+    ///
+    /// While in the `Waiting` state, returns `Input` events up until `dt_frame` has passed, or if idle, waits indefinitely.
+    /// Once `dt_frame` has elapsed, or no longer idle, returns in order, `Update`, `Render` and `AfterRender` then resumes `Waiting` state.
+    pub fn next(&mut self, window: &mut Window) -> Option<Event>
+    {
+        if window.should_close() { return None; }
+
+        match self.state {
+            State::Waiting => {
+                if self.idle {
+                    // Block and wait until an event is received.
+                    let event = window.wait_event();
+                    self.idle = false;
+                    Some(Event::Input(event))
+                } else {
+                    let current_time = Instant::now();
+                    if current_time < self.next_frame_time {
+                        // Wait for events until ready for next frame.
+                        let event = window.wait_event_timeout(self.next_frame_time - current_time);
+                        if let Some(e) = event {
+                            return Some(Event::Input(e));
+                        }
+                    }
+                    // Handle any pending input before updating.
+                    if let Some(e) = window.poll_event() {
+                        return Some(Event::Input(e));
+                    }
+                    self.state = State::Updated;
+                    let duration = (current_time - self.last_frame_time).as_secs_f64();
+                    Some(Event::Update(UpdateArgs{ dt: duration }))
+                }
+            },
+            State::Updated => {
+                // Update event just posted, send `Render` event (if window can be drawn to).
+                let size = window.size();
+                let duration = (Instant::now() - self.last_frame_time).as_secs_f64();
+                if size.width != 0 && size.height != 0 {
+                    self.state = State::Rendered;
+                    Some(Event::Render(render_args(window, duration)))
+                } else {
+                    self.state = State::Waiting;
+                    Some(Event::Idle(IdleArgs{ dt: duration }))
+                }
+            },
+            State::Rendered => {
+                // Just rendered, swap buffers, send `AfterRender`, initialize for next frame
+                // and resume `Waiting`
+                window.swap_buffers();
+                self.last_frame_time = Instant::now();
+                self.next_frame_time = self.last_frame_time + self.dt_frame;
+                self.state = State::Waiting;
+                self.idle = !self.updating;
+                self.updating = false;
+                Some(Event::AfterRender(AfterRenderArgs))
+            },
+        }
+    }
+}

--- a/src/backend/piston/mod.rs
+++ b/src/backend/piston/mod.rs
@@ -6,6 +6,7 @@ pub mod draw;
 pub mod event;
 pub mod window;
 pub mod gfx;
+pub mod events;
 
 pub use self::window::{EventWindow, Window, WindowEvents};
 pub use self::shader_version::OpenGL;

--- a/src/backend/piston/window.rs
+++ b/src/backend/piston/window.rs
@@ -70,7 +70,6 @@
 //! For more information about sRGB, see
 //! https://github.com/PistonDevelopers/piston/issues/1014
 
-extern crate event_loop;
 extern crate window as pistoncore_window;
 extern crate glutin_window;
 
@@ -82,7 +81,7 @@ use std::time::Duration;
 use super::gfx::{GfxContext, G2d};
 use super::shader_version::OpenGL;
 
-pub use self::event_loop::WindowEvents;
+pub use super::events::WindowEvents;
 pub use self::pistoncore_window::{AdvancedWindow, Position, Size, OpenGLWindow, 
                                   WindowSettings, BuildFromWindowSettings};
 pub use super::gfx::{draw, GlyphCache};
@@ -220,7 +219,7 @@ pub trait EventWindow<E>: BasicWindow {
 
 impl EventWindow<WindowEvents> for Window {
     fn next(&mut self, events: &mut WindowEvents) -> Option<Event> {
-        events.next(&mut self.window).map(|e| {
+        events.next(self).map(|e| {
             self.handle_event(&e);
             e
         })

--- a/src/backend/piston/window.rs
+++ b/src/backend/piston/window.rs
@@ -150,6 +150,7 @@ impl<W> Window<W>
     /// Let window handle new event.
     pub fn handle_event(&mut self, event: &Event<W::Event>) {
         if let Some(_) = event.after_render_args() {
+            self.swap_buffers();
             self.context.after_render();
         }
         self.context.check_resize(self.window.draw_size());


### PR DESCRIPTION
This is a cleaned up version of https://github.com/PistonDevelopers/conrod/pull/831 now that it is easier to integrate with the new window.

From commits:
>Add alternative event loop based on waiting for events rather than continuous polling, so that it uses zero CPU while idle.
New event loop is built on top of new `wait_event` and `wait_event_timeout` methods added to `piston::window::Window`.
Event loop has `update` method to trigger animation at a fixed rate, or to refresh the view. Calling `update` each frame recreates the behaviour of the default piston event loop.

>In examples, prevent event loop from going idle for at least one frame after an input event.
This is necessary in the case when a widget does not update atomically in a single frame.
This enables the event loop to go idle when there is no input, while not making app implementation
more complicated.
Hopefully this is temporary until widgets either handle updates atomically, notify the event loop
that they require an update, or widgets are initialized after the events that determine the widget state,
(ie. if a button label is changed when the button is pressed, the button label is created after
the button, and set based on whether the button was pressed.)

I originally intended to leave `pistoncore-event_loop` optionally supported by the `core_events` module. But with this change to the examples, (made easier by the recent change from `Raw` events to `Input` events) all apps should be able to use this event loop without any major changes.

It's still not 100% efficient, because it runs occasional redundant updates, however it's a major improvement over constantly running them 60+ times per second!

Also this event loop prevents the input/render event starvation issue here https://github.com/PistonDevelopers/conrod/issues/870 and resolves this issue https://github.com/PistonDevelopers/conrod/issues/824

There's one outstanding problem, the close window button doesn't work because of this: https://github.com/PistonDevelopers/glutin_window/issues/100.
Considering that, it might make sense to wait to merge until that issue is resolved.