### PR TITLE
Fix `TextEdit` height inference when unrestricted. Auto-scroll text when cursor would exceed scrollable area due to input.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.46.1"
+version = "0.46.2"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -5,7 +5,7 @@ use conrod::backend::piston::{self, Window, WindowEvents, OpenGL};
 use conrod::backend::piston::event::UpdateEvent;
 
 widget_ids! { 
-    struct Ids { canvas, text_edit }
+    struct Ids { canvas, text_edit, scrollbar }
 }
 
 fn main() {
@@ -73,16 +73,22 @@ fn main() {
 fn set_ui(ref mut ui: conrod::UiCell, ids: &Ids, demo_text: &mut String) {
     use conrod::{color, widget, Colorable, Positionable, Sizeable, Widget};
 
-    widget::Canvas::new().color(color::DARK_CHARCOAL).set(ids.canvas, ui);
+    widget::Canvas::new()
+        .scroll_kids_vertically()
+        .color(color::DARK_CHARCOAL)
+        .set(ids.canvas, ui);
 
     for edit in widget::TextEdit::new(demo_text)
         .color(color::LIGHT_BLUE)
-        .padded_wh_of(ids.canvas, 20.0)
+        .padded_w_of(ids.canvas, 20.0)
         .mid_top_of(ids.canvas)
         .align_text_x_middle()
         .line_spacing(2.5)
+        .restrict_to_height(false) // Let the height grow infinitely and scroll.
         .set(ids.text_edit, ui)
     {
         *demo_text = edit;
     }
+
+    widget::Scrollbar::y_axis(ids.canvas).auto_hide(true).set(ids.scrollbar, ui);
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -441,6 +441,44 @@ impl Graph {
         self.recursive_walk(idx, graphic_edge_parent)
     }
 
+    /// A **Walker** type that recursively walks **Depth** parents that are scrollable along the
+    /// *y* axis for the given node.
+    pub fn scrollable_y_parent_recursion(&self, idx: widget::Id)
+        -> RecursiveWalk<fn(&Graph, widget::Id) -> Option<IndexPair>>
+    {
+        fn scrollable_y_parent(graph: &Graph, id: widget::Id) -> Option<IndexPair> {
+            let mut depth_parents = graph.depth_parent_recursion(id);
+            while let Some((e, n)) = depth_parents.next(graph) {
+                if let Some(parent) = graph.widget(n) {
+                    if parent.maybe_y_scroll_state.is_some() {
+                        return Some((e, n));
+                    }
+                }
+            }
+            None
+        }
+        self.recursive_walk(idx, scrollable_y_parent)
+    }
+
+    /// A **Walker** type that recursively walks **Depth** parents that are scrollable along the
+    /// *x* axis for the given node.
+    pub fn scrollable_x_parent_recursion(&self, idx: widget::Id)
+        -> RecursiveWalk<fn(&Graph, widget::Id) -> Option<IndexPair>>
+    {
+        fn scrollable_x_parent(graph: &Graph, id: widget::Id) -> Option<IndexPair> {
+            let mut depth_parents = graph.depth_parent_recursion(id);
+            while let Some((e, n)) = depth_parents.next(graph) {
+                if let Some(parent) = graph.widget(n) {
+                    if parent.maybe_x_scroll_state.is_some() {
+                        return Some((e, n));
+                    }
+                }
+            }
+            None
+        }
+        self.recursive_walk(idx, scrollable_x_parent)
+    }
+
     /// A **Walker** type that may be used to step through the children of the given parent node.
     pub fn children(&self, parent: widget::Id) -> Children {
         self.dag.children(parent)

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -814,18 +814,14 @@ impl<'a> Widget for TextEdit<'a> {
                 let mut scrollable_parents = ui.widget_graph().scrollable_y_parent_recursion(id);
                 if let Some(parent_id) = scrollable_parents.next_node(ui.widget_graph()) {
                     if let Some(parent_rect) = ui.rect_of(parent_id) {
-                        if parent_rect.overlap(cursor_rect) != Some(parent_rect) {
-
-                            // If cursor is below, scroll down.
-                            if cursor_rect.bottom() < parent_rect.bottom() {
-                                let distance = parent_rect.bottom() - cursor_rect.bottom();
-                                ui.scroll_widget(parent_id, [0.0, distance]);
-
-                            // If cursor is above, scroll up.
-                            } else if cursor_rect.top() > parent_rect.top() {
-                                let distance = cursor_rect.top() - parent_rect.top();
-                                ui.scroll_widget(parent_id, [0.0, -distance]);
-                            }
+                        // If cursor is below, scroll down.
+                        if cursor_rect.bottom() < parent_rect.bottom() {
+                            let distance = parent_rect.bottom() - cursor_rect.bottom();
+                            ui.scroll_widget(parent_id, [0.0, distance]);
+                        // If cursor is above, scroll up.
+                        } else if cursor_rect.top() > parent_rect.top() {
+                            let distance = cursor_rect.top() - parent_rect.top();
+                            ui.scroll_widget(parent_id, [0.0, -distance]);
                         }
                     }
                 }


### PR DESCRIPTION
Currently `TextEdit` uses the default height inference when no height is specified, which is to take the height of the previously instantiated widget.

This PR fixes this behaviour so that if the `TextEdit`'s `restrict_to_height` field is set to `false`, its height will be inferred as the total height of the styled, line-wrapped text that it displays.

The `text_edit.rs` example has been updated to demonstrate this behaviour.

One problem that was highlighted while testing this is that the the parent container does not automatically scroll down when text is entered that would cause the size of the text to become greater than the size of the scrollable parent. This could possibly be fixed in a future PR by having the `TextEdit` "bubble up" a scroll event to its immediate y-axis-scrollable parent via the `Ui::scroll_widget` method. I'd add this now but it's midnight and I'm ready to 😴 

In the mean-time, a user may be able to emulate this behaviour by tracking the `TextEdit`'s height, comparing it to its parent's height and creating scroll events via the `Ui::scroll_widget` method as necessary themselves. Edit: although I guess what we really need is for the cursor position to be the thing that affects scrolling, not the total text height. Will look into this next time I get a chance.

Closes #866.

@Jascha-N hopefully this helps! I'll publish the fix to crates.io when travis passes :+1: