### PR TITLE
Publish 0.47.0 - improved EnvelopeEditor UX and glium GL ES 3+ support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.46.2"
+version = "0.47.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"


### PR DESCRIPTION
Bumped the minor version in this case due to very slight breaking change
in EnvelopeEditor that changes the behaviour of point insertion and
removal slightly. See #882 for details.

Includes the patch for supporting OpenGL ES 3.0+ via an alternative
shader program in the glium backend feature. See #885.