### PR TITLE
Validate Cursor in TextEdit widget. Clamp to text bounds if out of range.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.47.1"
+version = "0.47.2"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/text.rs
+++ b/src/text.rs
@@ -630,6 +630,33 @@ pub mod cursor {
                 })
         }
 
+        /// Clamps `self` to the given lines.
+        ///
+        /// If `self` would lie after the end of the last line, return the index at the end of the
+        /// last line.
+        ///
+        /// If `line_infos` is empty, returns cursor at line=0 char=0.
+        pub fn clamp_to_lines<I>(self, line_infos: I) -> Self
+            where I: Iterator<Item=super::line::Info>,
+        {
+            let mut last = None;
+            for (i, info) in line_infos.enumerate() {
+                if i == self.line {
+                    let num_chars = info.char_range().len();
+                    let char = std::cmp::min(self.char, num_chars);
+                    return Index { line: i, char: char };
+                }
+                last = Some((i, info));
+            }
+            match last {
+                Some((i, info)) => Index {
+                    line: i,
+                    char: info.char_range().len(),
+                },
+                None => Index { line: 0, char: 0 },
+            }
+        }
+
     }
 
 

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -349,6 +349,23 @@ impl<'a> Widget for TextEdit<'a> {
             })
         };
 
+        // Validate the position of the cursor. Ensure it is a valid position within the text.
+        match state.cursor {
+            Cursor::Idx(index) => {
+                let new_index = index.clamp_to_lines(state.line_infos.iter().cloned());
+                if index != new_index {
+                    state.update(|state| state.cursor = Cursor::Idx(index));
+                }
+            },
+            Cursor::Selection { start, end } => {
+                let new_start = start.clamp_to_lines(state.line_infos.iter().cloned());
+                let new_end = end.clamp_to_lines(state.line_infos.iter().cloned());
+                if start != new_start || end != new_end {
+                    state.update(|state| state.cursor = Cursor::Selection { start: start, end: end });
+                }
+            },
+        }
+
         let mut cursor = state.cursor;
         let mut drag = state.drag;
 

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -305,6 +305,25 @@ impl<'a> Widget for TextEdit<'a> {
             }
         }
 
+        // Validate the position of the cursor. Ensure the indices lie within the text.
+        match state.cursor {
+            Cursor::Idx(index) => {
+                let new_index = index.clamp_to_lines(state.line_infos.iter().cloned());
+                if index != new_index {
+                    let new_cursor = Cursor::Idx(new_index);
+                    state.update(|state| state.cursor = new_cursor);
+                }
+            },
+            Cursor::Selection { start, end } => {
+                let new_start = start.clamp_to_lines(state.line_infos.iter().cloned());
+                let new_end = end.clamp_to_lines(state.line_infos.iter().cloned());
+                if start != new_start || end != new_end {
+                    let new_cursor = Cursor::Selection { start: new_start, end: new_end };
+                    state.update(|state| state.cursor = new_cursor);
+                }
+            },
+        }
+
         // Find the position of the cursor at the given index over the given text.
         let cursor_xy_at = |cursor_idx: text::cursor::Index,
                             text: &str,
@@ -348,23 +367,6 @@ impl<'a> Widget for TextEdit<'a> {
                 Some(text::cursor::Index { line: line_idx, char: char_idx })
             })
         };
-
-        // Validate the position of the cursor. Ensure it is a valid position within the text.
-        match state.cursor {
-            Cursor::Idx(index) => {
-                let new_index = index.clamp_to_lines(state.line_infos.iter().cloned());
-                if index != new_index {
-                    state.update(|state| state.cursor = Cursor::Idx(index));
-                }
-            },
-            Cursor::Selection { start, end } => {
-                let new_start = start.clamp_to_lines(state.line_infos.iter().cloned());
-                let new_end = end.clamp_to_lines(state.line_infos.iter().cloned());
-                if start != new_start || end != new_end {
-                    state.update(|state| state.cursor = Cursor::Selection { start: start, end: end });
-                }
-            },
-        }
 
         let mut cursor = state.cursor;
         let mut drag = state.drag;


### PR DESCRIPTION
This adds a method to the `text::cursor::Index` for clamping to some given text described via an iterator yielding `text::line::Info`s.

Use this new method in the `TextEdit::update` in order to validate the position of the `Cursor`.