### PR TITLE
Introduce new `image::Id` type for uniquely identifying images.

### DIFF
--- a/examples/all_piston_window.rs
+++ b/examples/all_piston_window.rs
@@ -34,9 +34,6 @@ mod feature {
                 .build()
                 .unwrap();
 
-        // A demonstration of some state that we'd like to control with the App.
-        let mut app = support::DemoApp::new();
-
         // construct our `Ui`.
         let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64])
             .theme(support::theme())
@@ -75,7 +72,11 @@ mod feature {
 
         // Create our `conrod::image::Map` which describes each of our widget->image mappings.
         // In our case we only have one image, however the macro may be used to list multiple.
-        let image_map = support::image_map(&ids, rust_logo);
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(rust_logo);
+
+        // A demonstration of some state that we'd like to control with the App.
+        let mut app = support::DemoApp::new(rust_logo);
 
         // Poll events from the window.
         while let Some(event) = window.next() {

--- a/examples/all_winit_gfx.rs
+++ b/examples/all_winit_gfx.rs
@@ -208,9 +208,6 @@ mod feature {
         // Compile GL program
         let pso = factory.create_pipeline_simple(VERTEX_SHADER, FRAGMENT_SHADER, pipe::new()).unwrap();
 
-        // Demonstration app state that we'll control with our conrod GUI.
-        let mut app = support::DemoApp::new();
-
         // Create Ui and Ids of widgets to instantiate
         let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
         let ids = support::Ids::new(ui.widget_id_generator());
@@ -240,6 +237,15 @@ mod feature {
             (cache, texture, texture_view)
         };
 
+        // FIXME: We don't yet load the rust logo, so just insert nothing for now so we can get an
+        // identifier used to construct the DemoApp. This should be changed to *actually* load a
+        // gfx texture for the rust logo and insert it into the map.
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(());
+
+        // Demonstration app state that we'll control with our conrod GUI.
+        let mut app = support::DemoApp::new(rust_logo);
+
         // Event loop
         let mut events = window.poll_events();
 
@@ -266,7 +272,7 @@ mod feature {
                         },
                         render::PrimitiveKind::Lines { color, cap, thickness, points } => {
                         },
-                        render::PrimitiveKind::Image { color, source_rect } => {
+                        render::PrimitiveKind::Image { image_id, color, source_rect } => {
                         },
                         render::PrimitiveKind::Text { color, text, font_id } => {
                             let positioned_glyphs = text.positioned_glyphs(dpi_factor);

--- a/examples/all_winit_glium.rs
+++ b/examples/all_winit_glium.rs
@@ -34,9 +34,6 @@ mod feature {
             .build_glium()
             .unwrap();
 
-        // A demonstration of some app state that we want to control with the conrod GUI.
-        let mut app = support::DemoApp::new();
-
         // Construct our `Ui`.
         let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
 
@@ -59,7 +56,11 @@ mod feature {
             texture
         }
 
-        let image_map = support::image_map(&ids, load_rust_logo(&display));
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(load_rust_logo(&display));
+
+        // A demonstration of some app state that we want to control with the conrod GUI.
+        let mut app = support::DemoApp::new(rust_logo);
 
         // A type used for converting `conrod::render::Primitives` into `Command`s that can be used
         // for drawing to the glium `Surface`.

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -46,9 +46,8 @@ mod feature {
         // In our case we only have one image, however the macro may be used to list multiple.
         let rust_logo = load_rust_logo(&display);
         let (w, h) = (rust_logo.get_width(), rust_logo.get_height().unwrap());
-        let image_map = image_map! {
-            (ids.rust_logo, rust_logo),
-        };
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(rust_logo);
 
         // Poll events from the window.
         let mut event_loop = support::EventLoop::new();
@@ -77,7 +76,7 @@ mod feature {
                 // Draw a light blue background.
                 widget::Canvas::new().color(color::LIGHT_BLUE).set(ids.background, ui);
                 // Instantiate the `Image` at its full size in the middle of the window.
-                widget::Image::new().w_h(w as f64, h as f64).middle().set(ids.rust_logo, ui);
+                widget::Image::new(rust_logo).w_h(w as f64, h as f64).middle().set(ids.rust_logo, ui);
             }
 
             // Render the `Ui` and then display it on the screen.

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -57,9 +57,8 @@ mod feature {
         // In our case we only have one image, however the macro may be used to list multiple.
         let rust_logo = load_rust_logo(&display);
         let (w, h) = (rust_logo.get_width(), rust_logo.get_height().unwrap());
-        let image_map = image_map! {
-            (ids.rust_logo, rust_logo),
-        };
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(rust_logo);
 
         // We'll change the background colour with the image button.
         let mut bg_color = conrod::color::LIGHT_BLUE;
@@ -96,7 +95,7 @@ mod feature {
                     .set(ids.canvas, ui);
 
                 // Button widget example button.
-                if widget::Button::image(ids.rust_logo)
+                if widget::Button::image(rust_logo)
                     .w_h(w as conrod::Scalar, h as conrod::Scalar)
                     .middle_of(ids.canvas)
                     .color(color::TRANSPARENT)

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -28,17 +28,19 @@ pub struct DemoApp {
     ball_xy: conrod::Point,
     ball_color: conrod::Color,
     sine_frequency: f32,
+    rust_logo: conrod::image::Id,
 }
 
 
 impl DemoApp {
 
     /// Simple constructor for the `DemoApp`.
-    pub fn new() -> Self {
+    pub fn new(rust_logo: conrod::image::Id) -> Self {
         DemoApp {
             ball_xy: [0.0, 0.0],
             ball_color: conrod::color::WHITE,
             sine_frequency: 1.0,
+            rust_logo: rust_logo,
         }
     }
 
@@ -64,14 +66,6 @@ pub fn theme() -> conrod::Theme {
         widget_styling: std::collections::HashMap::new(),
         mouse_drag_threshold: 0.0,
         double_click_threshold: std::time::Duration::from_millis(500),
-    }
-}
-
-
-/// Create an image map that maps the `ids.rust_logo` to the `rust_logo` image.
-pub fn image_map<T>(ids: &Ids, rust_logo: T) -> conrod::image::Map<T> {
-    image_map! {
-        (ids.rust_logo, rust_logo)
     }
 }
 
@@ -244,7 +238,7 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
         .set(ids.image_title, ui);
 
     const LOGO_SIDE: conrod::Scalar = 144.0;
-    widget::Image::new()
+    widget::Image::new(app.rust_logo)
         .w_h(LOGO_SIDE, LOGO_SIDE)
         .down(60.0)
         .align_middle_x_of(ids.canvas)

--- a/src/backend/piston/draw.rs
+++ b/src/backend/piston/draw.rs
@@ -88,7 +88,7 @@ pub fn primitive<'a, Img, G, T, C, F>(
           C: FnMut(&mut G, &mut T, text::rt::Rect<u32>, &[u8]),
           F: FnMut(&Img) -> &T,
 {
-    let render::Primitive { id, kind, scizzor, rect } = primitive;
+    let render::Primitive { kind, scizzor, rect, .. } = primitive;
     let view_size = context.get_view_size();
     // Translate the `context` to suit conrod's orientation (middle (0, 0), y pointing upwards).
     let context = context.trans(view_size[0] / 2.0, view_size[1] / 2.0).scale(1.0, -1.0);
@@ -187,8 +187,8 @@ pub fn primitive<'a, Img, G, T, C, F>(
                                               graphics);
         },
 
-        render::PrimitiveKind::Image { color, source_rect } => {
-            if let Some(img) = image_map.get(&id) {
+        render::PrimitiveKind::Image { image_id, color, source_rect } => {
+            if let Some(img) = image_map.get(&image_id) {
                 let mut image = piston_graphics::image::Image::new();
                 image.color = color.map(|c| c.to_fsa());
                 if let Some(source_rect) = source_rect {

--- a/src/render.rs
+++ b/src/render.rs
@@ -11,6 +11,7 @@
 
 use {Align, Color, Dimensions, FontSize, Point, Rect, Scalar};
 use graph::{self, Graph};
+use image;
 use std;
 use text;
 use theme::Theme;
@@ -131,6 +132,8 @@ pub enum PrimitiveKind<'a> {
 
     /// A single `Image`, produced by the primitive `Image` widget.
     Image {
+        /// The unique identifier of the image that will be drawn.
+        image_id: image::Id,
         /// When `Some`, colours the `Image`. When `None`, the `Image` uses its regular colours.
         color: Option<Color>,
         /// The area of the texture that will be drawn to the `Image`'s `Rect`.
@@ -205,6 +208,7 @@ enum OwnedPrimitiveKind {
         point_range: std::ops::Range<usize>,
     },
     Image {
+        image_id: image::Id,
         color: Option<Color>,
         source_rect: Option<Rect>,
     },
@@ -516,6 +520,7 @@ impl<'a> Primitives<'a> {
                     let color = style.maybe_color(theme);
                     let kind = PrimitiveKind::Image {
                         color: color,
+                        image_id: state.image_id,
                         source_rect: state.src_rect,
                     };
                     return Some(new_primitive(id, kind, scizzor, rect));
@@ -580,8 +585,9 @@ impl<'a> Primitives<'a> {
                     primitives.push(new(kind));
                 },
 
-                PrimitiveKind::Image { color, source_rect } => {
+                PrimitiveKind::Image { image_id, color, source_rect } => {
                     let kind = OwnedPrimitiveKind::Image {
+                        image_id: image_id,
                         color: color,
                         source_rect: source_rect,
                     };
@@ -758,8 +764,9 @@ impl<'a> WalkOwnedPrimitives<'a> {
                     new(kind)
                 },
 
-                OwnedPrimitiveKind::Image { color, source_rect } => {
+                OwnedPrimitiveKind::Image { image_id, color, source_rect } => {
                     let kind = PrimitiveKind::Image {
+                        image_id: image_id,
                         color: color,
                         source_rect: source_rect,
                     };

--- a/src/widget/primitive/image.rs
+++ b/src/widget/primitive/image.rs
@@ -1,6 +1,7 @@
 //! A simple, non-interactive widget for drawing an `Image`.
 
 use {Color, Dimension, Rect, Widget, Ui};
+use image;
 use widget;
 
 
@@ -9,6 +10,8 @@ use widget;
 pub struct Image {
     /// Data necessary and common for all widget builder types.
     pub common: widget::CommonBuilder,
+    /// The unique identifier for the image that will be drawn.
+    pub image_id: image::Id,
     /// The rectangle area of the original source image that should be used.
     pub src_rect: Option<Rect>,
     /// Unique styling.
@@ -22,6 +25,8 @@ pub struct State {
     ///
     /// If `None`, the entire image will be used.
     pub src_rect: Option<Rect>,
+    /// The unique identifier for the image's associated data that will be drawn.
+    pub image_id: image::Id,
 }
 
 widget_style!{
@@ -38,7 +43,7 @@ impl Image {
     /// Construct a new `Image`.
     ///
     /// Note that the `Image` widget does not require borrowing or owning any image data directly.
-    /// Instead, image data is stored within a `conrod::image::Map` where widget indices are mapped
+    /// Instead, image data is stored within a `conrod::image::Map` where `image::Id`s are mapped
     /// to their associated data.
     ///
     /// This is done for a few reasons:
@@ -59,9 +64,10 @@ impl Image {
     /// 1. use an enum with a variant for each type
     /// 2. use a trait object, where the trait is implemented for each of your image types or
     /// 3. use an index type which may be mapped to your various image types.
-    pub fn new() -> Self {
+    pub fn new(image_id: image::Id) -> Self {
         Image {
             common: widget::CommonBuilder::new(),
+            image_id: image_id,
             src_rect: None,
             style: Style::new(),
         }
@@ -98,6 +104,7 @@ impl Widget for Image {
     fn init_state(&self, _: widget::id::Generator) -> Self::State {
         State {
             src_rect: None,
+            image_id: self.image_id,
         }
     }
 
@@ -121,8 +128,11 @@ impl Widget for Image {
 
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { state, .. } = args;
-        let Image { src_rect, .. } = self;
+        let Image { image_id, src_rect, .. } = self;
 
+        if state.image_id != image_id {
+            state.update(|state| state.image_id = image_id);
+        }
         if state.src_rect != src_rect {
             state.update(|state| state.src_rect = src_rect);
         }


### PR DESCRIPTION
This should solve #895 as it removes the association between images and
`widget::Id`s in favour of a new unique `image::Id` type.

`image::Id`s are returned upon inserting new images into the map,
similarly to how the `text::font::Map` produces `font::Id`s when
inserting new fonts into the map. This reduces the chance of users using
invalid identifiers, as an image has to be inserted into the map for
each identifier that exists.

cc @tl8roy, @TimBednarzyk, @christolliday

@tl8roy I'll likely integrate these changes into #906 tomorrow :+1:

Closes #895.