### PR TITLE
Use Condvar to make the example EventLoop thread-safe

### DIFF
--- a/examples/all_winit_glium.rs
+++ b/examples/all_winit_glium.rs
@@ -79,7 +79,7 @@ mod feature {
         // - Update the widgets via the `support::gui` fn.
         // - Render the current state of the `Ui`.
         // - Repeat.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -46,7 +46,7 @@ mod feature {
         let ids = &mut Ids::new(ui.widget_id_generator());
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -48,7 +48,7 @@ mod feature {
         let mut count = 0;
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -281,7 +281,7 @@ fn main() {
     let image_map = conrod::image::Map::<glium::texture::Texture2d>::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
+    let event_loop = support::EventLoop::new();
     'main: loop {
 
         // Handle all events.

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -41,7 +41,7 @@ fn main() {
     let directory = find_folder::Search::KidsThenParents(3, 5).for_folder("conrod").unwrap();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
+    let event_loop = support::EventLoop::new();
     'main: loop {
 
         // Handle all events.

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -50,7 +50,7 @@ mod feature {
         let rust_logo = image_map.insert(rust_logo);
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -64,7 +64,7 @@ mod feature {
         let mut bg_color = conrod::color::LIGHT_BLUE;
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -52,7 +52,7 @@ mod feature {
         let mut list = vec![true; 16];
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -72,7 +72,7 @@ mod feature {
         let mut list_selected = std::collections::HashSet::new();
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -135,7 +135,7 @@ mod feature {
         let mut app = DemoApp::new();
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -44,7 +44,7 @@ mod feature {
         let image_map = conrod::image::Map::<glium::texture::Texture2d>::new();
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -54,7 +54,7 @@ mod feature {
         let image_map = conrod::image::Map::<glium::texture::Texture2d>::new();
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -52,7 +52,7 @@ mod feature {
         let mut oval_range = (0.25, 0.75);
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -15,6 +15,8 @@ extern crate rand;
 
 use conrod;
 use std;
+use std::sync::{Arc, Mutex, Condvar};
+use std::time::Duration;
 
 #[cfg(feature="glium")] use conrod::backend::glium::glium;
 
@@ -364,8 +366,7 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
 /// glutin+glium event loop that works efficiently with conrod.
 #[cfg(feature="glium")]
 pub struct EventLoop {
-    ui_needs_update: bool,
-    last_update: std::time::Instant,
+    pair: Arc<(Mutex<bool>, Condvar)>,
 }
 
 #[cfg(feature="glium")]
@@ -373,33 +374,32 @@ impl EventLoop {
 
     pub fn new() -> Self {
         EventLoop {
-            last_update: std::time::Instant::now(),
-            ui_needs_update: false,
+            pair: Arc::new((Mutex::new(false), Condvar::new())),
         }
     }
 
     /// Produce an iterator yielding all available events.
-    pub fn next(&mut self, display: &glium::Display) -> Vec<glium::glutin::Event> {
-        // We don't want to loop any faster than 60 FPS, so wait until it has been at least 16ms
-        // since the last yield.
-        let last_update = self.last_update;
-        let sixteen_ms = std::time::Duration::from_millis(16);
-        let duration_since_last_update = std::time::Instant::now().duration_since(last_update);
-        if duration_since_last_update < sixteen_ms {
-            std::thread::sleep(sixteen_ms - duration_since_last_update);
-        }
-
-        // Collect all pending events.
+    pub fn next(&self, display: &glium::Display) -> Vec<glium::glutin::Event> {
         let mut events = Vec::new();
-        events.extend(display.poll_events());
 
-        // If there are no events and the `Ui` does not need updating, wait for the next event.
-        if events.is_empty() && !self.ui_needs_update {
-            events.extend(display.wait_events().next());
+        // FIXME: This will busy loop at 60FPS, ideally there would be a way to have the glium
+        //        display also fire needs_update() calls and then we could bump the timeout
+        //        to something much higher or even just use wait()
+        loop {
+            events.extend(display.poll_events());
+            if !events.is_empty() {
+                break;
+            }
+
+            let &(ref lock, ref cvar) = &*self.pair;
+            let guard = lock.lock().unwrap();
+            let mut needs_update = cvar.wait_timeout(guard, Duration::from_millis(16)).unwrap().0;
+
+            if *needs_update {
+                *needs_update = false;
+                break;
+            }
         }
-
-        self.ui_needs_update = false;
-        self.last_update = std::time::Instant::now();
 
         events
     }
@@ -409,8 +409,11 @@ impl EventLoop {
     ///
     /// This is primarily used on the occasion that some part of the `Ui` is still animating and
     /// requires further updates to do so.
-    pub fn needs_update(&mut self) {
-        self.ui_needs_update = true;
+    pub fn needs_update(&self) {
+        let &(ref lock, ref cvar) = &*self.pair;
+        let mut guard = lock.lock().unwrap();
+        *guard = true;
+        cvar.notify_one();
     }
 
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -61,7 +61,7 @@ mod feature {
         let image_map = conrod::image::Map::<glium::texture::Texture2d>::new();
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -57,7 +57,7 @@ mod feature {
             magna est, efficitur suscipit dolor eu, consectetur consectetur urna.".to_owned();
 
         // Poll events from the window.
-        let mut event_loop = support::EventLoop::new();
+        let event_loop = support::EventLoop::new();
         'main: loop {
 
             // Handle all events.


### PR DESCRIPTION
The event loop used to need to be mutable and was thus hard to use when you had several threads that needed to call needs_update(). Use std::sync::Condvar and friends to make it so the EventLoop doesn't need to be mutable at all and handles several threads properly.

next() will now busy loop at 60FPS while waiting for input. Ideally there would be a way to have the glium Window also fire needs_update() calls and then we could bump the timeout to something much higher or even just wait forever until there's an event. I don't see anything in the glium API that lets us do that cleanly though and this busy waiting is cheap (but may be a waste of power on mobile/laptops).