### PR TITLE
Add a slimmer `Input` enum with only the variants that are relevant to conrod.

### DIFF
--- a/src/backend/piston/event.rs
+++ b/src/backend/piston/event.rs
@@ -1,7 +1,8 @@
 //! A backend for converting piston events to conrod's `Input` type.
 
 use {Point, Scalar};
-use event::{Input, Motion};
+use event::Input;
+use input;
 pub use piston_input::{GenericEvent, UpdateEvent};
 
 /// Converts any `GenericEvent` to an `Input` event for conrod.
@@ -15,22 +16,22 @@ pub fn convert<E>(event: E, win_w: Scalar, win_h: Scalar) -> Option<Input>
 
     if let Some(xy) = event.mouse_cursor_args() {
         let (x, y) = translate_coords(xy);
-        return Some(Input::Move(Motion::MouseCursor(x, y)));
+        return Some(Input::Move(input::Motion::MouseCursor(x, y)));
     }
 
     if let Some(rel_xy) = event.mouse_relative_args() {
         let (rel_x, rel_y) = translate_coords(rel_xy);
-        return Some(Input::Move(Motion::MouseRelative(rel_x, rel_y)));
+        return Some(Input::Move(input::Motion::MouseRelative(rel_x, rel_y)));
     }
 
     if let Some(xy) = event.mouse_scroll_args() {
         // Invert the scrolling of the *y* axis as *y* is up in conrod.
         let (x, y) = (xy[0], -xy[1]);
-        return Some(Input::Move(Motion::MouseScroll(x, y)));
+        return Some(Input::Move(input::Motion::MouseScroll(x, y)));
     }
 
     if let Some(args) = event.controller_axis_args() {
-        return Some(Input::Move(Motion::ControllerAxis(args)));
+        return Some(Input::Move(input::Motion::ControllerAxis(args)));
     }
 
     if let Some(button) = event.press_args() {
@@ -51,10 +52,6 @@ pub fn convert<E>(event: E, win_w: Scalar, win_h: Scalar) -> Option<Input>
 
     if let Some(b) = event.focus_args() {
         return Some(Input::Focus(b));
-    }
-
-    if let Some(b) = event.cursor_args() {
-        return Some(Input::Cursor(b));
     }
 
     None

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -3,7 +3,7 @@
 extern crate winit;
 
 use Scalar;
-use event::{Input, Motion};
+use event::Input;
 use input;
 #[cfg(feature = "glium")] use glium;
 
@@ -109,16 +109,16 @@ pub fn convert<W>(e: winit::Event, window: &W) -> Option<Input>
             };
             let xy = [tx(location.0), ty(location.1)];
             let args = input::TouchArgs::new(0, id as i64, xy, 1.0, phase);
-            Some(Input::Move(Motion::Touch(args)).into())
+            Some(Input::Move(input::Motion::Touch(args)).into())
         }
 
         winit::Event::MouseMoved(x, y) =>
-            Some(Input::Move(Motion::MouseCursor(tx(x as Scalar), ty(y as Scalar))).into()),
+            Some(Input::Move(input::Motion::MouseCursor(tx(x as Scalar), ty(y as Scalar))).into()),
 
         winit::Event::MouseWheel(winit::MouseScrollDelta::PixelDelta(x, y), _) => {
             let x = x as Scalar / dpi_factor;
             let y = -y as Scalar / dpi_factor;
-            Some(Input::Move(Motion::MouseScroll(x, y)).into())
+            Some(Input::Move(input::Motion::MouseScroll(x, y)).into())
         },
 
         winit::Event::MouseWheel(winit::MouseScrollDelta::LineDelta(x, y), _) => {
@@ -126,7 +126,7 @@ pub fn convert<W>(e: winit::Event, window: &W) -> Option<Input>
             const ARBITRARY_POINTS_PER_LINE_FACTOR: Scalar = 10.0;
             let x = ARBITRARY_POINTS_PER_LINE_FACTOR * x as Scalar;
             let y = ARBITRARY_POINTS_PER_LINE_FACTOR * -y as Scalar;
-            Some(Input::Move(Motion::MouseScroll(x, y)).into())
+            Some(Input::Move(input::Motion::MouseScroll(x, y)).into())
         },
 
         winit::Event::MouseInput(winit::ElementState::Pressed, button) =>

--- a/src/event.rs
+++ b/src/event.rs
@@ -56,9 +56,21 @@ use widget;
 /// with the origin in the top left with *y* pointing down, so you might need to translate these
 /// co-ordinates when converting to this event. Also be sure to invert the *y* axis of MouseScroll
 /// events.
-pub use piston_input::Input;
-#[doc(inline)]
-pub use piston_input::Motion;
+#[derive(Clone, Debug, PartialEq)]
+pub enum Input {
+    /// A button on some input device was pressed.
+    Press(input::Button),
+    /// A button on some input device was released.
+    Release(input::Button),
+    /// The window was received to the given dimensions.
+    Resize(u32, u32),
+    /// Some motion input was received (e.g. moving mouse, joystick or touch pad).
+    Move(input::Motion),
+    /// Text input was received, usually via the keyboard.
+    Text(String),
+    /// The window was focused or lost focus.
+    Focus(bool),
+}
 
 
 /// Enum containing all the events that the `Ui` may provide.
@@ -167,7 +179,7 @@ pub struct Text {
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Move {
     /// The type of `Motion` that occurred.
-    pub motion: Motion,
+    pub motion: input::Motion,
     /// The modifier keys that were down at the time.
     pub modifiers: input::keyboard::ModifierKey,
 }
@@ -301,7 +313,7 @@ impl Move {
     /// Returns a copy of the `Move` relative to the given `xy`
     pub fn relative_to(&self, xy: Point) -> Move {
         let motion = match self.motion {
-            Motion::MouseCursor(x, y) => Motion::MouseCursor(x - xy[0], y - xy[1]),
+            input::Motion::MouseCursor(x, y) => input::Motion::MouseCursor(x - xy[0], y - xy[1]),
             motion => motion,
         };
         Move {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -32,6 +32,7 @@ pub use piston_input::{
     ControllerAxisArgs,
     keyboard,
     Key,
+    Motion,
     MouseButton,
     RenderArgs,
     Touch,

--- a/src/tests/global_input.rs
+++ b/src/tests/global_input.rs
@@ -1,5 +1,5 @@
-use event::{self, Input, Motion};
-use input::{self, Key, MouseButton};
+use event::{self, Input};
+use input::{self, Key, Motion, MouseButton};
 use input::Button::Keyboard;
 use input::Button::Mouse;
 use position::Scalar;

--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -8,8 +8,8 @@ use {
     Ui,
     UiBuilder
 };
-use event::{self, Input, Motion};
-use input::{self, Button, Key, MouseButton};
+use event::{self, Input};
+use input::{self, Button, Key, Motion, MouseButton};
 use input::keyboard::ModifierKey;
 use widget;
 use position::Point;
@@ -115,7 +115,6 @@ fn ui_should_push_input_events_to_aggregator() {
     test_handling_basic_input_event(ui, Input::Text("my string".to_string()));
     test_handling_basic_input_event(ui, Input::Resize(55, 99));
     test_handling_basic_input_event(ui, Input::Focus(true));
-    test_handling_basic_input_event(ui, Input::Cursor(true));
 }
 
 #[test]

--- a/src/tests/widget_input.rs
+++ b/src/tests/widget_input.rs
@@ -1,5 +1,5 @@
-use event::{self, Input, Motion};
-use input::{self, Button, MouseButton};
+use event::{self, Input};
+use input::{self, Button, Motion, MouseButton};
 use input::keyboard::NO_MODIFIER;
 use widget;
 use position::Rect;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -323,8 +323,8 @@ impl Ui {
     /// The given `event` must implement the **ToRawEvent** trait so that it can be converted to a
     /// `RawEvent` that can be used by the `Ui`.
     pub fn handle_event(&mut self, event: event::Input) {
-        use event::{self, Input, Motion};
-        use input::{Button, Key, ModifierKey};
+        use event::{self, Input};
+        use input::{Button, Key, ModifierKey, Motion};
         use input::state::mouse::Button as MouseButton;
 
         // Determines which widget is currently under the mouse and sets it within the `Ui`'s


### PR DESCRIPTION
This should simplify conrod's `Input` event API, making it clear which
events are necessary to drive the `Ui` forward.

This also fixes an issue appearing in downstream crates where conrod
loops that are run on a separate thread were broken due to `Input` no
longer being `Send` or `Sync`. See [here](https://github.com/PistonDevelopers/piston/pull/1149#pullrequestreview-18985967) for details.

Edit: Also, the `Motion` enum re-export was moved to the `input` module along with the rest of the remaining re-exported `pistoncore-input` types.