### PR TITLE
Add `Relative` position type. Make `position` mod pub.

### DIFF
--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -49,11 +49,12 @@ impl DemoApp {
 
 /// A set of reasonable stylistic defaults that works for the `gui` below.
 pub fn theme() -> conrod::Theme {
+    use conrod::position::{Align, Direction, Padding, Position, Relative};
     conrod::Theme {
         name: "Demo Theme".to_string(),
-        padding: conrod::Padding::none(),
-        x_position: conrod::Position::Align(conrod::Align::Start, None),
-        y_position: conrod::Position::Direction(conrod::Direction::Backwards, 20.0, None),
+        padding: Padding::none(),
+        x_position: Position::Relative(Relative::Align(Align::Start), None),
+        y_position: Position::Relative(Relative::Direction(Direction::Backwards, 20.0), None),
         background_color: conrod::color::DARK_CHARCOAL,
         shape_color: conrod::color::LIGHT_CHARCOAL,
         border_color: conrod::color::BLACK,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@ extern crate rusttype;
 pub use color::{Color, Colorable};
 pub use border::{Bordering, Borderable};
 pub use label::{FontSize, Labelable};
-pub use position::{Align, Axis, Corner, Depth, Direction, Dimension, Dimensions, Edge, Margin,
-                   Padding, Place, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};
+pub use position::{Dimensions, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};
 pub use theme::Theme;
 pub use ui::{Ui, UiCell, UiBuilder};
 pub use widget::{scroll, Widget};
@@ -32,7 +31,7 @@ pub mod guide;
 pub mod image;
 pub mod input;
 mod label;
-mod position;
+pub mod position;
 pub mod render;
 pub mod text;
 pub mod theme;

--- a/src/position/mod.rs
+++ b/src/position/mod.rs
@@ -58,13 +58,25 @@ pub enum Position {
     /// A specific position.
     Absolute(Scalar),
     /// A position relative to some other Widget.
-    Relative(Scalar, Option<widget::Id>),
-    /// A position aligned with some other Widget.
-    Align(Align, Option<widget::Id>),
-    /// A direction relative to some other Widget.
-    Direction(Direction, Scalar, Option<widget::Id>),
-    /// A position at a place on some other Widget.
-    Place(Place, Option<widget::Id>),
+    Relative(Relative, Option<widget::Id>),
+}
+
+/// Positions that are described as **Relative** to some other **Widget**.
+///
+/// **Relative** describes a relative position along a single axis.
+pub enum Relative {
+    /// A relative scalar distance.
+    Scalar(Scalar),
+    /// Aligned to either the `Start`, `Middle` or `End`.
+    Align(Align),
+    /// A distance as a `Scalar` value over the given `Direction`.
+    Direction(Direction, Scalar),
+    /// Some place on top of another widget.
+    ///
+    /// Similar to `Align`, but represents the `Start`/`End` of the other widget's `kid_area`.
+    ///
+    /// Also allows for specifying a `Margin` from either end.
+    Place(Place),
 }
 
 /// Directionally positioned, normally relative to some other widget.

--- a/src/position/range.rs
+++ b/src/position/range.rs
@@ -613,7 +613,7 @@ impl Range {
     /// # Examples
     ///
     /// ```
-    /// use conrod::{Edge, Range};
+    /// use conrod::position::{Edge, Range};
     ///
     /// assert_eq!(Range::new(0.0, 10.0).closest_edge(4.0), Edge::Start);
     /// assert_eq!(Range::new(0.0, 10.0).closest_edge(7.0), Edge::End);

--- a/src/position/rect.rs
+++ b/src/position/rect.rs
@@ -1,3 +1,4 @@
+//! Defines the scalar `Rect` type used throughout conrod.
 
 use super::{Dimensions, Padding, Point, Range, Scalar};
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,9 +9,10 @@
 //! This is the only module in which the piston graphics crate will be used directly.
 
 
-use {Align, Color, Dimensions, FontSize, Point, Rect, Scalar};
+use {Color, FontSize, Point, Rect, Scalar};
 use graph::{self, Graph};
 use image;
+use position::{Align, Dimensions};
 use std;
 use text;
 use theme::Theme;

--- a/src/text.rs
+++ b/src/text.rs
@@ -442,7 +442,8 @@ pub mod glyph {
 
 /// Logic related to the positioning of the cursor within text.
 pub mod cursor {
-    use {FontSize, Range, Rect, Scalar, Point, Align};
+    use FontSize;
+    use position::{Range, Rect, Scalar, Point, Align};
     use std;
 
     /// Every possible cursor position within each line of text yielded by the given iterator.
@@ -860,7 +861,8 @@ pub mod cursor {
 ///
 /// This module is the core of multi-line text handling.
 pub mod line {
-    use {Align, FontSize, Range, Rect, Scalar};
+    use FontSize;
+    use position::{Align, Range, Rect, Scalar};
     use std;
 
     /// The two types of **Break** indices returned by the **WrapIndicesBy** iterators.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -4,7 +4,7 @@
 
 use Scalar;
 use color::{Color, BLACK, WHITE};
-use position::{Align, Direction, Padding, Position};
+use position::{Align, Direction, Padding, Position, Relative};
 use std;
 use std::any::Any;
 use text;
@@ -83,8 +83,8 @@ impl Theme {
         Theme {
             name: "Demo Theme".to_string(),
             padding: Padding::none(),
-            x_position: Position::Align(Align::Start, None),
-            y_position: Position::Direction(Direction::Backwards, 20.0, None),
+            x_position: Position::Relative(Relative::Align(Align::Start), None),
+            y_position: Position::Relative(Relative::Direction(Direction::Backwards, 20.0), None),
             background_color: BLACK,
             shape_color: WHITE,
             border_color: BLACK,

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -1,20 +1,8 @@
 //! The `Button` widget and related items.
 
-use {
-    Align,
-    Color,
-    Colorable,
-    FontSize,
-    Borderable,
-    Labelable,
-    Rect,
-    Positionable,
-    Scalar,
-    Sizeable,
-    UiCell,
-    Widget,
-};
+use {Color, Colorable, FontSize, Borderable, Labelable, Positionable, Sizeable, UiCell, Widget};
 use image;
+use position::{Align, Rect, Scalar};
 use text;
 use widget;
 

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -1,27 +1,19 @@
 //! The `Canvas` widget and related items.
 
 use {
-    Align,
     Color,
     Colorable,
-    Dimensions,
     FontSize,
     Borderable,
     Labelable,
-    Padding,
-    Place,
-    Position,
     Positionable,
-    Range,
-    Rect,
-    Scalar,
     Sizeable,
     Theme,
     Ui,
     UiCell,
     Widget,
 };
-use position;
+use position::{self, Align, Dimensions, Padding, Place, Position, Range, Rect, Scalar};
 use position::Direction::{Forwards, Backwards};
 use widget;
 
@@ -240,11 +232,11 @@ impl<'a> Widget for Canvas<'a> {
     }
 
     fn default_x_position(&self, _ui: &Ui) -> Position {
-        Position::Place(Place::Middle, None)
+        Position::Relative(position::Relative::Place(Place::Middle), None)
     }
 
     fn default_y_position(&self, _ui: &Ui) -> Position {
-        Position::Place(Place::Middle, None)
+        Position::Relative(position::Relative::Place(Place::Middle), None)
     }
 
     /// The title bar area at which the Canvas can be clicked and dragged.

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -1,16 +1,7 @@
 //! The `DropDownList` and related items.
 
-use {
-    Align,
-    Color,
-    Colorable,
-    FontSize,
-    Borderable,
-    Labelable,
-    Positionable,
-    Scalar,
-    Sizeable,
-};
+use {Color, Colorable, FontSize, Borderable, Labelable, Positionable, Sizeable};
+use position::{Align, Scalar};
 use text;
 use utils;
 use widget::{self, Widget};

--- a/src/widget/envelope_editor.rs
+++ b/src/widget/envelope_editor.rs
@@ -1,21 +1,8 @@
 //! The `EnvelopeEditor` widget and related items.
 
-use {
-    Color,
-    Colorable,
-    Direction,
-    Edge,
-    Borderable,
-    FontSize,
-    Labelable,
-    Point,
-    Positionable,
-    Rect,
-    Scalar,
-    Sizeable,
-    Widget,
-};
+use {Color, Colorable, Borderable, FontSize, Labelable, Positionable, Sizeable, Widget};
 use num::Float;
+use position::{Direction, Edge, Point, Rect, Scalar};
 use std;
 use text;
 use utils::{clamp, map_range, percentage, val_to_string};

--- a/src/widget/primitive/image.rs
+++ b/src/widget/primitive/image.rs
@@ -1,7 +1,8 @@
 //! A simple, non-interactive widget for drawing an `Image`.
 
-use {Color, Dimension, Rect, Widget, Ui};
+use {Color, Widget, Ui};
 use image;
+use position::{Dimension, Rect};
 use widget;
 
 

--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -1,15 +1,7 @@
 //! The primitive widget used for displaying text.
 
-use {
-    Align,
-    Color,
-    Colorable,
-    Dimension,
-    FontSize,
-    Scalar,
-    Ui,
-    Widget,
-};
+use {Color, Colorable, FontSize, Ui, Widget};
+use position::{Align, Dimension, Scalar};
 use std;
 use text;
 use utils;

--- a/src/widget/range_slider.rs
+++ b/src/widget/range_slider.rs
@@ -1,19 +1,8 @@
 //! A widget for specifying start and end values for some linear range.
 
-use {
-    Color,
-    Colorable,
-    FontSize,
-    Borderable,
-    Labelable,
-    Padding,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Widget,
-};
+use {Color, Colorable, FontSize, Borderable, Labelable, Positionable, Widget};
 use num::{Float, NumCast, ToPrimitive};
+use position::{Padding, Range, Rect, Scalar};
 use text;
 use utils;
 use widget;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -1,6 +1,7 @@
 //! Scroll related types and logic.
 
-use {Align, Point, Padding, Range, Rect, Scalar, Ui};
+use Ui;
+use position::{Align, Point, Padding, Range, Rect, Scalar};
 use std::marker::PhantomData;
 
 

--- a/src/widget/scrollbar.rs
+++ b/src/widget/scrollbar.rs
@@ -1,16 +1,8 @@
 //! A widget that allows for manually scrolling via dragging the mouse.
 
-use {
-    Color,
-    Colorable,
-    Dimension,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Ui,
-};
+use {Color, Colorable, Positionable, Ui};
 use graph;
+use position::{Dimension, Range, Rect, Scalar};
 use std;
 use utils;
 use widget::{self, Widget};

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -1,19 +1,8 @@
 //! A widget for selecting a single value along some linear range.
 
-use {
-    Color,
-    Colorable,
-    FontSize,
-    Borderable,
-    Labelable,
-    Padding,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Widget,
-};
+use {Color, Colorable, FontSize, Borderable, Labelable, Positionable, Widget};
 use num::{Float, NumCast, ToPrimitive};
+use position::{Padding, Range, Rect, Scalar};
 use text;
 use widget;
 

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -1,20 +1,9 @@
 //! A widget for displaying and mutating a one-line field of text.
 
-use {
-    Align,
-    Color,
-    Colorable,
-    FontSize,
-    Borderable,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Sizeable,
-    Widget,
-};
+use {Color, Colorable, FontSize, Borderable, Positionable, Sizeable, Widget};
 use event;
 use input;
+use position::{Align, Range, Rect, Scalar};
 use text;
 use widget;
 

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -1,22 +1,9 @@
 //! A widget for displaying and mutating multi-line text, given as a `String`.
 
-use {
-    Align,
-    Color,
-    Colorable,
-    Dimension,
-    FontSize,
-    Point,
-    Positionable,
-    Range,
-    Rect,
-    Scalar,
-    Sizeable,
-    Widget,
-    Ui,
-};
+use {Color, Colorable, FontSize, Positionable, Sizeable, Widget, Ui};
 use event;
 use input;
+use position::{Align, Dimension, Point, Range, Rect, Scalar};
 use std;
 use text;
 use utils;

--- a/src/widget/title_bar.rs
+++ b/src/widget/title_bar.rs
@@ -1,18 +1,7 @@
 //! A simple title bar widget that automatically sizes itself to the top of some other widget.
 
-use {
-    Align,
-    Color,
-    Colorable,
-    Dimension,
-    FontSize,
-    Borderable,
-    Labelable,
-    Positionable,
-    Scalar,
-    Sizeable,
-    Ui,
-};
+use {Color, Colorable, FontSize, Borderable, Labelable, Positionable, Sizeable, Ui};
+use position::{Align, Dimension, Scalar};
 use text;
 use widget::{self, Widget};
 


### PR DESCRIPTION
This splits up the `Position` type into `Absolute` and `Relative`
variants by introducing a new `position::Relative` type.

This new `position::Relative` type should allow us to introduce cleaner relative
positioning APIs. E.g. one common user desire is to be able to have
greater control over positioning of child widgets such as labels. This
change would allow us to take a `position::Relative` for child widgets
along each axis, enabling this control in an expressive manner.

This also removes some of the `position` module re-exports from the root
in favour of making the `position` module public.

@tl8roy this is a step towards addressing #901 - I'll do a follow up PR with `Button::label_x(Relative)` and `Button::label_y(Relative)` methods soon.