### PR TITLE
Add a new `text::Justify` type to distinguish from `Align`.

### DIFF
--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -157,7 +157,7 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
         .padded_w_of(ids.canvas, MARGIN)
         .down(60.0)
         .align_middle_x_of(ids.canvas)
-        .align_text_middle()
+        .center_justify()
         .line_spacing(5.0)
         .set(ids.introduction, ui);
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -132,7 +132,7 @@ mod feature {
             .color(color::LIGHT_RED)
             .padded_w_of(ids.left_col, PAD)
             .mid_top_with_margin_on(ids.left_col, PAD)
-            .align_text_left()
+            .left_justify()
             .line_spacing(10.0)
             .set(ids.left_text, ui);
 
@@ -141,7 +141,7 @@ mod feature {
             .color(color::LIGHT_GREEN)
             .padded_w_of(ids.middle_col, PAD)
             .middle_of(ids.middle_col)
-            .align_text_middle()
+            .center_justify()
             .line_spacing(2.5)
             .set(ids.middle_text, ui);
 
@@ -150,7 +150,7 @@ mod feature {
             .color(color::LIGHT_BLUE)
             .padded_w_of(ids.right_col, PAD)
             .mid_bottom_with_margin_on(ids.right_col, PAD)
-            .align_text_right()
+            .right_justify()
             .line_spacing(5.0)
             .set(ids.right_text, ui);
     }

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -105,7 +105,7 @@ mod feature {
             .color(color::WHITE)
             .padded_w_of(ids.canvas, 20.0)
             .mid_top_of(ids.canvas)
-            .align_text_x_middle()
+            .center_justify()
             .line_spacing(2.5)
             .restrict_to_height(false) // Let the height grow infinitely and scroll.
             .set(ids.text_edit, ui)

--- a/src/render.rs
+++ b/src/render.rs
@@ -179,7 +179,7 @@ pub struct Text<'a> {
     font: &'a text::Font,
     font_size: FontSize,
     rect: Rect,
-    x_align: Align,
+    justify: text::Justify,
     y_align: Align,
     line_spacing: Scalar,
 }
@@ -228,7 +228,7 @@ struct OwnedText {
     font: text::Font,
     font_size: FontSize,
     rect: Rect,
-    x_align: Align,
+    justify: text::Justify,
     y_align: Align,
     line_spacing: Scalar,
 }
@@ -265,7 +265,7 @@ impl<'a> Text<'a> {
             font,
             font_size,
             rect,
-            x_align,
+            justify,
             y_align,
             line_spacing,
         } = self;
@@ -278,7 +278,7 @@ impl<'a> Text<'a> {
         let line_infos = line_infos.iter().cloned();
         let lines = line_infos.clone().map(|info| &text[info.byte_range()]);
         let line_rects = text::line::rects(line_infos, font_size, rect,
-                                           x_align, y_align, line_spacing);
+                                           justify, y_align, line_spacing);
 
         // Clear the existing glyphs and fill the buffer with glyphs for this Text.
         positioned_glyphs.clear();
@@ -490,7 +490,7 @@ impl<'a> Primitives<'a> {
                     let color = style.color(theme);
                     let font_size = style.font_size(theme);
                     let line_spacing = style.line_spacing(theme);
-                    let x_align = style.text_align(theme);
+                    let justify = style.justify(theme);
                     let y_align = Align::End;
 
                     let text = Text {
@@ -501,7 +501,7 @@ impl<'a> Primitives<'a> {
                         font: font,
                         font_size: font_size,
                         rect: rect,
-                        x_align: x_align,
+                        justify: justify,
                         y_align: y_align,
                         line_spacing: line_spacing,
                     };
@@ -603,7 +603,7 @@ impl<'a> Primitives<'a> {
                         font,
                         font_size,
                         rect,
-                        x_align,
+                        justify,
                         y_align,
                         line_spacing,
                         ..
@@ -630,7 +630,7 @@ impl<'a> Primitives<'a> {
                         font: font.clone(),
                         font_size: font_size,
                         rect: rect,
-                        x_align: x_align,
+                        justify: justify,
                         y_align: y_align,
                         line_spacing: line_spacing,
                     };
@@ -736,7 +736,7 @@ impl<'a> WalkOwnedPrimitives<'a> {
                         window_dim,
                         font_size,
                         rect,
-                        x_align,
+                        justify,
                         y_align,
                         line_spacing,
                     } = *text;
@@ -752,7 +752,7 @@ impl<'a> WalkOwnedPrimitives<'a> {
                         font: font,
                         font_size: font_size,
                         rect: rect,
-                        x_align: x_align,
+                        justify: justify,
                         y_align: y_align,
                         line_spacing: line_spacing,
                     };

--- a/src/text.rs
+++ b/src/text.rs
@@ -28,6 +28,21 @@ pub struct Lines<'a, I> {
     ranges: I,
 }
 
+/// A type used for referring to typographic alignment of `Text`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Justify {
+    /// Align text to the start of the bounding `Rect`'s *x* axis.
+    Left,
+    /// Symmetrically align text along the *y* axis.
+    Center,
+    /// Align text to the end of the bounding `Rect`'s *x* axis.
+    Right,
+    // /// Align wrapped text to both the start and end of the bounding `Rect`s *x* axis.
+    // ///
+    // /// Extra space is added between words in order to achieve this alignment.
+    // TODO: Full,
+}
+
 
 /// Determine the total height of a block of text with the given number of lines, font size and
 /// `line_spacing` (the space that separates each line of text).
@@ -691,7 +706,7 @@ pub mod cursor {
                                       line_infos: &'a [super::line::Info],
                                       font: &'a super::Font,
                                       font_size: FontSize,
-                                      x_align: Align,
+                                      x_align: super::Justify,
                                       y_align: Align,
                                       line_spacing: Scalar,
                                       rect: Rect) -> XysPerLineFromText<'a>
@@ -941,7 +956,7 @@ pub mod line {
     #[derive(Clone)]
     pub struct Rects<I> {
         infos: I,
-        x_align: Align,
+        x_align: super::Justify,
         line_spacing: Scalar,
         next: Option<Rect>,
     }
@@ -1272,7 +1287,7 @@ pub mod line {
     pub fn rects<I>(mut infos: I,
                     font_size: FontSize,
                     bounding_rect: Rect,
-                    x_align: Align,
+                    x_align: super::Justify,
                     y_align: Align,
                     line_spacing: Scalar) -> Rects<I>
         where I: Iterator<Item=Info> + ExactSizeIterator,
@@ -1283,9 +1298,9 @@ pub mod line {
             // Calculate the `x` `Range` of the first line `Rect`.
             let range = Range::new(0.0, first_info.width);
             let x = match x_align {
-                Align::Start => range.align_start_of(bounding_rect.x),
-                Align::Middle => range.align_middle_of(bounding_rect.x),
-                Align::End => range.align_end_of(bounding_rect.x),
+                super::Justify::Left => range.align_start_of(bounding_rect.x),
+                super::Justify::Center => range.align_middle_of(bounding_rect.x),
+                super::Justify::Right => range.align_end_of(bounding_rect.x),
             };
 
             // Calculate the `y` `Range` of the first line `Rect`.
@@ -1437,9 +1452,9 @@ pub mod line {
                     let x = {
                         let range = Range::new(0.0, info.width);
                         match x_align {
-                            Align::Start => range.align_start_of(line_rect.x),
-                            Align::Middle => range.align_middle_of(line_rect.x),
-                            Align::End => range.align_end_of(line_rect.x),
+                            super::Justify::Left => range.align_start_of(line_rect.x),
+                            super::Justify::Center => range.align_middle_of(line_rect.x),
+                            super::Justify::Right => range.align_end_of(line_rect.x),
                         }
                     };
 

--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -13,8 +13,9 @@ use {
     UiCell,
     Widget,
 };
-use position::{self, Align, Dimensions, Padding, Place, Position, Range, Rect, Scalar};
+use position::{self, Dimensions, Padding, Place, Position, Range, Rect, Scalar};
 use position::Direction::{Forwards, Backwards};
+use text;
 use widget;
 
 
@@ -87,8 +88,8 @@ widget_style! {
         - title_bar_maybe_wrap: Option<widget::text::Wrap> { Some(widget::text::Wrap::Whitespace) }
         /// The distance between lines for multi-line title bar text.
         - title_bar_line_spacing: Scalar { 1.0 }
-        /// The horizontal alignment of the title bar text.
-        - title_bar_text_align: Align { Align::Middle }
+        /// The label's typographic alignment over the *x* axis.
+        - title_bar_justify: text::Justify { text::Justify::Center }
     }
 }
 
@@ -294,13 +295,13 @@ impl<'a> Widget for Canvas<'a> {
             let color = style.title_bar_color(&ui.theme).unwrap_or(color);
             let font_size = style.title_bar_font_size(&ui.theme);
             let label_color = style.title_bar_text_color(&ui.theme);
-            let text_align = style.title_bar_text_align(&ui.theme);
+            let justify = style.title_bar_justify(&ui.theme);
             let line_spacing = style.title_bar_line_spacing(&ui.theme);
             let maybe_wrap = style.title_bar_maybe_wrap(&ui.theme);
             widget::TitleBar::new(label, state.ids.rectangle)
                 .and_mut(|title_bar| {
                     title_bar.style.maybe_wrap = Some(maybe_wrap);
-                    title_bar.style.text_align = Some(text_align);
+                    title_bar.style.justify = Some(justify);
                 })
                 .color(color)
                 .border(border)

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -1,7 +1,7 @@
 //! The `DropDownList` and related items.
 
 use {Color, Colorable, FontSize, Borderable, Labelable, Positionable, Sizeable};
-use position::{Align, Scalar};
+use position::{self, Align, Scalar};
 use text;
 use utils;
 use widget::{self, Widget};
@@ -37,8 +37,12 @@ widget_style! {
         - label_color: Color { theme.label_color }
         /// Font size for the item labels.
         - label_font_size: FontSize { theme.font_size_medium }
-        /// The label's alignment over the *x* axis.
-        - label_x_align: Align { Align::Middle }
+        /// The label's typographic alignment over the *x* axis.
+        - label_justify: text::Justify { text::Justify::Center }
+        /// The label's position relative to its `Button` along the *x* axis.
+        - label_x: position::Relative { position::Relative::Align(Align::Middle) }
+        /// The label's position relative to its `Button` along the *y* axis.
+        - label_y: position::Relative { position::Relative::Align(Align::Middle) }
         /// Maximum height of the Open menu before the scrollbar appears.
         - maybe_max_visible_height: Option<MaxHeight> { None }
         /// The position of the scrollbar in the case that the list is scrollable.
@@ -143,6 +147,35 @@ impl<'a, T> DropDownList<'a, T> {
         self
     }
 
+    /// Align the labels to the left of their `Button`s' surface.
+    pub fn left_justify_label(mut self) -> Self {
+        self.style.label_justify = Some(text::Justify::Left);
+        self
+    }
+
+    /// Align the labels to the right of their `Button`s' surface.
+    pub fn right_justify_label(mut self) -> Self {
+        self.style.label_justify = Some(text::Justify::Right);
+        self
+    }
+
+    /// Center the labels to the their `Button`s' surface.
+    pub fn center_justify_label(mut self) -> Self {
+        self.style.label_justify = Some(text::Justify::Center);
+        self
+    }
+
+    /// Specify the label's position relatively to `Button` along the *x* axis.
+    pub fn label_x(mut self, x: position::Relative) -> Self {
+        self.style.label_x = Some(x);
+        self
+    }
+
+    /// Specify the label's position relatively to `Button` along the *y* axis.
+    pub fn label_y(mut self, y: position::Relative) -> Self {
+        self.style.label_y = Some(y);
+        self
+    }
 
 }
 
@@ -318,7 +351,9 @@ impl Style {
             border_color: self.border_color,
             label_color: self.label_color,
             label_font_size: self.label_font_size,
-            label_x_align: self.label_x_align,
+            label_justify: self.label_justify,
+            label_x: self.label_x,
+            label_y: self.label_y,
             label_font_id: self.label_font_id,
         }
     }

--- a/src/widget/file_navigator/directory_view.rs
+++ b/src/widget/file_navigator/directory_view.rs
@@ -286,6 +286,7 @@ impl<'a> Widget for DirectoryView<'a> {
 
                 // Instantiate a `Button` for each item.
                 list_select::Event::Item(item) => {
+                    use position::{Place, Relative};
                     let entry = &state.entries[item.i];
                     let is_selected = entry.is_selected;
                     let is_directory = entry.path.is_dir();
@@ -317,7 +318,8 @@ impl<'a> Widget for DirectoryView<'a> {
                         .label(&entry_name)
                         .label_color(text_color)
                         .label_font_size(font_size)
-                        .align_label_left();
+                        .label_x(Relative::Place(Place::Start(Some(font_size as Scalar))))
+                        .left_justify_label();
                     item.set(button, ui);
                 },
 

--- a/src/widget/number_dialer.rs
+++ b/src/widget/number_dialer.rs
@@ -386,7 +386,7 @@ impl<'a, T> Widget for NumberDialer<'a, T>
                 .graphics_for(id)
                 .color(label_color)
                 .font_size(font_size)
-                .align_text_middle()
+                .center_justify()
                 .parent(id)
                 .set(slot.text_id, &mut ui);
 

--- a/src/widget/primitive/text.rs
+++ b/src/widget/primitive/text.rs
@@ -1,19 +1,19 @@
 //! The primitive widget used for displaying text.
 
 use {Color, Colorable, FontSize, Ui, Widget};
-use position::{Align, Dimension, Scalar};
+use position::{Dimension, Scalar};
 use std;
 use text;
 use utils;
 use widget;
 
 
-/// Displays some given text centred within a rectangular area.
+/// Displays some given text centered within a rectangular area.
 ///
 /// By default, the rectangular dimensions are fit to the area occuppied by the text.
 ///
 /// If some horizontal dimension is given, the text will automatically wrap to the width and align
-/// in accordance with the produced **Align**.
+/// in accordance with the produced **Alignment**.
 pub struct Text<'a> {
     /// Data necessary and common for all widget builder types.
     pub common: widget::CommonBuilder,
@@ -35,7 +35,7 @@ widget_style!{
         /// The spacing between consecutive lines.
         - line_spacing: Scalar { 1.0 }
         /// Alignment of the text along the *x* axis.
-        - text_align: Align { Align::Start }
+        - justify: text::Justify { text::Justify::Left }
         /// The id of the font to use for rendring and layout.
         - font_id: Option<text::font::Id> { theme.font_id }
         // /// The line styling for the text.
@@ -114,23 +114,23 @@ impl<'a> Text<'a> {
     }
 
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_left(self) -> Self {
-        self.align_text_to(Align::Start)
+    pub fn left_justify(self) -> Self {
+        self.justify(text::Justify::Left)
     }
 
     /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_middle(self) -> Self {
-        self.align_text_to(Align::Middle)
+    pub fn center_justify(self) -> Self {
+        self.justify(text::Justify::Center)
     }
 
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_right(self) -> Self {
-        self.align_text_to(Align::End)
+    pub fn right_justify(self) -> Self {
+        self.justify(text::Justify::Right)
     }
 
     builder_methods!{
         pub font_size { style.font_size = Some(FontSize) }
-        pub align_text_to { style.text_align = Some(Align) }
+        pub justify { style.justify = Some(text::Justify) }
         pub line_spacing { style.line_spacing = Some(Scalar) }
     }
 

--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -3,7 +3,7 @@
 use {Color, Colorable, FontSize, Borderable, Positionable, Sizeable, Widget};
 use event;
 use input;
-use position::{Align, Range, Rect, Scalar};
+use position::{Range, Rect, Scalar};
 use text;
 use widget;
 
@@ -35,8 +35,8 @@ widget_style!{
         - text_color: Color { theme.label_color }
         /// The font size for the text.
         - font_size: FontSize { theme.font_size_medium }
-        /// The horizontal alignment of the text.
-        - x_align: Align { Align::Start }
+        /// The typographic alignment of the text.
+        - justify: text::Justify { text::Justify::Left }
         /// The font used for the `Text`.
         - font_id: Option<text::font::Id> { theme.font_id }
     }
@@ -66,18 +66,18 @@ impl<'a> TextBox<'a> {
     }
 
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_left(self) -> Self {
-        self.x_align_text(Align::Start)
+    pub fn left_justify(self) -> Self {
+        self.justify(text::Justify::Left)
     }
 
     /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_middle(self) -> Self {
-        self.x_align_text(Align::Middle)
+    pub fn center_justify(self) -> Self {
+        self.justify(text::Justify::Center)
     }
 
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_right(self) -> Self {
-        self.x_align_text(Align::End)
+    pub fn right_justify(self) -> Self {
+        self.justify(text::Justify::Right)
     }
 
     /// Specify the font used for displaying the text.
@@ -89,7 +89,7 @@ impl<'a> TextBox<'a> {
     builder_methods!{
         pub text_color { style.text_color = Some(Color) }
         pub font_size { style.font_size = Some(FontSize) }
-        pub x_align_text { style.x_align = Some(Align) }
+        pub justify { style.justify = Some(text::Justify) }
         pub pad_text { style.text_padding = Some(Scalar) }
     }
 
@@ -135,7 +135,7 @@ impl<'a> Widget for TextBox<'a> {
         let font_size = style.font_size(ui.theme());
         let border = style.border(ui.theme());
         let text_padding = style.text_padding(ui.theme());
-        let x_align = style.x_align(ui.theme());
+        let justify = style.justify(ui.theme());
 
         let text_rect = {
             let w = rect.x.pad(border + text_padding).len();
@@ -166,7 +166,7 @@ impl<'a> Widget for TextBox<'a> {
             .xy(text_rect.xy())
             .font_size(font_size)
             .color(text_color)
-            .x_align_text(x_align)
+            .justify(justify)
             .parent(id)
             .set(state.ids.text_edit, ui)
         {

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -29,7 +29,7 @@ widget_style!{
         /// The font size for the text.
         - font_size: FontSize { theme.font_size_medium }
         /// The horizontal alignment of the text.
-        - x_align: Align { Align::Start }
+        - justify: text::Justify { text::Justify::Left }
         /// The vertical alignment of the text.
         - y_align: Align { Align::End }
         /// The vertical space between each line of text.
@@ -117,18 +117,18 @@ impl<'a> TextEdit<'a> {
     }
 
     /// Align the text to the left of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_left(self) -> Self {
-        self.x_align_text(Align::Start)
+    pub fn left_justify(self) -> Self {
+        self.justify(text::Justify::Left)
     }
 
     /// Align the text to the middle of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_x_middle(self) -> Self {
-        self.x_align_text(Align::Middle)
+    pub fn center_justify(self) -> Self {
+        self.justify(text::Justify::Center)
     }
 
     /// Align the text to the right of its bounding **Rect**'s *x* axis range.
-    pub fn align_text_right(self) -> Self {
-        self.x_align_text(Align::End)
+    pub fn right_justify(self) -> Self {
+        self.justify(text::Justify::Right)
     }
 
     /// Align the text to the left of its bounding **Rect**'s *y* axis range.
@@ -148,7 +148,7 @@ impl<'a> TextEdit<'a> {
 
     /// Align the text to the middle of its bounding **Rect**.
     pub fn align_text_middle(self) -> Self {
-        self.align_text_x_middle().align_text_y_middle()
+        self.center_justify().align_text_y_middle()
     }
 
     /// Specify the font used for displaying the text.
@@ -159,7 +159,7 @@ impl<'a> TextEdit<'a> {
 
     builder_methods!{
         pub font_size { style.font_size = Some(FontSize) }
-        pub x_align_text { style.x_align = Some(Align) }
+        pub justify { style.justify = Some(text::Justify) }
         pub y_align_text { style.y_align = Some(Align) }
         pub line_wrap { style.line_wrap = Some(Wrap) }
         pub line_spacing { style.line_spacing = Some(Scalar) }
@@ -254,7 +254,7 @@ impl<'a> Widget for TextEdit<'a> {
 
         let font_size = style.font_size(ui.theme());
         let line_wrap = style.line_wrap(ui.theme());
-        let x_align = style.x_align(ui.theme());
+        let justify = style.justify(ui.theme());
         let y_align = style.y_align(ui.theme());
         let line_spacing = style.line_spacing(ui.theme());
         let restrict_to_height = style.restrict_to_height(ui.theme());
@@ -319,7 +319,7 @@ impl<'a> Widget for TextEdit<'a> {
             -> Option<(Scalar, Range)>
         {
             let xys_per_line = text::cursor::xys_per_line_from_text(text, line_infos, font,
-                                                                    font_size, x_align, y_align,
+                                                                    font_size, justify, y_align,
                                                                     line_spacing, rect);
             text::cursor::xy_at(xys_per_line, cursor_idx)
         };
@@ -334,7 +334,7 @@ impl<'a> Widget for TextEdit<'a> {
             -> Option<(text::cursor::Index, Point)>
         {
             let xys_per_line = text::cursor::xys_per_line_from_text(text, line_infos, font,
-                                                                    font_size, x_align, y_align,
+                                                                    font_size, justify, y_align,
                                                                     line_spacing, rect);
             text::cursor::closest_cursor_index_and_xy(xy, xys_per_line)
         };
@@ -347,7 +347,7 @@ impl<'a> Widget for TextEdit<'a> {
                                             font: &text::Font| -> Option<text::cursor::Index>
         {
             let mut xys_per_line = text::cursor::xys_per_line_from_text(text, line_infos, font,
-                                                                        font_size, x_align, y_align,
+                                                                        font_size, justify, y_align,
                                                                         line_spacing, rect);
             xys_per_line.nth(line_idx).and_then(|(line_xs,_)| {
                 let (char_idx,_) = text::cursor::closest_cursor_index_on_line(x_pos,line_xs);
@@ -770,7 +770,7 @@ impl<'a> Widget for TextEdit<'a> {
             .font_id(font_id)
             .wh(text_rect.dim())
             .xy(text_rect.xy())
-            .align_text_to(x_align)
+            .justify(justify)
             .parent(id)
             .graphics_for(id)
             .color(color)
@@ -841,7 +841,7 @@ impl<'a> Widget for TextEdit<'a> {
                 let line_infos = state.line_infos.iter().cloned();
                 let lines = line_infos.clone().map(|info| &text[info.byte_range()]);
                 let line_rects = text::line::rects(line_infos.clone(), font_size, rect,
-                                                   x_align, y_align, line_spacing);
+                                                   justify, y_align, line_spacing);
                 let lines_with_rects = lines.zip(line_rects.clone());
                 let font = ui.fonts.get(font_id).unwrap();
                 text::line::selected_rects(lines_with_rects, font, font_size, start, end).collect()


### PR DESCRIPTION
Originally, `Align` was used to represent both widget alignment and
typographic alignment. The addition of the `text::Justify` type, along
with renaming the associated methods, should help to more clearly
distinguish between the two kinds of alignment. Closes #922.

This also adds `label_x` and `label_y` builder methods to the `Button`
type in order to allow for greater flexibility over label positioning.
@tl8roy this closes #905 