### PR TITLE
Add `#![deny(unsafe_code)]` to the crate root

### DIFF
--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -103,7 +103,11 @@ pub struct Vertex {
     pub color: [f32; 4],
 }
 
-implement_vertex!(Vertex, position, tex_coords, color, mode);
+#[allow(unsafe_code)]
+mod vertex_impl {
+    use super::Vertex;
+    implement_vertex!(Vertex, position, tex_coords, color, mode);
+}
 
 /// Draw text from the text cache texture `tex` in the fragment shader.
 pub const MODE_TEXT: u32 = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! If you are new to Conrod, we recommend checking out [The Guide](./guide/index.html).
 
+#![forbid(unsafe_code)]
 #![deny(missing_copy_implementations)]
 #![warn(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! If you are new to Conrod, we recommend checking out [The Guide](./guide/index.html).
 
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![deny(missing_copy_implementations)]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Conrod does not require unsafe and should have no need for FFI.

This makes it clear to users that memory-safety related bugs should not
originate from conrod.

Closes #544.