### PR TITLE
Add a simple "Hello World!" text example.

### DIFF
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -69,7 +69,7 @@ mod feature {
                 }
             }
 
-            // Instnatiate all widgets in the GUI.
+            // Instantiate all widgets in the GUI.
             {
                 let ui = &mut ui.set_widgets();
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -27,7 +27,7 @@ mod feature {
         let display = glium::glutin::WindowBuilder::new()
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
-            .with_title("Click me!")
+            .with_title("Hello Conrod!")
             .build_glium()
             .unwrap();
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,0 +1,126 @@
+//! A simple example that demonstrates using conrod within a basic `winit` window loop, using
+//! `glium` to render the `conrod::render::Primitives` to screen.
+//!
+//! Note that the event loop that we create in this example behaves the same as the example
+//! `EventLoop` in the `examples/support` module. It has been inlined in order to provide an
+//! example that does not depend on the `support` module.
+
+#[cfg(all(feature="winit", feature="glium"))] #[macro_use] extern crate conrod;
+
+fn main() {
+    feature::main();
+}
+
+#[cfg(all(feature="winit", feature="glium"))]
+mod feature {
+    extern crate find_folder;
+    use conrod::{self, widget, Colorable, Positionable, Sizeable, Widget};
+    use conrod::backend::glium::glium;
+    use conrod::backend::glium::glium::{DisplayBuild, Surface};
+    use std;
+
+    pub fn main() {
+        const WIDTH: u32 = 400;
+        const HEIGHT: u32 = 200;
+
+        // Build the window.
+        let display = glium::glutin::WindowBuilder::new()
+            .with_vsync()
+            .with_dimensions(WIDTH, HEIGHT)
+            .with_title("Click me!")
+            .build_glium()
+            .unwrap();
+
+        // construct our `Ui`.
+        let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
+
+        // Generate the widget identifiers.
+        widget_ids!(struct Ids { text, circle });
+        let ids = Ids::new(ui.widget_id_generator());
+
+        // Add a `Font` to the `Ui`'s `font::Map` from file.
+        const FONT_PATH: &'static str =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/assets/fonts/NotoSans/NotoSans-Regular.ttf");
+        ui.fonts.insert_from_file(FONT_PATH).unwrap();
+
+        // A type used for converting `conrod::render::Primitives` into `Command`s that can be used
+        // for drawing to the glium `Surface`.
+        let mut renderer = conrod::backend::glium::Renderer::new(&display).unwrap();
+
+        // The image map describing each of our widget->image mappings (in our case, none).
+        let image_map = conrod::image::Map::<glium::texture::Texture2d>::new();
+
+        // Poll events from the window.
+        let mut last_update = std::time::Instant::now();
+        let mut ui_needs_update = true;
+        'main: loop {
+
+            // We don't want to loop any faster than 60 FPS, so wait until it has been at least
+            // 16ms since the last yield.
+            let sixteen_ms = std::time::Duration::from_millis(16);
+            let duration_since_last_update = std::time::Instant::now().duration_since(last_update);
+            if duration_since_last_update < sixteen_ms {
+                std::thread::sleep(sixteen_ms - duration_since_last_update);
+            }
+
+            // Collect all pending events.
+            let mut events: Vec<_> = display.poll_events().collect();
+
+            // If there are no events and the `Ui` does not need updating, wait for the next event.
+            if events.is_empty() && !ui_needs_update {
+                events.extend(display.wait_events().next());
+            }
+
+            // Reset the needs_update flag and time this update.
+            ui_needs_update = false;
+            last_update = std::time::Instant::now();
+
+            // Handle all events.
+            for event in events {
+
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = conrod::backend::winit::convert(event.clone(), &display) {
+                    ui.handle_event(event);
+                    ui_needs_update = true;
+                }
+
+                match event {
+                    // Break from the loop upon `Escape`.
+                    glium::glutin::Event::KeyboardInput(_, _, Some(glium::glutin::VirtualKeyCode::Escape)) |
+                    glium::glutin::Event::Closed =>
+                        break 'main,
+                    _ => {},
+                }
+            }
+
+            // Instnatiate all widgets in the GUI.
+            {
+                let ui = &mut ui.set_widgets();
+
+                // "Hello World!" in the middle of the screen.
+                widget::Text::new("Hello World!")
+                    .middle_of(ui.window)
+                    .color(conrod::color::WHITE)
+                    .font_size(32)
+                    .set(ids.text, ui);
+            }
+
+            // Render the `Ui` and then display it on the screen.
+            if let Some(primitives) = ui.draw_if_changed() {
+                renderer.fill(&display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(&display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(not(all(feature="winit", feature="glium")))]
+mod feature {
+    pub fn main() {
+        println!("This example requires the `winit` and `glium` features. \
+                 Try running `cargo run --release --features=\"winit glium\" --example <example_name>`");
+    }
+}

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -93,7 +93,7 @@ mod feature {
                 }
             }
 
-            // Instnatiate all widgets in the GUI.
+            // Instantiate all widgets in the GUI.
             {
                 let ui = &mut ui.set_widgets();
 


### PR DESCRIPTION
This example aims to be a simple as possible demonstration of how to use
conrod with a basic winit loop using glium to draw to the screen. The
example avoids using the `examples/support` module in order to remain
copy-paste friendly. In turn, the `EventLoop` from the
`examples/support` module has been inlined into the main function.

<img width="512" alt="screen shot 2017-02-02 at 3 24 29 pm" src="https://cloud.githubusercontent.com/assets/4587373/22537103/b6ea0da6-e95b-11e6-81a2-6e0cf61fe3d3.png">

Closes #935 
Closes #932 

cc @suhr