### PR TITLE
Fix bug where hiDPI was not properly handled in winit feature

### DIFF
--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -375,7 +375,7 @@ impl EventLoop {
     pub fn new() -> Self {
         EventLoop {
             last_update: std::time::Instant::now(),
-            ui_needs_update: false,
+            ui_needs_update: true,
         }
     }
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -76,8 +76,11 @@ pub fn convert<W>(e: winit::Event, window: &W) -> Option<Input>
 
     match e {
 
-        winit::Event::Resized(w, h) =>
-            Some(Input::Resize(w, h).into()),
+        winit::Event::Resized(w, h) => {
+            let w = (w as Scalar / dpi_factor) as u32;
+            let h = (h as Scalar / dpi_factor) as u32;
+            Some(Input::Resize(w, h).into())
+        },
 
         winit::Event::ReceivedCharacter(ch) => {
             let string = match ch {


### PR DESCRIPTION
Also changes the `examples/support` module to always emit an update at
the start of the loop whether or not input has been received to make
sure the GUI is updated and drawn.