### PR TITLE
Add support for multi-touch events. Add `Touch` and `Tap` variants to `Ui` and `Widget` events.

### DIFF
--- a/src/backend/piston/event.rs
+++ b/src/backend/piston/event.rs
@@ -16,22 +16,35 @@ pub fn convert<E>(event: E, win_w: Scalar, win_h: Scalar) -> Option<Input>
 
     if let Some(xy) = event.mouse_cursor_args() {
         let (x, y) = translate_coords(xy);
-        return Some(Input::Move(input::Motion::MouseCursor(x, y)));
+        return Some(Input::Motion(input::Motion::MouseCursor { x: x, y: y }));
     }
 
     if let Some(rel_xy) = event.mouse_relative_args() {
         let (rel_x, rel_y) = translate_coords(rel_xy);
-        return Some(Input::Move(input::Motion::MouseRelative(rel_x, rel_y)));
+        return Some(Input::Motion(input::Motion::MouseRelative { x: rel_x, y: rel_y }));
     }
 
     if let Some(xy) = event.mouse_scroll_args() {
         // Invert the scrolling of the *y* axis as *y* is up in conrod.
         let (x, y) = (xy[0], -xy[1]);
-        return Some(Input::Move(input::Motion::MouseScroll(x, y)));
+        return Some(Input::Motion(input::Motion::Scroll { x: x, y: y }));
     }
 
     if let Some(args) = event.controller_axis_args() {
-        return Some(Input::Move(input::Motion::ControllerAxis(args)));
+        return Some(Input::Motion(input::Motion::ControllerAxis(args)));
+    }
+
+    if let Some(args) = event.touch_args() {
+        let id = input::touch::Id::new(args.id as u64);
+        let xy = [args.x, args.y];
+        let phase = match args.touch {
+            ::piston_input::Touch::Start => input::touch::Phase::Start,
+            ::piston_input::Touch::Move => input::touch::Phase::Move,
+            ::piston_input::Touch::Cancel => input::touch::Phase::Cancel,
+            ::piston_input::Touch::End => input::touch::Phase::End,
+        };
+        let touch = input::Touch { id: id, xy: xy, phase: phase };
+        return Some(Input::Touch(touch));
     }
 
     if let Some(button) = event.press_args() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -64,8 +64,10 @@ pub enum Input {
     Release(input::Button),
     /// The window was received to the given dimensions.
     Resize(u32, u32),
-    /// Some motion input was received (e.g. moving mouse, joystick or touch pad).
-    Move(input::Motion),
+    /// Some motion input was received (e.g. moving mouse or joystick axis).
+    Motion(input::Motion),
+    /// Input from a touch surface/screen.
+    Touch(input::Touch),
     /// Text input was received, usually via the keyboard.
     Text(String),
     /// The window was focused or lost focus.
@@ -313,7 +315,8 @@ impl Move {
     /// Returns a copy of the `Move` relative to the given `xy`
     pub fn relative_to(&self, xy: Point) -> Move {
         let motion = match self.motion {
-            input::Motion::MouseCursor(x, y) => input::Motion::MouseCursor(x - xy[0], y - xy[1]),
+            input::Motion::MouseCursor { x, y } =>
+                input::Motion::MouseCursor { x: x - xy[0], y: y - xy[1] },
             motion => motion,
         };
         Move {
@@ -439,6 +442,18 @@ impl Drag {
     }
 }
 
+
+impl From<input::Motion> for Input {
+    fn from(motion: input::Motion) -> Self {
+        Input::Motion(motion)
+    }
+}
+
+impl From<input::Touch> for Input {
+    fn from(touch: input::Touch) -> Self {
+        Input::Touch(touch)
+    }
+}
 
 impl From<Ui> for Event {
     fn from(ui: Ui) -> Self {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -39,6 +39,19 @@ pub use piston_input::{
 };
 
 
+/// Sources from which user input may be received.
+///
+/// We use these to track which sources of input are being captured by which widget.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Source {
+    /// Mouse input (i.e. movement, buttons).
+    Mouse,
+    /// Keyboard input.
+    Keyboard,
+    /// Input from a finger on a touch screen/surface.
+    Touch(self::touch::Id),
+}
+
 /// Different kinds of motion input.
 #[allow(missing_docs)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -104,6 +117,18 @@ pub mod touch {
         /// Construct a new identifier.
         pub fn new(id: u64) -> Self {
             Id(id)
+        }
+
+    }
+
+    impl Touch {
+
+        /// Returns a copy of the `Touch` relative to the given `xy`.
+        pub fn relative_to(&self, xy: Point) -> Self {
+            Touch {
+                xy: [self.xy[0] - xy[0], self.xy[1] - xy[1]],
+                ..*self
+            }
         }
 
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -19,8 +19,10 @@ pub mod state;
 pub mod widget;
 pub mod global;
 
+use Scalar;
 pub use self::state::State;
 pub use self::global::Global;
+pub use self::touch::Touch;
 pub use self::widget::Widget;
 
 #[doc(inline)]
@@ -32,9 +34,78 @@ pub use piston_input::{
     ControllerAxisArgs,
     keyboard,
     Key,
-    Motion,
     MouseButton,
     RenderArgs,
-    Touch,
-    TouchArgs,
 };
+
+
+/// Different kinds of motion input.
+#[allow(missing_docs)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Motion {
+    /// Absolute cursor position within the window.
+    ///
+    /// For more details on co-ordinate orientation etc, see the `Input` docs.
+    MouseCursor { x: Scalar, y: Scalar },
+    /// Relative mouse movement.
+    MouseRelative { x: Scalar, y: Scalar },
+    /// x and y in scroll ticks.
+    Scroll { x: Scalar, y: Scalar },
+    /// controller axis move event.
+    ControllerAxis(ControllerAxisArgs),
+}
+
+
+/// Touch-related items.
+pub mod touch {
+    use Point;
+
+    /// A type for uniquely identifying the source of a touch interaction.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Id(u64);
+
+    /// The stage of the touch interaction.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+    pub enum Phase {
+        /// The start of a touch interaction.
+        Start,
+        /// A touch moving across a surface.
+        Move,
+        /// The touch interaction was cancelled.
+        Cancel,
+        /// The end of a touch interaction.
+        End,
+    }
+
+    /// Represents a touch interaction.
+    ///
+    /// Each time a user touches the surface with a new finger, a new series of `Touch` events
+    /// `Start`, each with a unique identifier.
+    ///
+    /// For every `Id` there should be at least 2 events with `Start` and `End` (or `Cancel`led)
+    /// `Phase`s.
+    ///
+    /// A `Start` input received with the same `Id` as a previously received `End` does *not*
+    /// indicate that the same finger was used. `Id`s are only used to distinguish between
+    /// overlapping touch interactions.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct Touch {
+        /// The stage of the touch interaction.
+        pub phase: Phase,
+        /// A unique identifier associated with the source of the touch interaction.
+        pub id: Id,
+        /// The location of the touch on the surface/screen. See `Input` docs for information on
+        /// the co-ordinate system.
+        pub xy: Point,
+    }
+
+    impl Id {
+
+        /// Construct a new identifier.
+        pub fn new(id: u64) -> Self {
+            Id(id)
+        }
+
+    }
+
+}

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -9,6 +9,7 @@
 
 use position::Point;
 use self::mouse::Mouse;
+use std;
 use super::keyboard::{NO_MODIFIER, ModifierKey};
 use utils;
 use widget;
@@ -20,10 +21,12 @@ use widget;
 /// the mouse.
 ///
 /// It also includes which widgets, if any, are capturing keyboard and mouse input.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct State {
     /// Mouse position and button state.
     pub mouse: Mouse,
+    /// All in-progress touch interactions.
+    pub touch: std::collections::HashMap<super::touch::Id, self::touch::Touch>,
     /// Which widget, if any, is currently capturing the keyboard
     pub widget_capturing_keyboard: Option<widget::Id>,
     /// Which widget, if any, is currently capturing the mouse
@@ -42,6 +45,7 @@ impl State {
     /// Returns a fresh new input state
     pub fn new() -> State {
         State{
+            touch: std::collections::HashMap::new(),
             mouse: Mouse::new(),
             widget_capturing_keyboard: None,
             widget_capturing_mouse: None,
@@ -55,6 +59,38 @@ impl State {
         self.mouse.xy = utils::vec2_sub(self.mouse.xy, xy);
         self.mouse.buttons = self.mouse.buttons.relative_to(xy);
         self
+    }
+
+}
+
+/// Touch specific state.
+pub mod touch {
+    use position::Point;
+    use std;
+    use widget;
+
+    /// State stored about the start of a `Touch` interaction.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct Start {
+        /// The time at which the `Touch` began.
+        pub time: std::time::Instant,
+        /// The position at which the touch began.
+        pub xy: Point,
+        /// The widget under the beginning of the touch if there was one.
+        ///
+        /// This widget captures the `Touch` input source for its duration.
+        pub widget: Option<widget::Id>,
+    }
+
+    /// All state stored for a `Touch` interaction in progress.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct Touch {
+        /// The `Start` of the touch interaction.
+        pub start: Start,
+        /// The last recorded position of the finger on the window.
+        pub xy: Point,
+        /// The widget currently being touched.
+        pub widget: Option<widget::Id>,
     }
 
 }

--- a/src/input/widget.rs
+++ b/src/input/widget.rs
@@ -120,6 +120,13 @@ pub struct ButtonClicks<'a> {
     button: input::MouseButton,
 }
 
+/// An `Iterator` yielding all touch screen taps occuring within the given sequence of
+/// `widget::Event`s.
+#[derive(Clone)]
+pub struct Taps<'a> {
+    events: Events<'a>,
+}
+
 /// An iterator that yields all `event::Drag` events yielded by the `Events` iterator.
 ///
 /// Only events that occurred while the widget was capturing the device that did the dragging will
@@ -215,6 +222,14 @@ impl<'a> Widget<'a> {
     /// released over the widget.
     pub fn clicks(&self) -> Clicks<'a> {
         Clicks { events: self.events() }
+    }
+
+    /// Filters all events yielded by `Self::events` for all `event::Tap`s.
+    ///
+    /// A _tap_ is determined to have occured if a touch interaction both started and ended over
+    /// the widget.
+    pub fn taps(&self) -> Taps<'a> {
+        Taps { events: self.events() }
     }
 
     /// Produces an iterator that yields all `event::Drag` events yielded by the `Events` iterator.
@@ -589,6 +604,18 @@ impl<'a> Iterator for ButtonClicks<'a> {
         while let Some(click) = self.clicks.next() {
             if self.button == click.button {
                 return Some(click);
+            }
+        }
+        None
+    }
+}
+
+impl<'a> Iterator for Taps<'a> {
+    type Item = event::Tap;
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(event) = self.events.next() {
+            if let event::Widget::Tap(tap) = event {
+                return Some(tap);
             }
         }
         None

--- a/src/input/widget.rs
+++ b/src/input/widget.rs
@@ -416,35 +416,19 @@ impl<'a> Iterator for Events<'a> {
         while let Some(ui_event) = self.ui_events.next() {
             match *ui_event {
 
-                // Mouse capturing.
-                event::Ui::WidgetCapturesMouse(idx) => {
+                // Input source capturing.
+                event::Ui::WidgetCapturesInputSource(idx, source) => {
                     self.capturing_mouse = Some(idx);
                     if idx == self.idx {
-                        return Some(event::Widget::CapturesMouse);
+                        return Some(event::Widget::CapturesInputSource(source));
                     }
                 },
-                event::Ui::WidgetUncapturesMouse(idx) => {
+                event::Ui::WidgetUncapturesInputSource(idx, source) => {
                     if Some(idx) == self.capturing_mouse {
                         self.capturing_mouse = None;
                     }
                     if idx == self.idx {
-                        return Some(event::Widget::UncapturesMouse);
-                    }
-                },
-
-                // Keyboard capturing.
-                event::Ui::WidgetCapturesKeyboard(idx) => {
-                    self.capturing_keyboard = Some(idx);
-                    if idx == self.idx {
-                        return Some(event::Widget::CapturesKeyboard);
-                    }
-                },
-                event::Ui::WidgetUncapturesKeyboard(idx) => {
-                    if Some(idx) == self.capturing_keyboard {
-                        self.capturing_keyboard = None;
-                    }
-                    if idx == self.idx {
-                        return Some(event::Widget::UncapturesKeyboard);
+                        return Some(event::Widget::UncapturesInputSource(source));
                     }
                 },
 
@@ -454,8 +438,11 @@ impl<'a> Iterator for Events<'a> {
                 event::Ui::Text(idx, ref text) if idx == Some(self.idx) =>
                     return Some(text.clone().into()),
 
-                event::Ui::Move(idx, ref move_) if idx == Some(self.idx) =>
-                    return Some(move_.clone().into()),
+                event::Ui::Motion(idx, ref motion) if idx == Some(self.idx) =>
+                    return Some(motion.clone().into()),
+
+                event::Ui::Touch(idx, ref touch) if idx == Some(self.idx) =>
+                    return Some(touch.clone().relative_to(self.rect.xy()).into()),
 
                 event::Ui::Press(idx, ref press) if idx == Some(self.idx) =>
                     return Some(press.clone().relative_to(self.rect.xy()).into()),
@@ -468,6 +455,9 @@ impl<'a> Iterator for Events<'a> {
 
                 event::Ui::DoubleClick(idx, ref double_click) if idx == Some(self.idx) =>
                     return Some(double_click.clone().relative_to(self.rect.xy()).into()),
+
+                event::Ui::Tap(idx, ref tap) if idx == Some(self.idx) =>
+                    return Some(tap.clone().relative_to(self.rect.xy()).into()),
 
                 event::Ui::Drag(idx, ref drag) if idx == Some(self.idx) =>
                     return Some(drag.clone().relative_to(self.rect.xy()).into()),

--- a/src/tests/global_input.rs
+++ b/src/tests/global_input.rs
@@ -11,7 +11,7 @@ fn push_event(input: &mut input::Global, event: event::Event) {
 }
 
 fn mouse_move_event(x: Scalar, y: Scalar) -> event::Event {
-    event::Event::Raw(Input::Move(Motion::MouseRelative(x, y)))
+    event::Event::Raw(Input::Motion(Motion::MouseRelative { x: x, y: y }))
 }
 
 
@@ -19,7 +19,7 @@ fn mouse_move_event(x: Scalar, y: Scalar) -> event::Event {
 fn resetting_input_should_set_starting_state_to_current_state() {
     let mut input = input::Global::new();
     push_event(&mut input, event::Event::Raw(Input::Press(Keyboard(Key::LShift))));
-    push_event(&mut input, event::Event::Raw(Input::Move(Motion::MouseScroll(0.0, 50.0))));
+    push_event(&mut input, event::Event::Raw(Input::Motion(Motion::Scroll { x: 0.0, y: 50.0 })));
 
     let expected_start = input.current.clone();
     input.clear_events_and_update_start_state();
@@ -30,7 +30,7 @@ fn resetting_input_should_set_starting_state_to_current_state() {
 fn resetting_input_should_clear_out_events() {
     let mut input = input::Global::new();
     push_event(&mut input, event::Event::Raw(Input::Press(Keyboard(Key::LShift))));
-    push_event(&mut input, event::Event::Raw(Input::Move(Motion::MouseScroll(0.0, 50.0))));
+    push_event(&mut input, event::Event::Raw(Input::Motion(Motion::Scroll { x: 0.0, y: 50.0 })));
     input.clear_events_and_update_start_state();
     assert!(input.events().next().is_none());
 }
@@ -40,7 +40,7 @@ fn resetting_input_should_clear_out_events() {
 fn no_events_should_be_returned_after_reset_is_called() {
     let mut input = input::Global::new();
     push_event(&mut input, event::Event::Raw(Input::Press(Keyboard(Key::RShift))));
-    push_event(&mut input, event::Event::Raw(Input::Move(Motion::MouseScroll(7.0, 88.5))));
+    push_event(&mut input, event::Event::Raw(Input::Motion(Motion::Scroll { x: 7.0, y: 88.5 })));
     push_event(&mut input, event::Event::Raw(Input::Press(Mouse(MouseButton::Left))));
     push_event(&mut input, mouse_move_event(60.0, 30.0));
     push_event(&mut input, event::Event::Raw(Input::Release(Mouse(MouseButton::Left))));

--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -42,7 +42,7 @@ fn move_mouse_to_widget(widget_id: widget::Id, ui: &mut Ui) {
 }
 
 fn move_mouse_to_abs_coordinates(x: f64, y: f64, ui: &mut Ui) {
-    ui.handle_event(Input::Move(Motion::MouseCursor(x, y)));
+    ui.handle_event(Input::Motion(Motion::MouseCursor { x: x, y: y }));
 }
 
 fn test_handling_basic_input_event(ui: &mut Ui, event: Input) {
@@ -120,7 +120,7 @@ fn ui_should_push_input_events_to_aggregator() {
 #[test]
 fn high_level_scroll_event_should_be_created_from_a_raw_mouse_scroll() {
     let mut ui = windowless_ui();
-    ui.handle_event(Input::Move(Motion::MouseScroll(10.0, 33.0)));
+    ui.handle_event(Input::Motion(Motion::Scroll { x: 10.0, y: 33.0 }));
 
     let expected_scroll = event::Scroll{
         x: 10.0,

--- a/src/tests/widget_input.rs
+++ b/src/tests/widget_input.rs
@@ -14,8 +14,9 @@ fn push_event(input: &mut input::Global, event: event::Event) {
 fn mouse_should_return_none_if_another_widget_is_capturing_mouse() {
     let widget_area = Rect::from_corners([10.0, 10.0], [50.0, 50.0]);
     let mut global_input = input::Global::new();
-    push_event(&mut global_input, event::Ui::WidgetCapturesMouse(widget::Id::new(999)).into());
-    push_event(&mut global_input, event::Event::Raw(Input::Move(Motion::MouseRelative(30.0, 30.0))));
+    let source = input::Source::Mouse;
+    push_event(&mut global_input, event::Ui::WidgetCapturesInputSource(widget::Id::new(999), source).into());
+    push_event(&mut global_input, event::Event::Raw(Input::Motion(Motion::MouseRelative { x: 30.0, y: 30. })));
     push_event(&mut global_input, event::Event::Raw(Input::Press(Button::Mouse(MouseButton::Left))));
 
     let widget_input = input::Widget::for_widget(widget::Id::new(2), widget_area, &global_input);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -602,7 +602,7 @@ impl Ui {
             // 1. `Drag`
             // 2. `WidgetUncapturesMouse`
             // 3. `WidgetCapturesMouse`
-            Input::Move(motion) => {
+            Input::Motion(motion) => {
 
                 // Create a `Move` event.
                 let move_ = event::Move {
@@ -615,7 +615,7 @@ impl Ui {
 
                 match motion {
 
-                    Motion::MouseCursor(x, y) => {
+                    Motion::MouseCursor { x, y } => {
 
                         // Check for drag events.
                         let last_mouse_xy = self.global_input.current.mouse.xy;
@@ -647,8 +647,8 @@ impl Ui {
                         track_widget_under_mouse_and_update_capturing(self);
                     },
 
-                    // The mouse was scrolled.
-                    Motion::MouseScroll(x, y) => {
+                    // Some scrolling occurred (e.g. mouse scroll wheel).
+                    Motion::Scroll { x, y } => {
 
                         let mut scrollable_widgets = {
                             let depth_order = &self.depth_order.indices;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -355,7 +355,8 @@ impl Ui {
                 // Check to see if we need to uncapture a widget.
                 if let Some(idx) = ui.global_input.current.widget_capturing_mouse {
                     if widget_under_mouse != Some(idx) {
-                        let event = event::Ui::WidgetUncapturesMouse(idx).into();
+                        let source = input::Source::Mouse;
+                        let event = event::Ui::WidgetUncapturesInputSource(idx, source).into();
                         ui.global_input.push_event(event);
                         ui.global_input.current.widget_capturing_mouse = None;
                     }
@@ -364,7 +365,8 @@ impl Ui {
                 // Check to see if there is a new widget capturing the mouse.
                 if ui.global_input.current.widget_capturing_mouse.is_none() {
                     if let Some(idx) = widget_under_mouse {
-                        let event = event::Ui::WidgetCapturesMouse(idx).into();
+                        let source = input::Source::Mouse;
+                        let event = event::Ui::WidgetCapturesInputSource(idx, source).into();
                         ui.global_input.push_event(event);
                         ui.global_input.current.widget_capturing_mouse = Some(idx);
                     }
@@ -413,16 +415,18 @@ impl Ui {
                         // Check to see if we need to uncapture the keyboard.
                         if let Some(idx) = self.global_input.current.widget_capturing_keyboard {
                             if Some(idx) != self.global_input.current.widget_under_mouse {
-                                let event = event::Ui::WidgetUncapturesKeyboard(idx).into();
-                                self.global_input.push_event(event);
+                                let source = input::Source::Keyboard;
+                                let event = event::Ui::WidgetUncapturesInputSource(idx, source);
+                                self.global_input.push_event(event.into());
                                 self.global_input.current.widget_capturing_keyboard = None;
                             }
                         }
 
                         // Check to see if we need to capture the keyboard.
                         if let Some(idx) = self.global_input.current.widget_under_mouse {
-                            let event = event::Ui::WidgetCapturesKeyboard(idx).into();
-                            self.global_input.push_event(event);
+                            let source = input::Source::Keyboard;
+                            let event = event::Ui::WidgetCapturesInputSource(idx, source);
+                            self.global_input.push_event(event.into());
                             self.global_input.current.widget_capturing_keyboard = Some(idx);
                         }
                     }
@@ -552,8 +556,9 @@ impl Ui {
                     if let MouseButton::Left = mouse_button {
                         if let Some(idx) = self.global_input.current.widget_capturing_mouse {
                             if Some(idx) != self.global_input.current.widget_under_mouse {
-                                let event = event::Ui::WidgetUncapturesMouse(idx).into();
-                                self.global_input.push_event(event);
+                                let source = input::Source::Mouse;
+                                let event = event::Ui::WidgetUncapturesInputSource(idx, source);
+                                self.global_input.push_event(event.into());
                                 self.global_input.current.widget_capturing_mouse = None;
                             }
                         }
@@ -604,13 +609,13 @@ impl Ui {
             // 3. `WidgetCapturesMouse`
             Input::Motion(motion) => {
 
-                // Create a `Move` event.
-                let move_ = event::Move {
+                // Create a `Motion` event.
+                let move_ = event::Motion {
                     motion: motion,
                     modifiers: self.global_input.current.modifiers,
                 };
                 let widget = self.global_input.current.widget_capturing_mouse;
-                let move_event = event::Ui::Move(widget, move_).into();
+                let move_event = event::Ui::Motion(widget, move_).into();
                 self.global_input.push_event(move_event);
 
                 match motion {
@@ -784,7 +789,105 @@ impl Ui {
                 self.global_input.push_event(text_event);
             },
 
-            _ => (),
+            Input::Touch(touch) => match touch.phase {
+
+                input::touch::Phase::Start => {
+                    // Find the widget under the touch.
+                    let widget_under_touch =
+                        graph::algo::pick_widgets(&self.depth_order.indices, touch.xy)
+                            .next(&self.widget_graph, &self.depth_order.indices);
+
+                    // The start of the touch interaction state to be stored.
+                    let start = input::state::touch::Start {
+                        time: std::time::Instant::now(),
+                        xy: touch.xy,
+                        widget: widget_under_touch,
+                    };
+
+                    // The touch interaction state to be stored in the map.
+                    let state = input::state::touch::Touch {
+                        start: start,
+                        xy: touch.xy,
+                        widget: widget_under_touch,
+                    };
+
+                    // Insert the touch state into the map.
+                    self.global_input.current.touch.insert(touch.id, state);
+
+                    // Push touch event.
+                    let event = event::Ui::Touch(widget_under_touch, touch);
+                    self.global_input.push_event(event.into());
+
+                    // Push capture event.
+                    if let Some(widget) = widget_under_touch {
+                        let source = input::Source::Touch(touch.id);
+                        let event = event::Ui::WidgetCapturesInputSource(widget, source);
+                        self.global_input.push_event(event.into());
+                    }
+                },
+
+                input::touch::Phase::Move => {
+
+                    // Update the widget under the touch and return the widget capturing the touch.
+                    let widget = match self.global_input.current.touch.get_mut(&touch.id) {
+                        Some(touch) => {
+                            touch.widget =
+                                graph::algo::pick_widgets(&self.depth_order.indices, touch.xy)
+                                    .next(&self.widget_graph, &self.depth_order.indices);
+                            touch.xy = touch.xy;
+                            touch.start.widget
+                        },
+                        None => None,
+                    };
+                    let event = event::Ui::Touch(widget, touch);
+                    self.global_input.push_event(event.into());
+                },
+
+                input::touch::Phase::Cancel => {
+                    let widget = self.global_input.current.touch.remove(&touch.id).and_then(|t| t.start.widget);
+                    let event = event::Ui::Touch(widget, touch);
+                    self.global_input.push_event(event.into());
+
+                    // Generate an "uncaptures" event if necessary.
+                    if let Some(widget) = widget {
+                        let source = input::Source::Touch(touch.id);
+                        let event = event::Ui::WidgetUncapturesInputSource(widget, source);
+                        self.global_input.push_event(event.into());
+                    }
+                },
+
+                input::touch::Phase::End => {
+                    let old_touch = self.global_input.current.touch.remove(&touch.id).map(|touch| touch);
+                    let widget_capturing = old_touch.as_ref().and_then(|touch| touch.start.widget);
+                    let event = event::Ui::Touch(widget_capturing, touch);
+                    self.global_input.push_event(event.into());
+
+                    // Create a `Tap` event.
+                    //
+                    // If the widget at the end of the touch is the same as the widget at the start
+                    // of the touch, that widget receives the `Tap`.
+                    let tapped_widget =
+                        graph::algo::pick_widgets(&self.depth_order.indices, touch.xy)
+                            .next(&self.widget_graph, &self.depth_order.indices)
+                            .and_then(|widget| match Some(widget) == widget_capturing {
+                                true => Some(widget),
+                                false => None,
+                            });
+                    let tap = event::Tap { id: touch.id, xy: touch.xy };
+                    let event = event::Ui::Tap(tapped_widget, tap);
+                    self.global_input.push_event(event.into());
+
+                    // Generate an "uncaptures" event if necessary.
+                    if let Some(widget) = widget_capturing {
+                        let source = input::Source::Touch(touch.id);
+                        let event = event::Ui::WidgetUncapturesInputSource(widget, source);
+                        self.global_input.push_event(event.into());
+                    }
+                },
+
+            },
+
+            Input::Focus(_focused) => (),
         }
     }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -268,7 +268,7 @@ impl<'a> Widget for Button<'a, Flat> {
         let widget::UpdateArgs { id, state, style, rect, ui, .. } = args;
         let Button { maybe_label, .. } = self;
 
-        let (interaction, times_clicked) = interaction_and_times_clicked(id, ui);
+        let (interaction, times_triggered) = interaction_and_times_triggered(id, ui);
         let color = color_from_interaction(style.color(&ui.theme), interaction);
 
         bordered_rectangle(id, state.rectangle, rect, color, style, ui);
@@ -278,7 +278,7 @@ impl<'a> Widget for Button<'a, Flat> {
             label(id, state.label, l, style, ui);
         }
 
-        TimesClicked(times_clicked)
+        TimesClicked(times_triggered)
     }
 
 }
@@ -309,7 +309,7 @@ impl<'a> Widget for Button<'a, Image> {
         let widget::UpdateArgs { id, state, style, rect, ui, .. } = args;
         let Button { show, maybe_label, .. } = self;
 
-        let (interaction, times_clicked) = interaction_and_times_clicked(id, ui);
+        let (interaction, times_triggered) = interaction_and_times_triggered(id, ui);
 
         // Instantiate the image.
         let Image { image_id, press_image_id, hover_image_id, src_rect, color } = show;
@@ -346,7 +346,7 @@ impl<'a> Widget for Button<'a, Image> {
             label(id, state.label, s, style, ui);
         }
 
-        TimesClicked(times_clicked)
+        TimesClicked(times_triggered)
     }
 
 }
@@ -360,7 +360,7 @@ fn color_from_interaction(color: Color, interaction: Interaction) -> Color {
     }
 }
 
-fn interaction_and_times_clicked(button_id: widget::Id, ui: &UiCell) -> (Interaction, u16) {
+fn interaction_and_times_triggered(button_id: widget::Id, ui: &UiCell) -> (Interaction, u16) {
     let input = ui.widget_input(button_id);
     let interaction = input.mouse().map_or(Interaction::Idle, |mouse| {
         if mouse.buttons.left().is_down() {
@@ -369,8 +369,8 @@ fn interaction_and_times_clicked(button_id: widget::Id, ui: &UiCell) -> (Interac
             Interaction::Hover
         }
     });
-    let times_clicked = input.clicks().left().count() as u16;
-    (interaction, times_clicked)
+    let times_triggered = (input.clicks().left().count() + input.taps().count()) as u16;
+    (interaction, times_triggered)
 }
 
 fn bordered_rectangle(button_id: widget::Id, rectangle_id: widget::Id,

--- a/src/widget/toggle.rs
+++ b/src/widget/toggle.rs
@@ -142,7 +142,10 @@ impl<'a> Widget for Toggle<'a> {
 
         let times_clicked = TimesClicked {
             state: value,
-            count: if enabled { ui.widget_input(id).clicks().left().count() as u16 } else { 0 },
+            count: if enabled {
+                let input = ui.widget_input(id);
+                (input.clicks().left().count() + input.taps().count()) as u16
+            } else { 0 },
         };
 
         // BorderedRectangle widget.


### PR DESCRIPTION
Also makes it so that `Button` and `Toggle` now react to `Tap`s as well as `Click`s.

This also simplifies the `Motion` input type in favour of adding a new `Touch` input type and moving it into its own variant on the relevant event types.

cc @tl8roy I think this should be working, however I'm currently out of town and don't have a touch device that I can use for testing on me. If you could test and confirm that this works that would be great!

Closes #936.