### PR TITLE
[WIP] Expose widget capturing and mouse_over state

### DIFF
--- a/examples/all_winit_gfx.rs
+++ b/examples/all_winit_gfx.rs
@@ -363,7 +363,7 @@ mod feature {
             }
 
             // Update widgets if any event has happened
-            if ui.global_input.events().next().is_some() {
+            if ui.global_input().events().next().is_some() {
                 let mut ui = ui.set_widgets();
                 support::gui(&mut ui, &ids, &mut app);
             }

--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -51,11 +51,11 @@ fn test_handling_basic_input_event(ui: &mut Ui, event: Input) {
 }
 
 fn assert_event_was_pushed(ui: &Ui, event: event::Event) {
-    let found = ui.global_input.events().find(|evt| **evt == event);
+    let found = ui.global_input().events().find(|evt| **evt == event);
     assert!(found.is_some(),
             format!("expected to find event: {:?} in: \nevents: {:?}",
                     event,
-                    ui.global_input.events().collect::<Vec<&event::Event>>()));
+                    ui.global_input().events().collect::<Vec<&event::Event>>()));
 }
 
 fn to_window_coordinates(xy: Point, ui: &Ui) -> Point {
@@ -102,7 +102,7 @@ fn ui_should_reset_global_input_after_widget_are_set() {
             .set(button, ui);
     }
 
-    assert!(ui.global_input.events().next().is_none());
+    assert!(ui.global_input().events().next().is_none());
 }
 
 
@@ -127,7 +127,7 @@ fn high_level_scroll_event_should_be_created_from_a_raw_mouse_scroll() {
         y: 33.0,
         modifiers: ModifierKey::default()
     };
-    let event = ui.global_input.events().next().expect("expected a scroll event");
+    let event = ui.global_input().events().next().expect("expected a scroll event");
     if let event::Event::Ui(event::Ui::Scroll(_, scroll)) = *event {
         assert_eq!(expected_scroll, scroll);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -48,7 +48,7 @@ pub struct Ui {
     /// An index into the root widget of the graph, representing the entire window.
     pub window: widget::Id,
     /// Handles aggregation of events and providing them to Widgets
-    pub global_input: input::Global,
+    global_input: input::Global,
     /// Manages all fonts that have been loaded by the user.
     pub fonts: text::font::Map,
     /// The Widget cache, storing state for all widgets.
@@ -889,6 +889,14 @@ impl Ui {
 
             Input::Focus(_focused) => (),
         }
+    }
+
+
+    /// Get an immutable reference to global input. Handles aggregation of events and providing them to Widgets
+    ///
+    /// Can be used to access the current input state, e.g. which widgets are currently capturing inputs.
+    pub fn global_input(&self) -> &input::Global {
+        &self.global_input
     }
 
     /// Get the centred xy coords for some given `Dimension`s, `Position` and alignment.

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -317,8 +317,8 @@ impl<'a, T> Widget for DropDownList<'a, T>
                 // not any of the drop down list's children.
                 let should_close = clicked_item.is_some() ||
                     clicked_item.is_none()
-                    && ui.global_input.current.mouse.buttons.pressed().next().is_some()
-                    && match ui.global_input.current.widget_capturing_mouse {
+                    && ui.global_input().current.mouse.buttons.pressed().next().is_some()
+                    && match ui.global_input().current.widget_capturing_mouse {
                         None => true,
                         Some(capturing) => !ui.widget_graph()
                             .does_recursive_depth_edge_exist(id, capturing),


### PR DESCRIPTION
Attempt to fix #611 and #612.

Currently does not compile, the reason is this line: https://github.com/Drakulix/conrod/blob/feature/input_feedback/src/widget/drop_down_list.rs#L320

I did as suggested in #611 and made `global_input` private, so this is expected.

I would like to have some feedback regarding how I should attempt to fix this:

- Leave `global_input` public and open a new issue on that subject
- Expose more of `global_input.current` via functions to satisfy the current requirements of `DropDownList` (if yes, what exactly?)
- Refactor `DropDownList` in a way this is not required anymore (if yes, how?)