### PR TITLE
Improve Display implementations for errors

### DIFF
--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -893,6 +893,24 @@ impl From<glium::program::ProgramChooserCreationError> for RendererCreationError
     }
 }
 
+impl std::error::Error for RendererCreationError {
+    fn description(&self) -> &str {
+        match *self {
+            RendererCreationError::Texture(ref e) => std::error::Error::description(e),
+            RendererCreationError::Program(ref e) => std::error::Error::description(e),
+        }
+    }
+}
+
+impl std::fmt::Display for RendererCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match *self {
+            RendererCreationError::Texture(ref e) => std::fmt::Display(e, f),
+            RendererCreationError::Program(ref e) => std::fmt::Display(e, f),
+        }
+    }
+}
+
 impl From<glium::vertex::BufferCreationError> for DrawError {
     fn from(err: glium::vertex::BufferCreationError) -> Self {
         DrawError::Buffer(err)
@@ -902,5 +920,23 @@ impl From<glium::vertex::BufferCreationError> for DrawError {
 impl From<glium::DrawError> for DrawError {
     fn from(err: glium::DrawError) -> Self {
         DrawError::Draw(err)
+    }
+}
+
+impl std::error::Error for DrawError {
+    fn description(&self) -> &str {
+        match *self {
+            DrawError::Buffer(ref e) => std::error::Error::description(e),
+            DrawError::Draw(ref e) => std::error::Error::description(e),
+        }
+    }
+}
+
+impl std::fmt::Display for DrawError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match *self {
+            DrawError::Buffer(ref e) => std::fmt::Display(e, f),
+            DrawError::Draw(ref e) => std::fmt::Display(e, f),
+        }
     }
 }

--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -905,8 +905,8 @@ impl std::error::Error for RendererCreationError {
 impl std::fmt::Display for RendererCreationError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match *self {
-            RendererCreationError::Texture(ref e) => std::fmt::Display(e, f),
-            RendererCreationError::Program(ref e) => std::fmt::Display(e, f),
+            RendererCreationError::Texture(ref e) => std::fmt::Display::fmt(e, f),
+            RendererCreationError::Program(ref e) => std::fmt::Display::fmt(e, f),
         }
     }
 }
@@ -935,8 +935,8 @@ impl std::error::Error for DrawError {
 impl std::fmt::Display for DrawError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match *self {
-            DrawError::Buffer(ref e) => std::fmt::Display(e, f),
-            DrawError::Draw(ref e) => std::fmt::Display(e, f),
+            DrawError::Buffer(ref e) => std::fmt::Display::fmt(e, f),
+            DrawError::Draw(ref e) => std::fmt::Display::fmt(e, f),
         }
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -247,7 +247,10 @@ pub mod font {
 
     impl std::fmt::Display for Error {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-            writeln!(f, "{}", std::error::Error::description(self))
+            match *self {
+                Error::IO(ref e) => std::fmt::Display::fmt(e, f),
+                _ => write!(f, "{}", std::error::Error::description(self))
+            }
         }
     }
 


### PR DESCRIPTION
This adds a case to `conrod::text::font::Error`'s `Display` implementation which calls `std::io::Error`'s `Display` implementation instead of its `std::error::Error::description()`.

This also implements `std::error::Error` and `Display` for the two error structs created for the glium backend in a very minimal way. These could be expanded to include more information if it would be relevant, but even this minimal implementation would be helpful for displaying errors more nicely than Debug!

If there's anything else needed for this, please ask!