### PR TITLE
Update the widget under the cursor on widget change

### DIFF
--- a/src/tests/ui.rs
+++ b/src/tests/ui.rs
@@ -85,9 +85,8 @@ fn ui_should_reset_global_input_after_widget_are_set() {
     };
 
     move_mouse_to_widget(button, ui);
-    left_click_mouse(ui);
-
-    {
+    for _ in 0..2 {
+        left_click_mouse(ui);
         let ui = &mut ui.set_widgets();
 
         assert!(ui.global_input().events().next().is_some());


### PR DESCRIPTION
This should fix buttons not being clickable until the mouse moves when the UI is first created or when what widgets are on the screen change under the cursor.