### PR TITLE
[WIP] Add support for "password" TextEdit and TextBox widgets

### DIFF
--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -49,6 +49,9 @@ pub struct Style {
     /// The font used for the `Text`.
     #[conrod(default = "theme.font_id")]
     pub font_id: Option<Option<text::font::Id>>,
+    /// Display text with all characters replaced by this
+    #[conrod(default = "None")]
+    pub char_replace: Option<Option<char>>,
 }
 
 widget_ids! {
@@ -100,6 +103,7 @@ impl<'a> TextBox<'a> {
         pub font_size { style.font_size = Some(FontSize) }
         pub justify { style.justify = Some(text::Justify) }
         pub pad_text { style.text_padding = Some(Scalar) }
+        pub hide_with_char { style.char_replace = Some(Option<char>) }
     }
 
 }
@@ -157,6 +161,8 @@ impl<'a> Widget for TextBox<'a> {
             .border_color(border_color)
             .set(state.ids.rectangle, ui);
 
+        let char_replace = style.char_replace(ui.theme());
+
         let mut events = Vec::new();
 
         let text_color = style.text_color(ui.theme());
@@ -168,6 +174,7 @@ impl<'a> Widget for TextBox<'a> {
             .font_size(font_size)
             .color(text_color)
             .justify(justify)
+            .hide_with_char(char_replace)
             .parent(id)
             .set(state.ids.text_edit, ui)
         {

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -50,6 +50,9 @@ pub struct Style {
     /// The font used for the `Text`.
     #[conrod(default = "theme.font_id")]
     pub font_id: Option<Option<text::font::Id>>,
+    /// Display text with all characters replaced by this
+    #[conrod(default = "None")]
+    pub char_replace: Option<Option<char>>,
 }
 
 widget_ids! {
@@ -173,6 +176,7 @@ impl<'a> TextEdit<'a> {
         pub line_wrap { style.line_wrap = Some(Wrap) }
         pub line_spacing { style.line_spacing = Some(Scalar) }
         pub restrict_to_height { style.restrict_to_height = Some(bool) }
+        pub hide_with_char { style.char_replace = Some(Option<char>) }
     }
 
 }
@@ -275,6 +279,10 @@ impl<'a> Widget for TextEdit<'a> {
                 Wrap::Character => infos.wrap_by_character(max_width),
             }
         }
+
+        let mut replacement_string = style.char_replace
+            .and_then(|opt| opt)
+            .map(|c: char| text.chars().map(|_| c).collect::<String>().into());
 
         // Check to see if the given text has changed since the last time the widget was updated.
         {
@@ -442,7 +450,8 @@ impl<'a> Widget for TextEdit<'a> {
                         let abs_xy = utils::vec2_add(rel_xy, rect.xy());
                         let infos = &state.line_infos;
                         let font = ui.fonts.get(font_id).unwrap();
-                        let closest = closest_cursor_index_and_xy(abs_xy, &text, infos, font);
+                        let closest = closest_cursor_index_and_xy(abs_xy, &replacement_string.as_ref().unwrap_or(&text),
+                                                                  infos, font);
                         if let Some((closest_cursor, _)) = closest {
                             cursor = Cursor::Idx(closest_cursor);
                         }
@@ -507,6 +516,8 @@ impl<'a> Widget for TextEdit<'a> {
                                 *text.to_mut() = text.chars().take(start_idx)
                                     .chain(text.chars().skip(end_idx))
                                     .collect();
+                                replacement_string = style.char_replace.and_then(|opt| opt)
+                                    .map(|c: char| text.chars().map(|_| c).collect::<String>().into());
                                 state.update(|state| {
                                     let font = ui.fonts.get(font_id).unwrap();
                                     let w = rect.w();
@@ -527,20 +538,22 @@ impl<'a> Widget for TextEdit<'a> {
                                 Cursor::Selection { start, end } => (start, end),
                             };
 
+                            let displayed_text = replacement_string.as_ref().unwrap_or(&text);
+
                             let new_cursor_idx = {
                                 let line_infos = state.line_infos.iter().cloned();
                                 match (key, move_word) {
                                     (input::Key::Left, true) => cursor_idx
-                                        .previous_word_start(&text, line_infos),
+                                        .previous_word_start(&displayed_text, line_infos),
                                     (input::Key::Right, true) => cursor_idx
-                                        .next_word_end(&text, line_infos),
+                                        .next_word_end(&displayed_text, line_infos),
                                     (input::Key::Left, false) => cursor_idx
                                         .previous(line_infos),
                                     (input::Key::Right, false) => cursor_idx
                                         .next(line_infos),
 
                                     // Up/Down movement
-                                    _ => cursor_xy_at(cursor_idx, &text, &state.line_infos, font)
+                                    _ => cursor_xy_at(cursor_idx, &displayed_text, &state.line_infos, font)
                                         .and_then(|(x_pos, _)| {
                                             let text::cursor::Index { line, .. } = cursor_idx;
                                             let next_line = match key {
@@ -548,7 +561,7 @@ impl<'a> Widget for TextEdit<'a> {
                                                 input::Key::Down => line + 1,
                                                 _ => unreachable!(),
                                             };
-                                            closest_cursor_index_on_line(x_pos, next_line, &text, &state.line_infos, font)
+                                            closest_cursor_index_on_line(x_pos, next_line, &displayed_text, &state.line_infos, font)
                                         })
                                 }.unwrap_or(cursor_idx)
                             };
@@ -582,10 +595,10 @@ impl<'a> Widget for TextEdit<'a> {
                                                 let line_infos = state.line_infos.iter().cloned();
                                                 match key {
                                                     input::Key::Left | input::Key::Up => {
-                                                        cursor_idx.previous_word_start(&text, line_infos)
+                                                        cursor_idx.previous_word_start(&displayed_text, line_infos)
                                                     },
                                                     input::Key::Right | input::Key::Down => {
-                                                        cursor_idx.next_word_end(&text, line_infos)
+                                                        cursor_idx.next_word_end(&displayed_text, line_infos)
                                                     }
                                                     _ => unreachable!(),
                                                 }.unwrap_or(cursor_idx)
@@ -657,6 +670,8 @@ impl<'a> Widget for TextEdit<'a> {
                             match insert_text("\n", cursor, &text, &state.line_infos, font) {
                                 Some((new_text, new_cursor, new_line_infos)) => {
                                     *text.to_mut() = new_text;
+                                    replacement_string = style.char_replace.and_then(|opt| opt)
+                                        .map(|c: char| text.chars().map(|_| c).collect::<String>().into());
                                     cursor = new_cursor;
                                     state.update(|state| state.line_infos = new_line_infos);
                                 }, _ => ()
@@ -685,7 +700,7 @@ impl<'a> Widget for TextEdit<'a> {
                     }
 
                     // Ignore text produced by arrow keys.
-                    // 
+                    //
                     // TODO: These just happened to be the modifiers for the arrows on OS X, I've
                     // no idea if they also apply to other platforms. We should definitely see if
                     // there's a better way to handle this, or whether this should be fixed
@@ -699,6 +714,8 @@ impl<'a> Widget for TextEdit<'a> {
                     match insert_text(&string, cursor, &text, &state.line_infos, font) {
                         Some((new_text, new_cursor, new_line_infos)) => {
                             *text.to_mut() = new_text;
+                            replacement_string = style.char_replace.and_then(|opt| opt)
+                                .map(|c: char| text.chars().map(|_| c).collect::<String>().into());
                             cursor = new_cursor;
                             state.update(|state| state.line_infos = new_line_infos);
                         }, _ => ()
@@ -707,8 +724,9 @@ impl<'a> Widget for TextEdit<'a> {
 
                 // Check whether or not we need to extend a text selection or drag some text.
                 event::Widget::Drag(drag_event) if drag_event.button == input::MouseButton::Left => {
-                    match drag {
+                    let displayed_text = replacement_string.as_ref().unwrap_or(&text);
 
+                    match drag {
                         Some(Drag::Selecting) => {
                             let start_cursor_idx = match cursor {
                                 Cursor::Idx(idx) => idx,
@@ -717,7 +735,7 @@ impl<'a> Widget for TextEdit<'a> {
                             let abs_xy = utils::vec2_add(drag_event.to, rect.xy());
                             let infos = &state.line_infos;
                             let font = ui.fonts.get(font_id).unwrap();
-                            match closest_cursor_index_and_xy(abs_xy, &text, infos, font) {
+                            match closest_cursor_index_and_xy(abs_xy, &displayed_text, infos, font) {
                                 Some((end_cursor_idx, _)) =>
                                     cursor = Cursor::Selection {
                                         start: start_cursor_idx,
@@ -764,20 +782,26 @@ impl<'a> Widget for TextEdit<'a> {
         let text_y_range = Range::new(0.0, text_height).align_to(y_align, rect.y);
         let text_rect = Rect { x: rect.x, y: text_y_range };
 
-        match line_wrap {
-            Wrap::Whitespace => widget::Text::new(&text).wrap_by_word(),
-            Wrap::Character => widget::Text::new(&text).wrap_by_character(),
+        {
+            let display_text = match replacement_string {
+                Some(ref s) => s,
+                None => &text,
+            };
+            match line_wrap {
+                Wrap::Whitespace => widget::Text::new(display_text).wrap_by_word(),
+                Wrap::Character => widget::Text::new(display_text).wrap_by_character(),
+            }
+                .font_id(font_id)
+                .wh(text_rect.dim())
+                .xy(text_rect.xy())
+                .justify(justify)
+                .parent(id)
+                .graphics_for(id)
+                .color(color)
+                .line_spacing(line_spacing)
+                .font_size(font_size)
+                .set(state.ids.text, ui);
         }
-            .font_id(font_id)
-            .wh(text_rect.dim())
-            .xy(text_rect.xy())
-            .justify(justify)
-            .parent(id)
-            .graphics_for(id)
-            .color(color)
-            .line_spacing(line_spacing)
-            .font_size(font_size)
-            .set(state.ids.text, ui);
 
         // Draw the line for the cursor.
         let cursor_idx = match cursor {
@@ -792,7 +816,7 @@ impl<'a> Widget for TextEdit<'a> {
 
         let (cursor_x, cursor_y_range) = {
             let font = ui.fonts.get(font_id).unwrap();
-            cursor_xy_at(cursor_idx, &text, &state.line_infos, font)
+            cursor_xy_at(cursor_idx, replacement_string.as_ref().unwrap_or(&text), &state.line_infos, font)
                 .unwrap_or_else(|| {
                     let x = rect.left();
                     let y = Range::new(0.0, font_size as Scalar).align_to(y_align, rect.y);
@@ -840,7 +864,7 @@ impl<'a> Widget for TextEdit<'a> {
 
             let selected_rects: Vec<Rect> = {
                 let line_infos = state.line_infos.iter().cloned();
-                let lines = line_infos.clone().map(|info| &text[info.byte_range()]);
+                let lines = line_infos.clone().map(|info| &replacement_string.as_ref().unwrap_or(&text)[info.byte_range()]);
                 let line_rects = text::line::rects(line_infos.clone(), font_size, rect,
                                                    justify, y_align, line_spacing);
                 let lines_with_rects = lines.zip(line_rects.clone());
@@ -867,6 +891,7 @@ impl<'a> Widget for TextEdit<'a> {
                     .set(selected_rectangle_id, ui);
             }
         }
+
 
         take_if_owned(text)
     }


### PR DESCRIPTION
The way I've done it here technically works, but seems very hacky, and probably could be designed and written better. 

There are a few places in TextEdit where `&text` is replaced with `&replacement_string.as_ref().unwrap_or(&text)`, which is a bit bulky, but I'm not sure if there's a better way to do this while still having the ability to mutate `text` in the way this PR currently implements it.

I've tested this with an example text box, and it seems to support dragging, selecting, deleting, and correctly treats the entire password as a single word for the sake of ctrl+left, ctrl+right and ctrl+backspace. I can look into adding some actual unit tests for this once the design is improved more.