### PR TITLE
Add support for more layout `Direction`s to `List` and `ListSelect`

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -93,9 +93,8 @@ mod feature {
 
         widget::Canvas::new().color(conrod::color::DARK_CHARCOAL).set(ids.canvas, ui);
 
-        const ITEM_HEIGHT: conrod::Scalar = 50.0;
-
-        let (mut items, scrollbar) = widget::List::new(list.len(), ITEM_HEIGHT)
+        let (mut items, scrollbar) = widget::List::flow_down(list.len())
+            .item_size(50.0)
             .scrollbar_on_top()
             .middle_of(ids.canvas)
             .wh_of(ids.canvas)

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -103,10 +103,13 @@ mod feature {
 
                 // Instantiate the `ListSelect` widget.
                 let num_items = list_items.len();
-                let item_h = 32.0;
-                let (mut events, scrollbar) = widget::ListSelect::multiple(num_items, item_h)
+                let item_h = 30.0;
+                let font_size = item_h as conrod::FontSize / 2;
+                let (mut events, scrollbar) = widget::ListSelect::multiple(num_items)
+                    .flow_down()
+                    .item_size(item_h)
                     .scrollbar_next_to()
-                    .w_h(350.0, 220.0)
+                    .w_h(400.0, 230.0)
                     .top_left_with_margins_on(ids.canvas, 40.0, 40.0)
                     .set(ids.list_select, ui);
 
@@ -118,7 +121,6 @@ mod feature {
                         // For the `Item` events we instantiate the `List`'s items.
                         Event::Item(item) => {
                             let label = &list_items[item.i];
-                            let font_size = item_h as conrod::FontSize / 2;
                             let (color, label_color) = match list_selected.contains(&item.i) {
                                 true => (conrod::color::LIGHT_BLUE, conrod::color::YELLOW),
                                 false => (conrod::color::LIGHT_GREY, conrod::color::BLACK),

--- a/src/widget/drop_down_list.rs
+++ b/src/widget/drop_down_list.rs
@@ -275,7 +275,9 @@ impl<'a, T> Widget for DropDownList<'a, T>
                             .unwrap_or(10.0)
                     });
 
-                let (mut events, scrollbar) = widget::ListSelect::single(num_items, item_h)
+                let (mut events, scrollbar) = widget::ListSelect::single(num_items)
+                    .flow_down()
+                    .item_size(item_h)
                     .w_h(w, list_h)
                     .and(|ls| match scrollbar_position {
                         Some(widget::list::ScrollbarPosition::NextTo) => ls.scrollbar_next_to(),
@@ -283,7 +285,7 @@ impl<'a, T> Widget for DropDownList<'a, T>
                         None => ls,
                     })
                     .scrollbar_color(scrollbar_color)
-                    .scrollbar_width(scrollbar_width)
+                    .scrollbar_thickness(scrollbar_width)
                     .mid_top_of(id)
                     .floating(true)
                     .set(state.ids.list, ui);

--- a/src/widget/file_navigator/directory_view.rs
+++ b/src/widget/file_navigator/directory_view.rs
@@ -279,7 +279,9 @@ impl<'a> Widget for DirectoryView<'a> {
 
         let list_h = rect.h().min(state.entries.len() as Scalar * file_h);
         let (mut list_events, scrollbar) =
-            widget::ListSelect::multiple(state.entries.len(), file_h)
+            widget::ListSelect::multiple(state.entries.len())
+                .flow_down()
+                .item_size(file_h)
                 .scrollbar_on_top()
                 .w_h(rect.w(), list_h)
                 .mid_top_of(id)

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -205,7 +205,7 @@ impl<D> List<D, Dynamic>
 {
     /// Begin building a new `List`.
     pub fn new(num_items: usize) -> Self {
-        List::from_size(num_items, Dynamic {})
+        List::from_item_size(num_items, Dynamic {})
     }
 }
 
@@ -242,7 +242,7 @@ impl<D, S> List<D, S>
           S: ItemSize,
 {
     /// Begin building a new `List` given some direction and item size.
-    pub fn from_size(num_items: usize, item_size: S) -> Self {
+    pub fn from_item_size(num_items: usize, item_size: S) -> Self {
         List {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
@@ -442,6 +442,62 @@ impl<D, S> Item<D, S>
             .set(widget_id, ui)
     }
 
+}
+
+impl<S> Item<Down, S> {
+    /// The width of the `Item`.
+    pub fn width(&self) -> Scalar {
+        self.breadth
+    }
+}
+
+impl Item<Down, Fixed> {
+    /// The height of the `Item`.
+    pub fn height(&self) -> Scalar {
+        self.size.length
+    }
+}
+
+impl<S> Item<Up, S> {
+    /// The width of the `Item`.
+    pub fn width(&self) -> Scalar {
+        self.breadth
+    }
+}
+
+impl Item<Up, Fixed> {
+    /// The height of the `Item`.
+    pub fn height(&self) -> Scalar {
+        self.size.length
+    }
+}
+
+impl<S> Item<Right, S> {
+    /// The height of the `Item`.
+    pub fn height(&self) -> Scalar {
+        self.breadth
+    }
+}
+
+impl Item<Right, Fixed> {
+    /// The width of the `Item`.
+    pub fn width(&self) -> Scalar {
+        self.size.length
+    }
+}
+
+impl<S> Item<Left, S> {
+    /// The height of the `Item`.
+    pub fn height(&self) -> Scalar {
+        self.breadth
+    }
+}
+
+impl Item<Left, Fixed> {
+    /// The width of the `Item`.
+    pub fn width(&self) -> Scalar {
+        self.size.length
+    }
 }
 
 

--- a/src/widget/list.rs
+++ b/src/widget/list.rs
@@ -12,6 +12,7 @@ use {
     UiCell,
 };
 use graph;
+use position::{Range, Rect};
 use std;
 use widget;
 
@@ -25,22 +26,102 @@ use widget;
 ///   lists containing many items, i.e. a `FileNavigator` over a directory with thousands of files.
 #[derive(Clone)]
 #[allow(missing_copy_implementations)]
-pub struct List {
+pub struct List<D, S> {
     /// Common widget building params for the `List`.
     pub common: widget::CommonBuilder,
     /// Unique styling for the `List`.
     pub style: Style,
     /// Whether all or only visible items should be instantiated.
     pub item_instantiation: ItemInstantiation,
-    item_h: Scalar,
     num_items: usize,
+    direction: std::marker::PhantomData<D>,
+    item_size: S,
+}
+
+/// Items flow from bottom to top.
+#[derive(Clone, Copy, Debug)]
+pub enum Up {}
+/// Items flow from top to bottom.
+#[derive(Clone, Copy, Debug)]
+pub enum Down {}
+/// Items flow from right to left.
+#[derive(Clone, Copy, Debug)]
+pub enum Left {}
+/// Items flow from left to right.
+#[derive(Clone, Copy, Debug)]
+pub enum Right {}
+
+/// A type that implements `ItemSize` for `List`s whose `Item`s are a fixed size and known prior to
+/// setting the widgets for each item.
+#[derive(Clone, Copy, Debug)]
+pub struct Fixed {
+    /// The length of each item in the direction that the list flows.
+    pub length: Scalar,
+}
+
+/// A type that implements `ItemSize` for `List`s whose `Item`s' length are unknown until setting
+/// the widget for each item.
+#[derive(Clone, Copy, Debug)]
+pub struct Dynamic {}
+
+/// The direction in which the list is layed out.
+pub trait Direction {
+    /// The direction along which the `Scrollbar` is laid out.
+    type Axis: widget::scrollbar::Axis;
+
+    /// For some given `Rect`, returns the parallel and perpendicular ranges respectively.
+    fn ranges(Rect) -> (Range, Range);
+
+    /// Begin building the scrollbar for the `List`.
+    fn scrollbar(widget::Id) -> widget::Scrollbar<Self::Axis>;
+
+    /// Borrow the scroll state associated with this `Direction`'s axis.
+    fn common_scroll(common: &widget::CommonBuilder) -> Option<&widget::scroll::Scroll>;
+
+    /// Positions the given widget.
+    fn position_item<W>(item_widget: W,
+                        last_id: Option<widget::Id>,
+                        scroll_trigger_id: widget::Id,
+                        first_item_margin: Scalar) -> W
+        where W: Widget;
+
+    /// Position the `Rectangle` used for scrolling `List`s with fixed `Item` sizes.
+    fn position_scroll_trigger<W>(scroll_trigger: W, list: widget::Id) -> W
+        where W: Widget;
+
+    /// Calls the suitable `scroll_kids_<axis>` method on the `List`.
+    fn scroll_list_kids<S>(list: List<Self, S>) -> List<Self, S>
+        where Self: Sized,
+              S: ItemSize;
+
+    /// Size the widget given its breadth.
+    fn size_breadth<W>(widget: W, breadth: Scalar) -> W
+        where W: Widget;
+
+    /// Size the widget given its length.
+    fn size_length<W>(widget: W, length: Scalar) -> W
+        where W: Widget;
+}
+
+/// The way in which the `List`'s items are sized. E.g. `Fired` or `Dynamic`.
+pub trait ItemSize: Sized + Clone + Copy {
+
+    /// Update the `List` widget.
+    fn update_list<D>(List<D, Self>, widget::UpdateArgs<List<D, Self>>)
+        -> <List<D, Self> as Widget>::Event
+        where D: Direction;
+
+    /// Set the size for the given item `widget` and return it.
+    fn size_item<W, D>(&self, widget: W, breadth: Scalar) -> W
+        where W: Widget,
+              D: Direction;
 }
 
 widget_style! {
     /// Unique styling for the `List`.
     style Style {
         /// The width of the scrollbar if it is visible.
-        - scrollbar_width: Option<Scalar> { None }
+        - scrollbar_thickness: Option<Scalar> { None }
         /// The color of the scrollbar if it is visible.
         - scrollbar_color: Color { theme.border_color }
         /// The location of the `List`'s scrollbar.
@@ -63,22 +144,22 @@ pub struct State {
 
 /// The data necessary for instantiating a single item within a `List`.
 #[derive(Copy, Clone, Debug)]
-pub struct Item {
+pub struct Item<D, S> {
     /// The index of the item within the list.
     pub i: usize,
     /// The id generated for the widget.
     pub widget_id: widget::Id,
     /// The id used for the previous item's widget.
     pub last_id: Option<widget::Id>,
-    /// The width of the item.
-    pub w: Scalar,
-    /// The height of the item.
-    pub h: Scalar,
+    breadth: Scalar,
+    size: S,
     /// The id of the `scroll_trigger` rectangle, upon which this widget will be placed.
     scroll_trigger_id: widget::Id,
     /// The distance between the top of the first visible item and the top of the `scroll_trigger`
     /// `Rectangle`. This field is used for positioning the item's widget.
     first_item_margin: Scalar,
+    /// The direction in which the items are laid out.
+    direction: std::marker::PhantomData<D>,
 }
 
 /// The way in which a `List` should instantiate its `Item`s.
@@ -100,65 +181,103 @@ pub enum ScrollbarPosition {
 }
 
 /// A wrapper around a `List`'s `Scrollbar` and its `widget::Id`.
-pub struct Scrollbar {
-    widget: widget::Scrollbar<widget::scroll::Y>,
+pub struct Scrollbar<A> {
+    widget: widget::Scrollbar<A>,
     id: widget::Id,
 }
 
 /// An `Iterator` yielding each `Item` in the list.
-pub struct Items {
+pub struct Items<D, S> {
     item_indices: std::ops::Range<usize>,
     next_item_indices_index: usize,
     list_id: widget::Id,
     last_id: Option<widget::Id>,
     scroll_trigger_id: widget::Id,
     first_item_margin: Scalar,
-    item_w: Scalar,
-    item_h: Scalar,
+    item_breadth: Scalar,
+    item_size: S,
+    direction: std::marker::PhantomData<D>,
 }
 
 
-impl List {
+impl<D> List<D, Dynamic>
+    where D: Direction,
+{
+    /// Begin building a new `List`.
+    pub fn new(num_items: usize) -> Self {
+        List::from_size(num_items, Dynamic {})
+    }
+}
 
-    /// Create a List context to be built upon.
-    pub fn new(num_items: usize, item_height: Scalar) -> Self {
+impl List<Left, Dynamic> {
+    /// Begin building a new `List` flowing from right to left.
+    pub fn flow_left(num_items: usize) -> Self {
+        List::new(num_items)
+    }
+}
+
+impl List<Right, Dynamic> {
+    /// Begin building a new `List` flowing from left to right.
+    pub fn flow_right(num_items: usize) -> Self {
+        List::new(num_items)
+    }
+}
+
+impl List<Up, Dynamic> {
+    /// Begin building a new `List` flowing from bottom to top.
+    pub fn flow_up(num_items: usize) -> Self {
+        List::new(num_items)
+    }
+}
+
+impl List<Down, Dynamic> {
+    /// Begin building a new `List` flowing from top to bottom.
+    pub fn flow_down(num_items: usize) -> Self {
+        List::new(num_items)
+    }
+}
+
+impl<D, S> List<D, S>
+    where D: Direction,
+          S: ItemSize,
+{
+    /// Begin building a new `List` given some direction and item size.
+    pub fn from_size(num_items: usize, item_size: S) -> Self {
         List {
             common: widget::CommonBuilder::new(),
             style: Style::new(),
-            item_h: item_height,
             num_items: num_items,
-            item_instantiation: ItemInstantiation::OnlyVisible,
+            item_instantiation: ItemInstantiation::All,
+            item_size: item_size,
+            direction: std::marker::PhantomData,
         }.crop_kids()
     }
 
-    /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` to the
-    /// right of the items.
-    pub fn scrollbar_next_to(mut self) -> Self {
-        self.style.scrollbar_position = Some(Some(ScrollbarPosition::NextTo));
-        self.scroll_kids_vertically()
+    /// Specify a fixed item size, where size is a `Scalar` in the direction that the `List` is
+    /// flowing. When a `List` is constructed with this method, all items will have a fixed, equal
+    /// length.
+    pub fn item_size(self, length: Scalar) -> List<D, Fixed> {
+        let List { common, style, num_items, .. } = self;
+        List {
+            common: common,
+            style: style,
+            num_items: num_items,
+            item_instantiation: ItemInstantiation::OnlyVisible,
+            item_size: Fixed { length: length },
+            direction: std::marker::PhantomData,
+        }
     }
+}
 
-    /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` that hovers
-    /// above the right edge of the items and automatically hides when the user is not scrolling.
-    pub fn scrollbar_on_top(mut self) -> Self {
-        self.style.scrollbar_position = Some(Some(ScrollbarPosition::OnTop));
-        self.scroll_kids_vertically()
-    }
-
-    /// The width of the `Scrollbar`.
-    pub fn scrollbar_width(mut self, w: Scalar) -> Self {
-        self.style.scrollbar_width = Some(Some(w));
-        self
-    }
-
-    /// The color of the `Scrollbar`.
-    pub fn scrollbar_color(mut self, color: Color) -> Self {
-        self.style.scrollbar_color = Some(color);
-        self
-    }
-
+impl<D> List<D, Fixed>
+    where D: Direction,
+{
     /// Indicates that an `Item` should be instatiated for every element in the list, regardless of
     /// whether or not the `Item` would be visible.
+    ///
+    /// This is the default (and only) behaviour for `List`s with dynamic item sizes. This is
+    /// because a `List` cannot know the total length of its combined items in advanced when each
+    /// item is dynamically sized and their size is not given until they are set.
     ///
     /// Note: This may cause significantly heavier CPU load for lists containing many items (100+).
     /// We only recommend using this when absolutely necessary as large lists may cause unnecessary
@@ -172,20 +291,51 @@ impl List {
     /// avoid bloating the widget graph with unnecessary nodes and in turn keep traversal times to
     /// a minimum.
     ///
-    /// This is the default `List` behaviour.
+    /// This is the default behaviour for `List`s with fixed item sizes.
     pub fn instantiate_only_visible_items(mut self) -> Self {
         self.item_instantiation = ItemInstantiation::OnlyVisible;
         self
     }
-
 }
 
+impl<D, S> List<D, S>
+    where D: Direction,
+          S: ItemSize,
+{
+    /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` to the
+    /// right of the items.
+    pub fn scrollbar_next_to(mut self) -> Self {
+        self.style.scrollbar_position = Some(Some(ScrollbarPosition::NextTo));
+        D::scroll_list_kids(self)
+    }
 
+    /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` that hovers
+    /// above the right edge of the items and automatically hides when the user is not scrolling.
+    pub fn scrollbar_on_top(mut self) -> Self {
+        self.style.scrollbar_position = Some(Some(ScrollbarPosition::OnTop));
+        D::scroll_list_kids(self)
+    }
 
-impl Widget for List {
+    /// The width of the `Scrollbar`.
+    pub fn scrollbar_thickness(mut self, w: Scalar) -> Self {
+        self.style.scrollbar_thickness = Some(Some(w));
+        self
+    }
+
+    /// The color of the `Scrollbar`.
+    pub fn scrollbar_color(mut self, color: Color) -> Self {
+        self.style.scrollbar_color = Some(color);
+        self
+    }
+}
+
+impl<D, S> Widget for List<D, S>
+    where D: Direction,
+          S: ItemSize,
+{
     type State = State;
     type Style = Style;
-    type Event = (Items, Option<Scrollbar>);
+    type Event = (Items<D, S>, Option<Scrollbar<D::Axis>>);
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -206,109 +356,18 @@ impl Widget for List {
     }
 
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
-        let widget::UpdateArgs { id, state, rect, prev, mut ui, style, .. } = args;
-        let List { common, item_h, num_items, item_instantiation, .. } = self;
-
-        // We need a positive item height in order to do anything useful.
-        assert!(item_h > 0.0, "the given item height was {:?} however it must be > 0", item_h);
-
-        let total_item_h = num_items as Scalar * item_h;
-
-        // Determine whether or not the list is currently scrollable.
-        let is_scrollable = common.maybe_y_scroll.is_some() && total_item_h > rect.h();
-
-        // The width of the scrollbar.
-        let scrollbar_w = style.scrollbar_width(&ui.theme)
-            .unwrap_or_else(|| {
-                ui.theme.widget_style::<widget::scrollbar::Style>()
-                    .and_then(|style| style.style.thickness)
-                    .unwrap_or(10.0)
-            });
-
-        let scrollbar_position = style.scrollbar_position(&ui.theme);
-        let item_w = match (is_scrollable, scrollbar_position) {
-            (true, Some(ScrollbarPosition::NextTo)) => rect.w() - scrollbar_w,
-            _ => rect.w(),
-        };
-
-        // The widget used to scroll the `List`'s range.
-        //
-        // By using one long `Rectangle` widget to trigger the scrolling, this allows us to only
-        // instantiate the visible items.
-        widget::Rectangle::fill([rect.w(), total_item_h])
-            .mid_top_of(id)
-            .color(color::TRANSPARENT)
-            .parent(id)
-            .set(state.ids.scroll_trigger, ui);
-
-        // Determine the index range of the items that should be instantiated.
-        let (item_idx_range, first_item_margin) = match item_instantiation {
-            ItemInstantiation::All => {
-                let range = 0..num_items;
-                let margin = 0.0;
-                (range, margin)
-            },
-            ItemInstantiation::OnlyVisible => {
-                let scroll_trigger_rect = ui.rect_of(state.ids.scroll_trigger).unwrap();
-                let hidden_range_length = (scroll_trigger_rect.top() - rect.top()).max(0.0);
-                let num_top_hidden_items = hidden_range_length / item_h;
-                let num_visible_items = rect.h() / item_h;
-
-                let first_visible_item_idx = num_top_hidden_items.floor() as usize;
-                let end_visible_item_idx = std::cmp::min(
-                    (num_top_hidden_items + num_visible_items).ceil() as usize,
-                    num_items,
-                );
-
-                let range = first_visible_item_idx..end_visible_item_idx;
-                let margin = first_visible_item_idx as Scalar * item_h;
-                (range, margin)
-            },
-        };
-
-        // Ensure there are at least as many indices as there are visible items.
-        if state.ids.items.len() < item_idx_range.len() {
-            let id_gen = &mut ui.widget_id_generator();
-            state.update(|state| state.ids.items.resize(item_idx_range.len(), id_gen));
-        }
-
-        let items = Items {
-            list_id: id,
-            item_indices: item_idx_range,
-            next_item_indices_index: 0,
-            last_id: None,
-            scroll_trigger_id: state.ids.scroll_trigger,
-            first_item_margin: first_item_margin,
-            item_w: item_w,
-            item_h: item_h,
-        };
-
-        // Instantiate the `Scrollbar` only if necessary.
-        let auto_hide = match (is_scrollable, scrollbar_position) {
-            (false, _) | (true, None) => return (items, None),
-            (_, Some(ScrollbarPosition::NextTo)) => false,
-            (_, Some(ScrollbarPosition::OnTop)) => true,
-        };
-        let scrollbar_color = style.scrollbar_color(&ui.theme);
-        let scrollbar = widget::Scrollbar::y_axis(id)
-            .and_if(prev.maybe_floating.is_some(), |s| s.floating(true))
-            .color(scrollbar_color)
-            .thickness(scrollbar_w)
-            .auto_hide(auto_hide);
-        let scrollbar = Scrollbar {
-            widget: scrollbar,
-            id: state.ids.scrollbar,
-        };
-
-        (items, Some(scrollbar))
+        S::update_list(self, args)
     }
 }
 
 
-impl Items {
+impl<D, S> Items<D, S>
+    where D: Direction,
+          S: ItemSize,
+{
 
     /// Yield the next `Item` in the list.
-    pub fn next(&mut self, ui: &Ui) -> Option<Item> {
+    pub fn next(&mut self, ui: &Ui) -> Option<Item<D, S>> {
         let Items {
             ref mut item_indices,
             ref mut next_item_indices_index,
@@ -316,13 +375,14 @@ impl Items {
             list_id,
             scroll_trigger_id,
             first_item_margin,
-            item_w,
-            item_h,
+            item_breadth,
+            item_size,
+            ..
         } = *self;
 
         // Retrieve the `node_index` that was generated for the next `Item`.
         let node_index = match ui.widget_graph().widget(list_id)
-            .and_then(|container| container.unique_widget_state::<List>())
+            .and_then(|container| container.unique_widget_state::<List<D, S>>())
             .and_then(|&graph::UniqueWidgetState { ref state, .. }| {
                 state.ids.items.get(*next_item_indices_index).map(|&id| id)
             })
@@ -341,9 +401,10 @@ impl Items {
                     last_id: *last_id,
                     widget_id: node_index,
                     scroll_trigger_id: scroll_trigger_id,
-                    w: item_w,
-                    h: item_h,
+                    breadth: item_breadth,
+                    size: item_size,
                     first_item_margin: first_item_margin,
+                    direction: std::marker::PhantomData,
                 };
                 *last_id = Some(node_index);
                 Some(item)
@@ -355,7 +416,10 @@ impl Items {
 }
 
 
-impl Item {
+impl<D, S> Item<D, S>
+    where D: Direction,
+          S: ItemSize,
+{
 
     /// Sets the given widget as the widget to use for the item.
     ///
@@ -367,15 +431,13 @@ impl Item {
     pub fn set<W>(self, widget: W, ui: &mut UiCell) -> W::Event
         where W: Widget,
     {
-        let Item { widget_id, last_id, w, h, scroll_trigger_id, first_item_margin, .. } = self;
+        let Item {
+            widget_id, last_id, breadth, size, scroll_trigger_id, first_item_margin, ..
+        } = self;
 
         widget
-            .w_h(w, h)
-            .and(|w| match last_id {
-                None => w.mid_top_with_margin_on(scroll_trigger_id, first_item_margin)
-                    .align_left_of(scroll_trigger_id),
-                Some(id) => w.down_from(id, 0.0),
-            })
+            .and(|w| size.size_item::<W, D>(w, breadth))
+            .and(|w| D::position_item(w, last_id, scroll_trigger_id, first_item_margin))
             .parent(scroll_trigger_id)
             .set(widget_id, ui)
     }
@@ -383,10 +445,439 @@ impl Item {
 }
 
 
-impl Scrollbar {
+impl<A> Scrollbar<A>
+    where A: widget::scrollbar::Axis,
+{
     /// Set the `Scrollbar` within the given `Ui`.
     pub fn set(self, ui: &mut UiCell) {
         let Scrollbar { widget, id } = self;
         widget.set(id, ui);
     }
+}
+
+
+impl ItemSize for Fixed {
+
+    fn update_list<D>(list: List<D, Self>, args: widget::UpdateArgs<List<D, Self>>)
+        -> <List<D, Self> as Widget>::Event
+        where D: Direction,
+    {
+        let widget::UpdateArgs { id, state, rect, prev, mut ui, style, .. } = args;
+        let List { common, item_size, num_items, item_instantiation, .. } = list;
+
+        // The following code is generic over the direction in which the `List` is laid out.
+        //
+        // To avoid using terms like `width` and `height`, the more general terms `length` and
+        // `breadth` are used. For a `List` flowing downwards, `length` would refer to the item's
+        // `height`, while `breadth` would refer to the item's `width`.
+
+        // We need a positive item length in order to do anything useful.
+        assert!(item_size.length > 0.0,
+                "the given item height was {:?} however it must be > 0",
+                item_size.length);
+
+        let total_item_length = num_items as Scalar * item_size.length;
+        let (list_range, list_perpendicular_range) = D::ranges(rect);
+        let list_length = list_range.len();
+        let list_breadth = list_perpendicular_range.len();
+
+        // Determine whether or not the list is currently scrollable.
+        let is_scrollable = D::common_scroll(&common).is_some() && total_item_length > list_length;
+
+        // The width of the scrollbar.
+        let scrollbar_thickness = style.scrollbar_thickness(&ui.theme)
+            .unwrap_or_else(|| {
+                ui.theme.widget_style::<widget::scrollbar::Style>()
+                    .and_then(|style| style.style.thickness)
+                    .unwrap_or(10.0)
+            });
+
+        let scrollbar_position = style.scrollbar_position(&ui.theme);
+        let item_breadth = match (is_scrollable, scrollbar_position) {
+            (true, Some(ScrollbarPosition::NextTo)) => list_breadth - scrollbar_thickness,
+            _ => list_breadth,
+        };
+
+        // The widget used to scroll the `List`'s range.
+        //
+        // By using one long `Rectangle` widget to trigger the scrolling, this allows us to only
+        // instantiate the visible items.
+        {
+            let scroll_trigger = widget::Rectangle::fill([0.0, 0.0]);
+            let scroll_trigger = D::position_scroll_trigger(scroll_trigger, id);
+            let scroll_trigger = D::size_breadth(scroll_trigger, list_breadth);
+            let scroll_trigger = D::size_length(scroll_trigger, total_item_length);
+            scroll_trigger.color(color::TRANSPARENT).parent(id).set(state.ids.scroll_trigger, ui);
+        }
+
+        // Determine the index range of the items that should be instantiated.
+        let (item_idx_range, first_item_margin) = match item_instantiation {
+            ItemInstantiation::All => {
+                let range = 0..num_items;
+                let margin = 0.0;
+                (range, margin)
+            },
+            ItemInstantiation::OnlyVisible => {
+                let scroll_trigger_rect = ui.rect_of(state.ids.scroll_trigger).unwrap();
+                let (scroll_trigger_range, _) = D::ranges(scroll_trigger_rect);
+
+                let hidden_range_length = (scroll_trigger_range.start - list_range.start).abs();
+                let num_start_hidden_items = hidden_range_length / item_size.length;
+                let num_visible_items = list_length / item_size.length;
+                let first_visible_item_idx = num_start_hidden_items.floor() as usize;
+                let end_visible_item_idx = std::cmp::min(
+                    (num_start_hidden_items + num_visible_items).ceil() as usize,
+                    num_items,
+                );
+
+                let range = first_visible_item_idx..end_visible_item_idx;
+                let margin = first_visible_item_idx as Scalar * item_size.length;
+                (range, margin)
+            },
+        };
+
+        // Ensure there are at least as many indices as there are visible items.
+        if state.ids.items.len() < item_idx_range.len() {
+            let id_gen = &mut ui.widget_id_generator();
+            state.update(|state| state.ids.items.resize(item_idx_range.len(), id_gen));
+        }
+
+        let items = Items {
+            list_id: id,
+            item_indices: item_idx_range,
+            next_item_indices_index: 0,
+            last_id: None,
+            scroll_trigger_id: state.ids.scroll_trigger,
+            item_breadth: item_breadth,
+            direction: std::marker::PhantomData,
+            first_item_margin: first_item_margin,
+            item_size: item_size,
+        };
+
+        // Instantiate the `Scrollbar` only if necessary.
+        let auto_hide = match (is_scrollable, scrollbar_position) {
+            (false, _) | (true, None) => return (items, None),
+            (_, Some(ScrollbarPosition::NextTo)) => false,
+            (_, Some(ScrollbarPosition::OnTop)) => true,
+        };
+        let scrollbar_color = style.scrollbar_color(&ui.theme);
+        let scrollbar = D::scrollbar(id)
+            .and_if(prev.maybe_floating.is_some(), |s| s.floating(true))
+            .color(scrollbar_color)
+            .thickness(scrollbar_thickness)
+            .auto_hide(auto_hide);
+        let scrollbar = Scrollbar {
+            widget: scrollbar,
+            id: state.ids.scrollbar,
+        };
+
+        (items, Some(scrollbar))
+    }
+
+    fn size_item<W, D>(&self, widget: W, breadth: Scalar) -> W
+        where W: Widget,
+              D: Direction,
+    {
+        let widget = D::size_breadth(widget, breadth);
+        D::size_length(widget, self.length)
+    }
+
+}
+
+impl ItemSize for Dynamic {
+
+    fn update_list<D>(list: List<D, Self>, args: widget::UpdateArgs<List<D, Self>>)
+        -> <List<D, Self> as Widget>::Event
+        where D: Direction,
+    {
+        let widget::UpdateArgs { id, state, rect, prev, ui, style, .. } = args;
+        let List { item_size, num_items, .. } = list;
+
+        let (_, list_perpendicular_range) = D::ranges(rect);
+        let list_breadth = list_perpendicular_range.len();
+
+        // Always instantiate all items for a list with dynamically sized items.
+        let item_idx_range = 0..num_items;
+        let first_item_margin = 0.0;
+
+        // Ensure there are at least as many indices as there are visible items.
+        if state.ids.items.len() < item_idx_range.len() {
+            let id_gen = &mut ui.widget_id_generator();
+            state.update(|state| state.ids.items.resize(item_idx_range.len(), id_gen));
+        }
+
+        // The width of the scrollbar.
+        let scrollbar_thickness = style.scrollbar_thickness(&ui.theme)
+            .unwrap_or_else(|| {
+                ui.theme.widget_style::<widget::scrollbar::Style>()
+                    .and_then(|style| style.style.thickness)
+                    .unwrap_or(10.0)
+            });
+
+        let scrollbar_position = style.scrollbar_position(&ui.theme);
+        let item_breadth = match scrollbar_position {
+            Some(ScrollbarPosition::NextTo) => list_breadth - scrollbar_thickness,
+            _ => list_breadth,
+        };
+
+        let items = Items {
+            list_id: id,
+            item_indices: item_idx_range,
+            next_item_indices_index: 0,
+            last_id: None,
+            scroll_trigger_id: id,
+            item_breadth: item_breadth,
+            direction: std::marker::PhantomData,
+            first_item_margin: first_item_margin,
+            item_size: item_size,
+        };
+
+        // Instantiate the `Scrollbar` only if necessary.
+        let auto_hide = match scrollbar_position {
+            None => return (items, None),
+            Some(ScrollbarPosition::NextTo) => false,
+            Some(ScrollbarPosition::OnTop) => true,
+        };
+        let scrollbar_color = style.scrollbar_color(&ui.theme);
+        let scrollbar = D::scrollbar(id)
+            .and_if(prev.maybe_floating.is_some(), |s| s.floating(true))
+            .color(scrollbar_color)
+            .thickness(scrollbar_thickness)
+            .auto_hide(auto_hide);
+        let scrollbar = Scrollbar {
+            widget: scrollbar,
+            id: state.ids.scrollbar,
+        };
+
+        (items, Some(scrollbar))
+    }
+
+    fn size_item<W, D>(&self, widget: W, breadth: Scalar) -> W
+        where W: Widget,
+              D: Direction,
+    {
+        D::size_breadth(widget, breadth)
+    }
+
+}
+
+
+impl Direction for Down {
+    type Axis = widget::scroll::Y;
+
+    fn ranges(Rect { x, y }: Rect) -> (Range, Range) {
+        (y.invert(), x)
+    }
+
+    fn scrollbar(id: widget::Id) -> widget::Scrollbar<Self::Axis> {
+        widget::Scrollbar::y_axis(id)
+    }
+
+    fn common_scroll(common: &widget::CommonBuilder) -> Option<&widget::scroll::Scroll> {
+        common.maybe_y_scroll.as_ref()
+    }
+
+    fn scroll_list_kids<S>(list: List<Self, S>) -> List<Self, S>
+        where Self: Sized,
+              S: ItemSize,
+    {
+        list.scroll_kids_vertically()
+    }
+
+    fn position_item<W>(widget: W,
+                        last_id: Option<widget::Id>,
+                        scroll_trigger_id: widget::Id,
+                        first_item_margin: Scalar) -> W
+        where W: Widget,
+    {
+        match last_id {
+            None => widget.mid_top_with_margin_on(scroll_trigger_id, first_item_margin)
+                .align_left_of(scroll_trigger_id),
+            Some(id) => widget.down_from(id, 0.0),
+        }
+    }
+
+    fn position_scroll_trigger<W>(scroll_trigger: W, list: widget::Id) -> W
+        where W: Widget
+    {
+        scroll_trigger.mid_top_of(list)
+    }
+
+    fn size_breadth<W>(widget: W, breadth: Scalar) -> W
+        where W: Widget
+    {
+        widget.w(breadth)
+    }
+
+    fn size_length<W>(widget: W, length: Scalar) -> W
+        where W: Widget
+    {
+        widget.h(length)
+    }
+
+}
+
+impl Direction for Up {
+    type Axis = widget::scroll::Y;
+
+    fn ranges(Rect { x, y }: Rect) -> (Range, Range) {
+        (y, x)
+    }
+
+    fn scrollbar(id: widget::Id) -> widget::Scrollbar<Self::Axis> {
+        widget::Scrollbar::y_axis(id)
+    }
+
+    fn common_scroll(common: &widget::CommonBuilder) -> Option<&widget::scroll::Scroll> {
+        common.maybe_y_scroll.as_ref()
+    }
+
+    fn scroll_list_kids<S>(list: List<Self, S>) -> List<Self, S>
+        where Self: Sized,
+              S: ItemSize,
+    {
+        list.scroll_kids_vertically()
+    }
+
+    fn position_item<W>(widget: W,
+                        last_id: Option<widget::Id>,
+                        scroll_trigger_id: widget::Id,
+                        first_item_margin: Scalar) -> W
+        where W: Widget,
+    {
+        match last_id {
+            None => widget.mid_bottom_with_margin_on(scroll_trigger_id, first_item_margin)
+                .align_left_of(scroll_trigger_id),
+            Some(id) => widget.up_from(id, 0.0),
+        }
+    }
+
+    fn position_scroll_trigger<W>(scroll_trigger: W, list: widget::Id) -> W
+        where W: Widget
+    {
+        scroll_trigger.mid_bottom_of(list)
+    }
+
+    fn size_breadth<W>(widget: W, breadth: Scalar) -> W
+        where W: Widget
+    {
+        widget.w(breadth)
+    }
+
+    fn size_length<W>(widget: W, length: Scalar) -> W
+        where W: Widget
+    {
+        widget.h(length)
+    }
+
+}
+
+impl Direction for Left {
+    type Axis = widget::scroll::X;
+
+    fn ranges(Rect { x, y }: Rect) -> (Range, Range) {
+        (x.invert(), y)
+    }
+
+    fn scrollbar(id: widget::Id) -> widget::Scrollbar<Self::Axis> {
+        widget::Scrollbar::x_axis(id)
+    }
+
+    fn common_scroll(common: &widget::CommonBuilder) -> Option<&widget::scroll::Scroll> {
+        common.maybe_x_scroll.as_ref()
+    }
+
+    fn scroll_list_kids<S>(list: List<Self, S>) -> List<Self, S>
+        where Self: Sized,
+              S: ItemSize,
+    {
+        list.scroll_kids_horizontally()
+    }
+
+    fn position_item<W>(widget: W,
+                        last_id: Option<widget::Id>,
+                        scroll_trigger_id: widget::Id,
+                        first_item_margin: Scalar) -> W
+        where W: Widget,
+    {
+        match last_id {
+            None => widget.mid_right_with_margin_on(scroll_trigger_id, first_item_margin)
+                .align_top_of(scroll_trigger_id),
+            Some(id) => widget.left_from(id, 0.0),
+        }
+    }
+
+    fn position_scroll_trigger<W>(scroll_trigger: W, list: widget::Id) -> W
+        where W: Widget
+    {
+        scroll_trigger.mid_right_of(list)
+    }
+
+    fn size_breadth<W>(widget: W, breadth: Scalar) -> W
+        where W: Widget
+    {
+        widget.h(breadth)
+    }
+
+    fn size_length<W>(widget: W, length: Scalar) -> W
+        where W: Widget
+    {
+        widget.w(length)
+    }
+
+}
+
+impl Direction for Right {
+    type Axis = widget::scroll::X;
+
+    fn ranges(Rect { x, y }: Rect) -> (Range, Range) {
+        (x, y)
+    }
+
+    fn scrollbar(id: widget::Id) -> widget::Scrollbar<Self::Axis> {
+        widget::Scrollbar::x_axis(id)
+    }
+
+    fn common_scroll(common: &widget::CommonBuilder) -> Option<&widget::scroll::Scroll> {
+        common.maybe_x_scroll.as_ref()
+    }
+
+    fn scroll_list_kids<S>(list: List<Self, S>) -> List<Self, S>
+        where Self: Sized,
+              S: ItemSize,
+    {
+        list.scroll_kids_horizontally()
+    }
+
+    fn position_item<W>(widget: W,
+                        last_id: Option<widget::Id>,
+                        scroll_trigger_id: widget::Id,
+                        first_item_margin: Scalar) -> W
+        where W: Widget,
+    {
+        match last_id {
+            None => widget.mid_left_with_margin_on(scroll_trigger_id, first_item_margin)
+                .align_top_of(scroll_trigger_id),
+            Some(id) => widget.right_from(id, 0.0),
+        }
+    }
+
+    fn position_scroll_trigger<W>(scroll_trigger: W, list: widget::Id) -> W
+        where W: Widget
+    {
+        scroll_trigger.mid_left_of(list)
+    }
+
+    fn size_breadth<W>(widget: W, breadth: Scalar) -> W
+        where W: Widget
+    {
+        widget.h(breadth)
+    }
+
+    fn size_length<W>(widget: W, length: Scalar) -> W
+        where W: Widget
+    {
+        widget.w(length)
+    }
+
 }

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -247,7 +247,7 @@ impl<M, D, S> ListSelect<M, D, S>
     /// flowing. When a `List` is constructed with this method, all items will have a fixed, equal
     /// length.
     pub fn item_size(self, length: Scalar) -> ListSelect<M, D, widget::list::Fixed> {
-        let ListSelect { common, num_items, mode, direction, style, item_instantiation, .. } = self;
+        let ListSelect { common, num_items, mode, direction, style, .. } = self;
         ListSelect {
             common: common,
             num_items: num_items,
@@ -255,7 +255,7 @@ impl<M, D, S> ListSelect<M, D, S>
             direction: direction,
             item_size: widget::list::Fixed { length: length },
             style: style,
-            item_instantiation: item_instantiation,
+            item_instantiation: widget::list::ItemInstantiation::OnlyVisible,
         }
     }
 }
@@ -315,6 +315,10 @@ impl<M, D> ListSelect<M, D, widget::list::Fixed> {
     /// Indicates that an `Item` should be instatiated for every element in the list, regardless of
     /// whether or not the `Item` would be visible.
     ///
+    /// This is the default (and only) behaviour for `List`s with dynamic item sizes. This is
+    /// because a `List` cannot know the total length of its combined items in advanced when each
+    /// item is dynamically sized and their size is not given until they are set.
+    ///
     /// Note: This may cause significantly heavier CPU load for lists containing many items (100+).
     /// We only recommend using this when absolutely necessary as large lists may cause unnecessary
     /// bloating within the widget graph, and in turn result in greater traversal times.
@@ -327,7 +331,7 @@ impl<M, D> ListSelect<M, D, widget::list::Fixed> {
     /// avoid bloating the widget graph with unnecessary nodes and in turn keep traversal times to
     /// a minimum.
     ///
-    /// This is the default `List` behaviour.
+    /// This is the default behaviour for `ListSelect`s with fixed item sizes.
     pub fn instantiate_only_visible_items(mut self) -> Self {
         self.item_instantiation = widget::list::ItemInstantiation::OnlyVisible;
         self

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -377,7 +377,7 @@ impl<M, D, S> Widget for ListSelect<M, D, S>
         }
 
 
-        let mut list = widget::List::<D, _>::from_size(num_items, item_size);
+        let mut list = widget::List::<D, _>::from_item_size(num_items, item_size);
 
         let scrollbar_position = style.scrollbar_position(&ui.theme);
         list = match scrollbar_position {

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -7,13 +7,32 @@ use std;
 /// A wrapper around the `List` widget that handles single and multiple selection logic.
 #[derive(Clone)]
 #[allow(missing_copy_implementations)]
-pub struct ListSelect<M> {
+pub struct ListSelect<M, D, S> {
     common: widget::CommonBuilder,
-    item_h: Scalar,
     num_items: usize,
     mode: M,
+    direction: std::marker::PhantomData<D>,
+    item_size: S,
     style: widget::list::Style,
     item_instantiation: widget::list::ItemInstantiation,
+}
+
+/// A trait that extends the `List` `Direction` trait with behaviour necessary for the `ListSelect`
+/// widget.
+///
+/// Implemented for the `Down`, `Right`, `Up`, `Left` types.
+pub trait Direction: widget::list::Direction {
+    /// Maps a given `key` to a direction along the list.
+    fn key_direction(key: input::Key) -> Option<ListDirection>;
+}
+
+/// The direction in which the list flows.
+#[derive(Copy, Clone, Debug)]
+pub enum ListDirection {
+    /// The direction flowing from the start of the list to the end of the list.
+    Forward,
+    /// The direction flowing from the end of the list to the start of the list.
+    Backward,
 }
 
 /// Allows the `ListSelect` to be generic over `Single` and `Multiple` selection modes.
@@ -24,24 +43,25 @@ pub trait Mode {
     type Selection;
 
     /// Update the `PendingEvents` in accordance with the given `Click` event.
-    fn click_selection<F>(&self,
-                          event::Click,
-                          i: usize,
-                          num_items: usize,
-                          &State,
-                          is_selected: F,
-                          &mut PendingEvents<Self::Selection>)
+    fn click_selection<F, D, S>(&self,
+                                event::Click,
+                                i: usize,
+                                num_items: usize,
+                                &State,
+                                is_selected: F,
+                                &mut PendingEvents<Self::Selection, D, S>)
         where F: Fn(usize) -> bool;
 
     /// Update the `PendingEvents` in accordance with the given `KeyPress` event.
-    fn key_selection<F>(&self,
-                        event::KeyPress,
-                        i: usize,
-                        num_items: usize,
-                        &State,
-                        is_selected: F,
-                        &mut PendingEvents<Self::Selection>)
-        where F: Fn(usize) -> bool;
+    fn key_selection<F, D, S>(&self,
+                              event::KeyPress,
+                              i: usize,
+                              num_items: usize,
+                              &State,
+                              is_selected: F,
+                              &mut PendingEvents<Self::Selection, D, S>)
+        where F: Fn(usize) -> bool,
+              D: Direction;
 }
 
 widget_ids! {
@@ -58,28 +78,28 @@ pub struct State {
     last_selected_entry: std::cell::Cell<Option<usize>>,
 }
 
-/// Buffer use for storing events that have been produced but are yet to be yielded.
-pub type PendingEvents<S> = std::collections::VecDeque<Event<S>>;
+/// Buffer used for storing events that have been produced but are yet to be yielded.
+pub type PendingEvents<Selection, D, S> = std::collections::VecDeque<Event<Selection, D, S>>;
 
 /// An iterator-like type for yielding `ListSelect` `Event`s.
-pub struct Events<M>
+pub struct Events<M, D, S>
     where M: Mode,
 {
     id: widget::Id,
-    items: widget::list::Items,
+    items: widget::list::Items<D, S>,
     num_items: usize,
     mode: M,
-    pending_events: PendingEvents<M::Selection>,
+    pending_events: PendingEvents<M::Selection, D, S>,
 }
 
 /// The kind of events that the `ListSelect` may `react` to.
 /// Provides tuple(s) of index in list and string representation of selection
 #[derive(Clone, Debug)]
-pub enum Event<S> {
+pub enum Event<Selection, Direction, Size> {
     /// The next `Item` is ready for instantiation.
-    Item(widget::list::Item),
+    Item(widget::list::Item<Direction, Size>),
     /// A change in selection has occurred.
-    Selection(S),
+    Selection(Selection),
     /// A button press occurred while the widget was capturing the mouse.
     Press(event::Press),
     /// A button release occurred while the widget was capturing the mouse.
@@ -147,36 +167,120 @@ impl Selection {
 }
 
 
-impl ListSelect<Single> {
+impl ListSelect<Single, widget::list::Down, widget::list::Dynamic> {
     /// Construct a new ListSelect, allowing one selected item at a time.
-    pub fn single(num_items: usize, item_h: Scalar) -> Self {
-        Self::new(num_items, item_h, Single)
+    pub fn single(num_items: usize) -> Self {
+        Self::new(num_items, Single)
     }
 }
 
-impl ListSelect<Multiple> {
+impl ListSelect<Multiple, widget::list::Down, widget::list::Dynamic> {
     /// Construct a new ListSelect, allowing multiple selected items.
-    pub fn multiple(num_items: usize, item_h: Scalar) -> Self {
-        Self::new(num_items, item_h, Multiple)
+    pub fn multiple(num_items: usize) -> Self {
+        Self::new(num_items, Multiple)
     }
 }
 
-impl<M> ListSelect<M> {
+impl<M, D, S> ListSelect<M, D, S>
+    where M: Mode,
+          D: Direction,
+          S: widget::list::ItemSize,
+{
 
+    /// Flows items from top to bottom.
+    pub fn flow_down(self) -> ListSelect<M, widget::list::Down, S> {
+        let ListSelect { common, num_items, mode, item_size, style, item_instantiation, .. } = self;
+        ListSelect {
+            common: common,
+            num_items: num_items,
+            mode: mode,
+            direction: std::marker::PhantomData,
+            item_size: item_size,
+            style: style,
+            item_instantiation: item_instantiation,
+        }
+    }
+
+    /// Flows items from left to right.
+    pub fn flow_right(self) -> ListSelect<M, widget::list::Right, S> {
+        let ListSelect { common, num_items, mode, item_size, style, item_instantiation, .. } = self;
+        ListSelect {
+            common: common,
+            num_items: num_items,
+            mode: mode,
+            direction: std::marker::PhantomData,
+            item_size: item_size,
+            style: style,
+            item_instantiation: item_instantiation,
+        }
+    }
+
+    /// Flows items from right to left.
+    pub fn flow_left(self) -> ListSelect<M, widget::list::Left, S> {
+        let ListSelect { common, num_items, mode, item_size, style, item_instantiation, .. } = self;
+        ListSelect {
+            common: common,
+            num_items: num_items,
+            mode: mode,
+            direction: std::marker::PhantomData,
+            item_size: item_size,
+            style: style,
+            item_instantiation: item_instantiation,
+        }
+    }
+
+    /// Flows items from bottom to top.
+    pub fn flow_up(self) -> ListSelect<M, widget::list::Up, S> {
+        let ListSelect { common, num_items, mode, item_size, style, item_instantiation, .. } = self;
+        ListSelect {
+            common: common,
+            num_items: num_items,
+            mode: mode,
+            direction: std::marker::PhantomData,
+            item_size: item_size,
+            style: style,
+            item_instantiation: item_instantiation,
+        }
+    }
+
+    /// Specify a fixed item size, where size is a `Scalar` in the direction that the `List` is
+    /// flowing. When a `List` is constructed with this method, all items will have a fixed, equal
+    /// length.
+    pub fn item_size(self, length: Scalar) -> ListSelect<M, D, widget::list::Fixed> {
+        let ListSelect { common, num_items, mode, direction, style, item_instantiation, .. } = self;
+        ListSelect {
+            common: common,
+            num_items: num_items,
+            mode: mode,
+            direction: direction,
+            item_size: widget::list::Fixed { length: length },
+            style: style,
+            item_instantiation: item_instantiation,
+        }
+    }
+}
+
+impl<M> ListSelect<M, widget::list::Down, widget::list::Dynamic> {
     /// Begin building a new `ListSelect` with the given mode.
     ///
     /// This method is only useful when using a custom `Mode`, otherwise `ListSelect::single` or
     /// `ListSelect::multiple` will probably be more suitable.
-    pub fn new(num_items: usize, item_h: Scalar, mode: M) -> Self {
+    pub fn new(num_items: usize, mode: M) -> Self
+        where M: Mode,
+    {
         ListSelect {
             common: widget::CommonBuilder::new(),
             style: widget::list::Style::new(),
-            item_h: item_h,
             num_items: num_items,
+            item_size: widget::list::Dynamic {},
             mode: mode,
-            item_instantiation: widget::list::ItemInstantiation::OnlyVisible,
+            direction: std::marker::PhantomData,
+            item_instantiation: widget::list::ItemInstantiation::All,
         }
     }
+}
+
+impl<M, D, S> ListSelect<M, D, S> {
 
     /// Specifies that the `List` should be scrollable and should provide a `Scrollbar` to the
     /// right of the items.
@@ -193,8 +297,8 @@ impl<M> ListSelect<M> {
     }
 
     /// The width of the `Scrollbar`.
-    pub fn scrollbar_width(mut self, w: Scalar) -> Self {
-        self.style.scrollbar_width = Some(Some(w));
+    pub fn scrollbar_thickness(mut self, w: Scalar) -> Self {
+        self.style.scrollbar_thickness = Some(Some(w));
         self
     }
 
@@ -203,6 +307,10 @@ impl<M> ListSelect<M> {
         self.style.scrollbar_color = Some(color);
         self
     }
+
+}
+
+impl<M, D> ListSelect<M, D, widget::list::Fixed> {
 
     /// Indicates that an `Item` should be instatiated for every element in the list, regardless of
     /// whether or not the `Item` would be visible.
@@ -227,12 +335,14 @@ impl<M> ListSelect<M> {
 
 }
 
-impl<M> Widget for ListSelect<M>
+impl<M, D, S> Widget for ListSelect<M, D, S>
     where M: Mode,
+          D: Direction,
+          S: widget::list::ItemSize,
 {
     type State = State;
     type Style = widget::list::Style;
-    type Event = (Events<M>, Option<widget::list::Scrollbar>);
+    type Event = (Events<M, D, S>, Option<widget::list::Scrollbar<D::Axis>>);
 
     fn common(&self) -> &widget::CommonBuilder {
         &self.common
@@ -256,7 +366,7 @@ impl<M> Widget for ListSelect<M>
     /// Update the state of the ListSelect.
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { id, mut state, style, mut ui, .. } = args;
-        let ListSelect { num_items, item_h, item_instantiation, mode, .. } = self;
+        let ListSelect { num_items, item_size, item_instantiation, mode, .. } = self;
 
         // Make sure that `last_selected_entry` refers to an actual selected value in the list.
         // If not push first selected item, if any.
@@ -266,10 +376,16 @@ impl<M> Widget for ListSelect<M>
             }
         }
 
-        let scrollbar_position = style.scrollbar_position(&ui.theme);
 
-        let mut list = widget::List::new(num_items, item_h)
-            .and_if(scrollbar_position.is_some(), |ls| ls.scroll_kids_vertically());
+        let mut list = widget::List::<D, _>::from_size(num_items, item_size);
+
+        let scrollbar_position = style.scrollbar_position(&ui.theme);
+        list = match scrollbar_position {
+            Some(widget::list::ScrollbarPosition::OnTop) => list.scrollbar_on_top(),
+            Some(widget::list::ScrollbarPosition::NextTo) => list.scrollbar_next_to(),
+            None => list,
+        };
+
         list.item_instantiation = item_instantiation;
         list.style = style.clone();
         let (items, scrollbar) = list.middle_of(id).wh_of(id).set(state.ids.list, ui);
@@ -286,12 +402,14 @@ impl<M> Widget for ListSelect<M>
     }
 }
 
-impl<M> Events<M>
+impl<M, D, S> Events<M, D, S>
     where M: Mode,
+          D: Direction,
+          S: widget::list::ItemSize,
 {
 
     /// Yield the next `Event`.
-    pub fn next<F>(&mut self, ui: &Ui, is_selected: F) -> Option<Event<M::Selection>>
+    pub fn next<F>(&mut self, ui: &Ui, is_selected: F) -> Option<Event<M::Selection, D, S>>
         where F: Fn(usize) -> bool,
     {
         let Events {
@@ -315,7 +433,7 @@ impl<M> Events<M>
         let state = || {
             ui.widget_graph()
                 .widget(id)
-                .and_then(|container| container.unique_widget_state::<ListSelect<M>>())
+                .and_then(|container| container.unique_widget_state::<ListSelect<M, D, S>>())
                 .map(|&graph::UniqueWidgetState { ref state, .. }| state)
                 .expect("couldn't find `ListSelect` state in the widget graph")
         };
@@ -393,13 +511,13 @@ impl<M> Events<M>
 impl Mode for Single {
     type Selection = usize;
 
-    fn click_selection<F>(&self,
-                          _: event::Click,
-                          i: usize,
-                          _num_items: usize,
-                          state: &State,
-                          _is_selected: F,
-                          pending: &mut PendingEvents<Self::Selection>)
+    fn click_selection<F, D, S>(&self,
+                                _: event::Click,
+                                i: usize,
+                                _num_items: usize,
+                                state: &State,
+                                _is_selected: F,
+                                pending: &mut PendingEvents<Self::Selection, D, S>)
         where F: Fn(usize) -> bool,
     {
         state.last_selected_entry.set(Some(i));
@@ -407,24 +525,25 @@ impl Mode for Single {
         pending.push_back(event);
     }
 
-    fn key_selection<F>(&self,
-                        press: event::KeyPress,
-                        _i: usize,
-                        num_items: usize,
-                        state: &State,
-                        _is_selected: F,
-                        pending: &mut PendingEvents<Self::Selection>)
+    fn key_selection<F, D, S>(&self,
+                              press: event::KeyPress,
+                              _i: usize,
+                              num_items: usize,
+                              state: &State,
+                              _is_selected: F,
+                              pending: &mut PendingEvents<Self::Selection, D, S>)
         where F: Fn(usize) -> bool,
+              D: Direction,
     {
         let i = match state.last_selected_entry.get() {
             Some(i) => i,
             None => return,
         };
 
-        let selection = match press.key {
-            input::Key::Up => if i == 0 { 0 } else { i - 1 },
-            input::Key::Down => std::cmp::min(i + 1, num_items - 1),
-            _ => return,
+        let selection = match D::key_direction(press.key) {
+            Some(ListDirection::Backward) => if i == 0 { 0 } else { i - 1 },
+            Some(ListDirection::Forward) => std::cmp::min(i + 1, num_items - 1),
+            None => return,
         };
 
         state.last_selected_entry.set(Some(selection));
@@ -437,13 +556,13 @@ impl Mode for Single {
 impl Mode for Multiple {
     type Selection = Selection;
 
-    fn click_selection<F>(&self,
-                          click: event::Click,
-                          i: usize,
-                          num_items: usize,
-                          state: &State,
-                          is_selected: F,
-                          pending: &mut PendingEvents<Self::Selection>)
+    fn click_selection<F, D, S>(&self,
+                                click: event::Click,
+                                i: usize,
+                                num_items: usize,
+                                state: &State,
+                                is_selected: F,
+                                pending: &mut PendingEvents<Self::Selection, D, S>)
         where F: Fn(usize) -> bool,
     {
         let shift = click.modifiers.contains(input::keyboard::SHIFT);
@@ -485,14 +604,15 @@ impl Mode for Multiple {
         pending.push_back(event);
     }
 
-    fn key_selection<F>(&self,
-                        press: event::KeyPress,
-                        _i: usize,
-                        num_items: usize,
-                        state: &State,
-                        is_selected: F,
-                        pending: &mut PendingEvents<Self::Selection>)
+    fn key_selection<F, D, S>(&self,
+                              press: event::KeyPress,
+                              _i: usize,
+                              num_items: usize,
+                              state: &State,
+                              is_selected: F,
+                              pending: &mut PendingEvents<Self::Selection, D, S>)
         where F: Fn(usize) -> bool,
+              D: Direction,
     {
         let i = match state.last_selected_entry.get() {
             Some(i) => i,
@@ -501,14 +621,14 @@ impl Mode for Multiple {
 
         let alt = press.modifiers.contains(input::keyboard::ALT);
 
-        let end = match press.key {
-            input::Key::Up =>
+        let end = match D::key_direction(press.key) {
+            Some(ListDirection::Backward) => 
                 if i == 0 || alt { 0 } else { i - 1 },
-            input::Key::Down => {
+            Some(ListDirection::Forward) => {
                 let last_idx = num_items - 1;
                 if i >= last_idx || alt { last_idx } else { i + 1 }
             },
-            _ => return,
+            None => return,
         };
 
         state.last_selected_entry.set(Some(end));
@@ -528,4 +648,44 @@ impl Mode for Multiple {
         pending.push_back(event);
     }
 
+}
+
+impl Direction for widget::list::Down {
+    fn key_direction(key: input::Key) -> Option<ListDirection> {
+        match key {
+            input::Key::Down => Some(ListDirection::Forward),
+            input::Key::Up => Some(ListDirection::Backward),
+            _ => None,
+        }
+    }
+}
+
+impl Direction for widget::list::Up {
+    fn key_direction(key: input::Key) -> Option<ListDirection> {
+        match key {
+            input::Key::Up => Some(ListDirection::Forward),
+            input::Key::Down => Some(ListDirection::Backward),
+            _ => None,
+        }
+    }
+}
+
+impl Direction for widget::list::Right {
+    fn key_direction(key: input::Key) -> Option<ListDirection> {
+        match key {
+            input::Key::Right => Some(ListDirection::Forward),
+            input::Key::Left => Some(ListDirection::Backward),
+            _ => None,
+        }
+    }
+}
+
+impl Direction for widget::list::Left {
+    fn key_direction(key: input::Key) -> Option<ListDirection> {
+        match key {
+            input::Key::Left => Some(ListDirection::Forward),
+            input::Key::Right => Some(ListDirection::Backward),
+            _ => None,
+        }
+    }
 }


### PR DESCRIPTION
Supports `flow_down` (default), `flow_right`, `flow_up` and `flow_left`.

Also adds support to `List` and `ListSelect` for items with varying
sizes.

Both list widget types no longer take the item size in their
constructors. Instead, for lists with fixed item sizes, the `item_size`
method should be used.

The list and list_select examples have been updated accordingly.