### PR TITLE
Enable multisample anti-aliasing for glium backend

### DIFF
--- a/examples/all_winit_glium.rs
+++ b/examples/all_winit_glium.rs
@@ -31,6 +31,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIN_W, WIN_H)
             .with_title("Conrod with glium!")
+            .with_multisampling(8)
             .build_glium()
             .unwrap();
 

--- a/examples/all_winit_glium_threaded.rs
+++ b/examples/all_winit_glium_threaded.rs
@@ -29,6 +29,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIN_W, WIN_H)
             .with_title("Conrod with glium!")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -24,6 +24,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("Canvas Demo")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -23,6 +23,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("Click me!")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -251,6 +251,7 @@ fn main() {
         .with_vsync()
         .with_dimensions(WIDTH, HEIGHT)
         .with_title("Control Panel")
+        .with_multisampling(4)
         .build_glium()
         .unwrap();
 

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -16,6 +16,7 @@ fn main() {
         .with_vsync()
         .with_dimensions(WIDTH, HEIGHT)
         .with_title("FileNavigator Demo")
+        .with_multisampling(4)
         .build_glium()
         .unwrap();
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -27,6 +27,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("Hello Conrod!")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -28,6 +28,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("Image Widget Demonstration")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -34,6 +34,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("Image Button Demonstration")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -110,6 +110,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("Widget Demonstration")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -27,6 +27,7 @@ mod feature {
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
             .with_title("PlotPath Demo")
+            .with_multisampling(4)
             .build_glium()
             .unwrap();
 

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -36,6 +36,7 @@ mod feature {
         let display = glium::glutin::WindowBuilder::new()
             .with_vsync()
             .with_dimensions(WIDTH, HEIGHT)
+            .with_multisampling(4)
             .with_title("Primitive Widgets Demo")
             .build_glium()
             .unwrap();

--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -289,7 +289,7 @@ pub fn program<F>(facade: &F) -> Result<glium::Program, glium::program::ProgramC
 /// Default glium `DrawParameters` with alpha blending enabled.
 pub fn draw_parameters() -> glium::DrawParameters<'static> {
     let blend = glium::Blend::alpha_blending();
-    glium::DrawParameters { blend: blend, ..Default::default() }
+    glium::DrawParameters { multisampling: true, blend: blend, ..Default::default() }
 }
 
 


### PR DESCRIPTION
Closes #967.

@sp-1234 this seems to fix the anti-aliasing in the primitives example for me. Is this what you had in mind?