### PR TITLE
Replace default hasher for HashSet and HashMap on fnv.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 daggy = "0.4.0"
+fnv = "1.0"
 num = "0.1.30"
 pistoncore-input = "0.17.0"
 rusttype = "0.2.0"

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -64,7 +64,7 @@ pub fn theme() -> conrod::Theme {
         font_size_large: 26,
         font_size_medium: 18,
         font_size_small: 12,
-        widget_styling: std::collections::HashMap::new(),
+        widget_styling: conrod::theme::StyleMap::default(),
         mouse_drag_threshold: 0.0,
         double_click_threshold: std::time::Duration::from_millis(500),
     }

--- a/src/graph/algo.rs
+++ b/src/graph/algo.rs
@@ -191,8 +191,8 @@ fn cropped_area_of_widget_maybe_within_depth(graph: &Graph,
 /// FIXME: This currently uses call stack recursion to do a depth-first search through all
 /// depth_children for the total bounding box. This should use a proper `Dfs` type with it's own
 /// stack for safer traversal that won't blow the stack on hugely deep GUIs.
-pub fn kids_bounding_box(graph: &Graph,
-                         prev_updated: &std::collections::HashSet<widget::Id>,
+pub fn kids_bounding_box<T: std::hash::BuildHasher>(graph: &Graph,
+                         prev_updated: &std::collections::HashSet<widget::Id, T>,
                          idx: widget::Id) -> Option<Rect>
 {
     // When traversing the `depth_kids`, we only want to visit those who:

--- a/src/graph/algo.rs
+++ b/src/graph/algo.rs
@@ -7,7 +7,7 @@
 
 use daggy::Walker;
 use position::{Point, Rect};
-use std;
+use fnv;
 use super::{EdgeIndex, Graph};
 use widget;
 
@@ -191,8 +191,8 @@ fn cropped_area_of_widget_maybe_within_depth(graph: &Graph,
 /// FIXME: This currently uses call stack recursion to do a depth-first search through all
 /// depth_children for the total bounding box. This should use a proper `Dfs` type with it's own
 /// stack for safer traversal that won't blow the stack on hugely deep GUIs.
-pub fn kids_bounding_box<T: std::hash::BuildHasher>(graph: &Graph,
-                         prev_updated: &std::collections::HashSet<widget::Id, T>,
+pub fn kids_bounding_box(graph: &Graph,
+                         prev_updated: &fnv::FnvHashSet<widget::Id>,
                          idx: widget::Id) -> Option<Rect>
 {
     // When traversing the `depth_kids`, we only want to visit those who:

--- a/src/graph/depth_order.rs
+++ b/src/graph/depth_order.rs
@@ -49,10 +49,10 @@ impl DepthOrder {
     ///
     /// The `visit_by_depth` algorithm should not be recursive and instead use either looping,
     /// walking or iteration.
-    pub fn update(&mut self,
+    pub fn update<T: std::hash::BuildHasher>(&mut self,
                   graph: &Graph,
                   root: widget::Id,
-                  updated_widgets: &std::collections::HashSet<widget::Id>)
+                  updated_widgets: &std::collections::HashSet<widget::Id, T>)
     {
         let DepthOrder { ref mut indices, ref mut floating } = *self;
 
@@ -88,9 +88,9 @@ impl DepthOrder {
 
 
 /// Recursive function for visiting all nodes within the dag.
-fn visit_by_depth(graph: &Graph,
+fn visit_by_depth<T: std::hash::BuildHasher>(graph: &Graph,
                   idx: widget::Id,
-                  updated_widgets: &std::collections::HashSet<widget::Id>,
+                  updated_widgets: &std::collections::HashSet<widget::Id, T>,
                   depth_order: &mut Vec<widget::Id>,
                   floating_deque: &mut Vec<widget::Id>)
 {

--- a/src/graph/depth_order.rs
+++ b/src/graph/depth_order.rs
@@ -2,6 +2,7 @@
 
 use daggy::Walker;
 use std;
+use fnv;
 use super::{Graph, Node};
 use widget;
 
@@ -49,10 +50,10 @@ impl DepthOrder {
     ///
     /// The `visit_by_depth` algorithm should not be recursive and instead use either looping,
     /// walking or iteration.
-    pub fn update<T: std::hash::BuildHasher>(&mut self,
+    pub fn update(&mut self,
                   graph: &Graph,
                   root: widget::Id,
-                  updated_widgets: &std::collections::HashSet<widget::Id, T>)
+                  updated_widgets: &fnv::FnvHashSet<widget::Id>)
     {
         let DepthOrder { ref mut indices, ref mut floating } = *self;
 
@@ -88,9 +89,9 @@ impl DepthOrder {
 
 
 /// Recursive function for visiting all nodes within the dag.
-fn visit_by_depth<T: std::hash::BuildHasher>(graph: &Graph,
+fn visit_by_depth(graph: &Graph,
                   idx: widget::Id,
-                  updated_widgets: &std::collections::HashSet<widget::Id, T>,
+                  updated_widgets: &fnv::FnvHashSet<widget::Id>,
                   depth_order: &mut Vec<widget::Id>,
                   floating_deque: &mut Vec<widget::Id>)
 {

--- a/src/image.rs
+++ b/src/image.rs
@@ -3,6 +3,7 @@
 //! - [Map](./struct.Map.html)
 
 use std;
+use fnv;
 
 /// Unique image identifier.
 ///
@@ -33,8 +34,8 @@ pub struct Map<Img> {
     pub trigger_redraw: std::cell::Cell<bool>,
 }
 
-/// The type of `std::collections::HashMap` used within the `image::Map`.
-pub type HashMap<Img> = std::collections::HashMap<Id, Img>;
+/// The type of `std::collections::HashMap` with `fnv::FnvHasher` used within the `image::Map`.
+pub type HashMap<Img> = fnv::FnvHashMap<Id, Img>;
 
 /// An iterator yielding an `Id` for each new `Img` inserted into the `Map` via the `extend`
 /// method.
@@ -57,7 +58,7 @@ impl<Img> Map<Img> {
     pub fn new() -> Self {
         Map {
             next_index: 0,
-            map: std::collections::HashMap::new(),
+            map: HashMap::<Img>::default(),
             trigger_redraw: std::cell::Cell::new(true),
         }
     }

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -9,7 +9,7 @@
 
 use position::Point;
 use self::mouse::Mouse;
-use std;
+use fnv;
 use super::keyboard::{NO_MODIFIER, ModifierKey};
 use utils;
 use widget;
@@ -26,7 +26,7 @@ pub struct State {
     /// Mouse position and button state.
     pub mouse: Mouse,
     /// All in-progress touch interactions.
-    pub touch: std::collections::HashMap<super::touch::Id, self::touch::Touch>,
+    pub touch: fnv::FnvHashMap<super::touch::Id, self::touch::Touch>,
     /// Which widget, if any, is currently capturing the keyboard
     pub widget_capturing_keyboard: Option<widget::Id>,
     /// Which widget, if any, is currently capturing the mouse
@@ -45,7 +45,7 @@ impl State {
     /// Returns a fresh new input state
     pub fn new() -> State {
         State{
-            touch: std::collections::HashMap::new(),
+            touch: fnv::FnvHashMap::default(),
             mouse: Mouse::new(),
             widget_capturing_keyboard: None,
             widget_capturing_mouse: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(missing_docs)]
 
 extern crate daggy;
+extern crate fnv;
 extern crate num;
 extern crate input as piston_input;
 extern crate rusttype;

--- a/src/text.rs
+++ b/src/text.rs
@@ -91,6 +91,7 @@ impl<'a, I> Iterator for Lines<'a, I>
 
 /// The `font::Id` and `font::Map` types.
 pub mod font {
+    use fnv;
     use std;
 
     /// A type-safe wrapper around the `FontId`.
@@ -105,7 +106,7 @@ pub mod font {
     /// A collection of mappings from `font::Id`s to `rusttype::Font`s.
     pub struct Map {
         next_index: usize,
-        map: std::collections::HashMap<Id, super::Font>,
+        map: fnv::FnvHashMap<Id, super::Font>,
     }
 
     /// An iterator yielding an `Id` for each new `rusttype::Font` inserted into the `Map` via the
@@ -144,7 +145,7 @@ pub mod font {
         pub fn new() -> Self {
             Map {
                 next_index: 0,
-                map: std::collections::HashMap::new(),
+                map: fnv::FnvHashMap::default(),
             }
         }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -11,6 +11,10 @@ use std::any::Any;
 use text;
 use widget;
 
+/// `std::collections::HashMap` with `fnv::FnvHasher` for unique styling
+/// of each widget, index-able by the **Widget::kind**.
+pub type StyleMap = fnv::FnvHashMap<std::any::TypeId, WidgetDefault>;
+
 
 /// A serializable collection of canvas and widget styling defaults.
 pub struct Theme {
@@ -40,8 +44,9 @@ pub struct Theme {
     pub font_size_medium: u32,
     /// A default "small" font size.
     pub font_size_small: u32,
-    /// Unique styling for each widget, index-able by the **Widget::kind**.
-    pub widget_styling: fnv::FnvHashMap<std::any::TypeId, WidgetDefault>,
+    /// `StyleMap` for unique styling
+    /// of each widget, index-able by the **Widget::kind**.
+    pub widget_styling: StyleMap,
     /// Mouse Drag distance threshold determines the minimum distance from the mouse-down point
     /// that the mouse must move before starting a drag operation.
     pub mouse_drag_threshold: Scalar,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,7 @@
 use Scalar;
 use color::{Color, BLACK, WHITE};
 use position::{Align, Direction, Padding, Position, Relative};
+use fnv;
 use std;
 use std::any::Any;
 use text;
@@ -40,7 +41,7 @@ pub struct Theme {
     /// A default "small" font size.
     pub font_size_small: u32,
     /// Unique styling for each widget, index-able by the **Widget::kind**.
-    pub widget_styling: std::collections::HashMap<std::any::TypeId, WidgetDefault>,
+    pub widget_styling: fnv::FnvHashMap<std::any::TypeId, WidgetDefault>,
     /// Mouse Drag distance threshold determines the minimum distance from the mouse-down point
     /// that the mouse must move before starting a drag operation.
     pub mouse_drag_threshold: Scalar,
@@ -94,7 +95,7 @@ impl Theme {
             font_size_large: 26,
             font_size_medium: 18,
             font_size_small: 12,
-            widget_styling: std::collections::HashMap::new(),
+            widget_styling: fnv::FnvHashMap::default(),
             mouse_drag_threshold: 0.0,
             double_click_threshold: std::time::Duration::from_millis(500),
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,6 +5,7 @@ use input;
 use position::{self, Align, Direction, Dimensions, Padding, Point, Position, Range, Rect, Scalar};
 use render;
 use std;
+use fnv;
 use text;
 use theme::Theme;
 use utils;
@@ -67,12 +68,12 @@ pub struct Ui {
     /// The order in which widgets from the `widget_graph` are drawn.
     depth_order: graph::DepthOrder,
     /// The set of widgets that have been updated since the beginning of the `set_widgets` stage.
-    updated_widgets: std::collections::HashSet<widget::Id>,
+    updated_widgets: fnv::FnvHashSet<widget::Id>,
     /// The `updated_widgets` for the previous `set_widgets` stage.
     ///
     /// We use this to compare against the newly generated `updated_widgets` to see whether or not
     /// we require re-drawing.
-    prev_updated_widgets: std::collections::HashSet<widget::Id>,
+    prev_updated_widgets: fnv::FnvHashSet<widget::Id>,
     /// Scroll events that have been emitted during a call to `Ui::set_widgets`. These are usually
     /// emitted by some widget like the `Scrollbar`.
     ///
@@ -172,10 +173,11 @@ impl Ui {
             maybe_widgets_capacity.map_or_else(
                 || (Graph::new(),
                    graph::DepthOrder::new(),
-                   std::collections::HashSet::new()),
+                   fnv::FnvHashSet::default()),
                 |n| (Graph::with_node_capacity(n),
                      graph::DepthOrder::with_node_capacity(n),
-                     std::collections::HashSet::with_capacity(n)));
+                     std::collections::HashSet::with_capacity_and_hasher(n,
+                        fnv::FnvBuildHasher::default())));
 
         let window = widget_graph.add_placeholder();
         let prev_updated_widgets = updated_widgets.clone();
@@ -270,7 +272,7 @@ impl Ui {
     ///
     /// This set indicates which widgets have been instantiated since the beginning of the most
     /// recent `Ui::set_widgets` call.
-    pub fn updated_widgets(&self) -> &std::collections::HashSet<widget::Id> {
+    pub fn updated_widgets(&self) -> &fnv::FnvHashSet<widget::Id> {
         &self.updated_widgets
     }
 
@@ -278,7 +280,7 @@ impl Ui {
     ///
     /// This set indicates which widgets have were instantiated during the previous call to
     /// `Ui::set_widgets`.
-    pub fn prev_updated_widgets(&self) -> &std::collections::HashSet<widget::Id> {
+    pub fn prev_updated_widgets(&self) -> &fnv::FnvHashSet<widget::Id> {
         &self.prev_updated_widgets
     }
 

--- a/src/widget/list_select.rs
+++ b/src/widget/list_select.rs
@@ -120,15 +120,15 @@ pub struct Multiple;
 
 /// Represents some change in item selection for a `ListSelect` in `Multiple` mode.
 #[derive(Clone, Debug)]
-pub enum Selection {
+pub enum Selection<H: std::hash::BuildHasher = std::collections::hash_map::RandomState> {
     /// Items which have been added to the selection.
-    Add(std::collections::HashSet<usize>),
+    Add(std::collections::HashSet<usize, H>),
     /// Items which have been removed from the selection.
-    Remove(std::collections::HashSet<usize>),
+    Remove(std::collections::HashSet<usize, H>),
 }
 
 
-impl Selection {
+impl<H: std::hash::BuildHasher> Selection<H> {
 
     /// Update the given slice of `bool`s with this `Selection`.
     ///
@@ -151,7 +151,9 @@ impl Selection {
     }
 
     /// Update the given set of selected indices with this `Selection`.
-    pub fn update_index_set(&self, set: &mut std::collections::HashSet<usize>) {
+    pub fn update_index_set<T>(&self, set: &mut std::collections::HashSet<usize, T>)
+        where T: std::hash::BuildHasher
+    {
         match *self {
             Selection::Add(ref indices) =>
                 for &i in indices {


### PR DESCRIPTION
Fnv hasher s more efficient for smaller hash keys such as ids, which usually used in conrod.
Since we don't need resistance against HashDoS attacks, we can use more efficient hashing algorithm.

[Comparison of hashing algorithms in rust](http://cglab.ca/~abeinges/blah/hash-rs/)
[fnv docs](https://doc.servo.org/fnv/index.html)