### PR TITLE
Added function for overriding the button style with a custom one

### DIFF
--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -182,6 +182,11 @@ impl<'a> Button<'a, Flat> {
         Self::new_internal(Flat)
     }
 
+    /// Override the default button style
+    pub fn with_style(mut self, s: Style) -> Self{
+        self.style = s;
+        self
+    }
 }
 
 


### PR DESCRIPTION
Previously you had to do:
```
    let mut btn_file_primary = widget::Button::new()
            .label(STR_FILE)
            .h(16.0)
            .w(50.0)
            .top_left_of(ids.main_window);

    btn_file_primary.style = my_custom_style;
    
    btn_file_primary.set(ids.rectangle_fill, ui);
```

Now you only have to do:
```
    widget::Button::new()
            .label(STR_FILE)
            .h(16.0)
            .w(50.0)
            .with_style(button_style_primary)
            .top_left_of(ids.main_window)
            .set(ids.rectangle_fill, ui);
```

It's only a convenience function. Didn't add any tests.