### PR TITLE
[WIP] SDL2 backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ rusttype = "0.2.0"
 # - Converting piston `GenericEvent` types to `conrod::event::Raw`s.
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston` module.
+#
+# `sdl2`
+# Provides an SDL2 based primitive renderer and event handling.
+# Enabled the `conrod::backend::sdl2` module.
+sdl2 = { version = "0.30.0", optional = true, features = ["gfx"] }
 glium = { version = "0.16.0", optional = true }
 winit = { version = "0.5.9", optional = true }
 piston2d-graphics = { version = "0.21.1", optional = true }

--- a/examples/all_sdl2.rs
+++ b/examples/all_sdl2.rs
@@ -1,0 +1,155 @@
+//! An example demonstrating all widgets in a long, vertically scrollable window.
+
+#[cfg(feature="sdl2")] #[macro_use] extern crate conrod;
+#[cfg(feature="sdl2")] mod support;
+
+fn main() {
+    feature::main();
+}
+
+#[cfg(feature="sdl2")]
+mod feature {
+    extern crate find_folder;
+    extern crate sdl2;
+    extern crate image;
+    use conrod;
+    use support;
+
+    use self::sdl2::video::{Window, WindowBuilder};
+    use self::sdl2::render::{BlendMode, Canvas, Texture};
+    use self::sdl2::event::Event;
+    use self::sdl2::surface::Surface;
+    use self::sdl2::pixels::PixelFormatEnum;
+
+
+    pub fn main() {
+        const WIDTH: u32 = support::WIN_W;
+        const HEIGHT: u32 = support::WIN_H;
+
+        // Initialize the SDL2 subsystems we need
+        let sdl = sdl2::init().unwrap();
+        let video = sdl.video().unwrap();
+
+        // Construct the window and canvas.
+        let mut canvas: Canvas<Window> = WindowBuilder::new(&video, "All Widgets - SDL2 Backend", WIDTH, HEIGHT)
+            .build()
+            .unwrap()
+            .into_canvas()
+            .present_vsync()
+            .build()
+            .unwrap();
+
+        let texture_creator = canvas.texture_creator();
+
+        // construct our `Ui`.
+        let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64])
+            .theme(support::theme())
+            .build();
+
+        // Add a `Font` to the `Ui`'s `font::Map` from file.
+        let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();
+        let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
+        ui.fonts.insert_from_file(font_path).unwrap();
+
+        // Create a texture to use for efficiently caching text on the GPU.
+        let mut text_cache_pixels = Vec::new();
+        let (mut glyph_cache, mut text_texture_cache) = {
+            const SCALE_TOLERANCE: f32 = 0.1;
+            const POSITION_TOLERANCE: f32 = 0.1;
+            const TEXTURE_WIDTH: u32 = 512;
+            const TEXTURE_HEIGHT: u32 = 512;
+
+            let cache = conrod::text::GlyphCache::new(TEXTURE_WIDTH, TEXTURE_HEIGHT, SCALE_TOLERANCE, POSITION_TOLERANCE);
+
+            // The format uses the reversed channel order since we're assuming little endian
+            let mut texture = texture_creator.create_texture_static(Some(PixelFormatEnum::ABGR8888), TEXTURE_WIDTH, TEXTURE_HEIGHT).unwrap();
+            texture.set_blend_mode(BlendMode::Blend);   // FIXME not sure if add or blend is right
+            // FIXME: Also, SDL claims that the blend mode is set automatically
+            (cache, texture)
+        };
+
+        // Instantiate the generated list of widget identifiers.
+        let ids = support::Ids::new(ui.widget_id_generator());
+
+        // Load the rust logo from file to a piston_window texture.
+        let rust_logo: Texture = {
+            let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
+            let path = assets.join("images/rust.png");
+
+            // Use the `image` crate to load the file. Could also use `sdl2::image` if enabled
+            // (which uses the `SDL_image` library internally).
+
+            let rgba_image = image::open(&path).unwrap().to_rgba();
+            let (w, h) = rgba_image.dimensions();
+            let mut raw_data = rgba_image.into_raw();
+
+            // The format uses the reversed channel order since we're assuming little endian
+            let surface = Surface::from_data(&mut raw_data, w, h, w * 4, PixelFormatEnum::ABGR8888).unwrap();
+            texture_creator.create_texture_from_surface(surface).unwrap()
+        };
+
+        // Create our `conrod::image::Map` which describes each of our widget->image mappings.
+        // In our case we only have one image, however the macro may be used to list multiple.
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(rust_logo);
+
+        // A demonstration of some state that we'd like to control with the App.
+        let mut app = support::DemoApp::new(rust_logo);
+
+        // Poll events from SDL's event pump
+        let mut event_pump = sdl.event_pump().unwrap();
+        for event in event_pump.wait_iter() {
+            if let Event::Quit { .. } = event {
+                println!("Received quit event, exiting!");
+                break;
+            }
+
+            // Convert the SDL2 event to a conrod event.
+            let viewport = canvas.viewport();
+            let (win_w, win_h) = (viewport.width() as conrod::Scalar, viewport.height() as conrod::Scalar);
+            if let Some(e) = conrod::backend::sdl2::event::convert(event.clone(), win_w, win_h) {
+                ui.handle_event(e);
+            }
+
+            {
+                let mut ui = ui.set_widgets();
+                support::gui(&mut ui, &ids, &mut app);
+            }
+
+            if let Some(primitives) = ui.draw_if_changed() {
+
+                // A function used for caching glyphs to the texture cache.
+                let cache_queued_glyphs = |_: &mut Canvas<_>,
+                                           cache: &mut Texture,
+                                           rect: conrod::text::rt::Rect<u32>,
+                                           data: &[u8]|
+                    {
+                        text_cache_pixels.clear();
+                        text_cache_pixels.extend(data.iter().flat_map(|&b| vec![255, 255, 255, b]));
+
+                        let sdl_rect = (rect.min.x as i32, rect.min.y as i32, rect.width(), rect.height()).into();
+                        let pitch = 4 * rect.width() as usize;   // Bytes per row
+                        cache.update(Some(sdl_rect), &text_cache_pixels, pitch).unwrap();
+                    };
+
+                // Draw the conrod `render::Primitives`.
+                canvas.clear();
+                conrod::backend::sdl2::draw::primitives(primitives,
+                                                        &mut canvas,
+                                                        &mut text_texture_cache,
+                                                        &mut glyph_cache,
+                                                        cache_queued_glyphs,
+                                                        &mut image_map);
+                canvas.present();
+            }
+        }
+    }
+}
+
+#[cfg(not(feature="sdl2"))]
+mod feature {
+    pub fn main() {
+        println!("This example requires the `sdl2` feature. \
+                 Try running `cargo run --release --features=\"sdl2\" --example <example_name>`");
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,3 +10,4 @@
 #[cfg(feature="glium")] pub mod glium;
 #[cfg(feature="winit")] pub mod winit;
 #[cfg(feature="piston")] pub mod piston;
+#[cfg(feature="sdl2")] pub mod sdl2;

--- a/src/backend/sdl2/draw.rs
+++ b/src/backend/sdl2/draw.rs
@@ -1,0 +1,177 @@
+//! Provides methods to draw conrod primitives.
+//!
+//! Primitives are drawn using the SDL renderer's capabilities or `SDL_gfx` for more involved
+//! shapes.
+
+use super::sdl2::render::{Canvas, RenderTarget, Texture};
+use super::sdl2::rect::Rect as SdlRect;
+use super::sdl2::pixels::Color as SdlColor;
+use super::sdl2::gfx::primitives::DrawRenderer;
+
+use render::{self, PrimitiveWalker};
+use color::Color;
+use position::rect::Rect;
+use position::{Point, Scalar};
+use text;
+use image;
+
+/// Renders a sequence of primitives.
+///
+/// # Parameters
+///
+/// * `primitives`: A `PrimitiveWalker` yielding the primitives to be rendered.
+/// * `canvas`: An SDL `Canvas` the primitives are drawn onto.
+/// * `text_texture_cache`: An SDL `Texture` acting as the on-GPU glyph cache.
+/// * `glyph_cache`: The Rusttype glyph cache to use.
+/// * `cache_queued_glyphs`: Callback function called when `text_texture_cache` should be updated
+///   with new data.
+/// * `image_map`: Map of image IDs to SDL `Texture`s.
+pub fn primitives<'a, 't: 'a, P, U: 'a, C>(
+    mut primitives: P,
+    canvas: &'a mut Canvas<U>,
+    text_texture_cache: &'a mut Texture<'t>,
+    glyph_cache: &'a mut text::GlyphCache,
+    mut cache_queued_glyphs: C,
+    image_map: &'a mut image::Map<Texture<'t>>,
+)
+    where P: PrimitiveWalker,
+          U: RenderTarget,
+          C: FnMut(&mut Canvas<U>, &mut Texture, text::rt::Rect<u32>, &[u8]),
+{
+    let dpi_factor = dpi_factor();
+
+    let viewport = canvas.viewport();
+    let (voff_x, voff_y) = (viewport.w as Scalar / 2.0, viewport.h as Scalar / 2.0);
+
+    // Maps a conrod point to SDL's coordinate system
+    let map_point = |p: Point| {
+        [(p[0] + voff_x) as i32, (- p[1] + voff_y) as i32]
+    };
+
+    // Translates a conrod `Rect` to SDL, changing coordinate systems.
+    // SDL's coordinate system originates at the top left corner, y pointing downwards.
+    let map_rect = |rect: Rect| SdlRect::new(
+        map_point(rect.top_left())[0] as i32,
+        map_point(rect.top_left())[1] as i32,
+        rect.w() as u32,
+        rect.h() as u32
+    );
+
+    let map_color = |color: Color| {
+        let rgba = color.to_rgb();
+        SdlColor {
+            r: (rgba.0 * 255.0) as u8,
+            g: (rgba.1 * 255.0) as u8,
+            b: (rgba.2 * 255.0) as u8,
+            a: (rgba.3 * 255.0) as u8,
+        }
+    };
+
+    while let Some(primitive) = primitives.next_primitive() {
+        let render::Primitive { kind, scizzor, rect, .. } = primitive;
+
+        canvas.set_clip_rect(map_rect(scizzor));
+
+        match kind {
+
+            render::PrimitiveKind::Rectangle { color } => {
+                canvas.set_draw_color(map_color(color));
+                canvas.fill_rect(map_rect(rect));
+            },
+
+            render::PrimitiveKind::Polygon { color, points } => {
+                let (mut vx, mut vy) = (Vec::new(), Vec::new());
+
+                for p in points {
+                    let p = map_point(*p);
+                    vx.push(p[0] as i16);
+                    vy.push(p[1] as i16);
+                }
+
+                canvas.filled_polygon(&vx, &vy, map_color(color)).unwrap();
+            },
+
+            render::PrimitiveKind::Lines { color, cap: _, thickness, points } => {
+                // FIXME Doesn't handle the cap properly
+                for points in points.windows(2) {
+                    let (start, end) = (map_point(points[0]), map_point(points[1]));
+                    canvas.thick_line(start[0] as i16, start[1] as i16, end[0] as i16, end[1] as i16, thickness as u8, map_color(color)).unwrap();
+                }
+            },
+
+            render::PrimitiveKind::Text { color, text, font_id } => {
+
+                let positioned_glyphs = text.positioned_glyphs(dpi_factor);
+
+                // Queue the glyphs to be cached.
+                for glyph in positioned_glyphs.iter() {
+                    glyph_cache.queue_glyph(font_id.index(), glyph.clone());
+                }
+
+                // Cache the glyphs within the GPU cache.
+                glyph_cache.cache_queued(|rect, data| {
+                    cache_queued_glyphs(canvas, text_texture_cache, rect, data)
+                }).unwrap();
+
+                let cache_id = font_id.index();
+                let query = text_texture_cache.query();
+                let (tex_w, tex_h) = (query.width, query.height);
+
+                let rectangles = positioned_glyphs.into_iter()
+                    .filter_map(|g| glyph_cache.rect_for(cache_id, g).ok().unwrap_or(None))
+                    .map(|(uv_rect, screen_rect)| {
+                        let rectangle = {
+                            let div_dpi_factor = |s| (s as f32 / dpi_factor as f32) as f64;
+                            let left = div_dpi_factor(screen_rect.min.x);
+                            let top = div_dpi_factor(screen_rect.min.y);
+                            let right = div_dpi_factor(screen_rect.max.x);
+                            let bottom = div_dpi_factor(screen_rect.max.y);
+                            let w = right - left;
+                            let h = bottom - top;
+                            Some(SdlRect::new(left as i32, top as i32, w as u32, h as u32))
+                        };
+                        let source_rectangle = {
+                            let x = (uv_rect.min.x * tex_w as f32) as f64;
+                            let y = (uv_rect.min.y * tex_h as f32) as f64;
+                            let w = ((uv_rect.max.x - uv_rect.min.x) * tex_w as f32) as f64;
+                            let h = ((uv_rect.max.y - uv_rect.min.y) * tex_h as f32) as f64;
+                            Some(SdlRect::new(x as i32, y as i32, w as u32, h as u32))
+                        };
+                        (rectangle, source_rectangle)
+                    });
+
+                let color = map_color(color);
+                text_texture_cache.set_color_mod(color.r, color.g, color.b);
+                text_texture_cache.set_alpha_mod(color.a);
+
+                for (dest, src) in rectangles {
+                    canvas.copy(&text_texture_cache, src, dest).unwrap();
+                }
+            },
+
+            render::PrimitiveKind::Image { image_id, color, source_rect } => {
+                if let Some(img) = image_map.get_mut(image_id) {
+                    if let Some(color) = color {
+                        let color = map_color(color);
+                        img.set_color_mod(color.r, color.g, color.b);
+                        img.set_alpha_mod(color.a);
+                    }
+
+                    canvas.copy(img, source_rect.map(|r| SdlRect::new(r.x.start as i32, r.y.start as i32, r.w() as u32, r.h() as u32)), map_rect(rect)).unwrap();
+                } else {
+                    panic!("no entry in image map for id {:?}", image_id);
+                }
+            },
+
+            render::PrimitiveKind::Other(_widget) => {},
+
+            _ => {},
+
+        }
+    }
+}
+
+fn dpi_factor() -> f32 {
+    // FIXME: We can calculate the DPI factor by accessing the video subsystem
+    1.0
+}

--- a/src/backend/sdl2/event.rs
+++ b/src/backend/sdl2/event.rs
@@ -1,0 +1,98 @@
+use super::sdl2::event::Event;
+use super::sdl2::mouse::MouseButton;
+
+use input::state::mouse;
+use {Point, Scalar};
+use event::Input;
+use input;
+
+pub fn convert(event: Event, win_w: Scalar, win_h: Scalar) -> Option<Input> {
+    // Translate the coordinates from top-left-origin-with-y-down to centre-origin-with-y-up.
+    let translate_coords = |xy: Point| (xy[0] - win_w / 2.0, -(xy[1] - win_h / 2.0));
+
+    match event {
+        Event::MouseWheel { x, y, .. } => Some(Input::Motion(input::Motion::Scroll {
+            x: x as Scalar * 20.0,
+            y: -(y as Scalar) * 20.0
+        })),
+        Event::MouseMotion {x, y, .. } => {
+            let (x, y) = translate_coords([x as Scalar, y as Scalar]);
+            Some(Input::Motion(input::Motion::MouseCursor { x, y }))
+        }
+        Event::MouseButtonDown { mouse_btn, .. } => {
+            Some(Input::Press(input::Button::Mouse(convert_mouse_btn(mouse_btn))))
+        }
+        Event::MouseButtonUp { mouse_btn, .. } => {
+            Some(Input::Release(input::Button::Mouse(convert_mouse_btn(mouse_btn))))
+        }
+        _ => None,
+    }
+
+    /*
+    if let Some(xy) = event.mouse_cursor_args() {
+        let (x, y) = translate_coords(xy);
+        return Some(Input::Motion(input::Motion::MouseCursor { x: x, y: y }));
+    }
+
+    if let Some(rel_xy) = event.mouse_relative_args() {
+        let (rel_x, rel_y) = translate_coords(rel_xy);
+        return Some(Input::Motion(input::Motion::MouseRelative { x: rel_x, y: rel_y }));
+    }
+
+    if let Some(xy) = event.mouse_scroll_args() {
+        // Invert the scrolling of the *y* axis as *y* is up in conrod.
+        let (x, y) = (xy[0], -xy[1]);
+        return Some(Input::Motion(input::Motion::Scroll { x: x, y: y }));
+    }
+
+    if let Some(args) = event.controller_axis_args() {
+        return Some(Input::Motion(input::Motion::ControllerAxis(args)));
+    }
+
+    if let Some(args) = event.touch_args() {
+        let id = input::touch::Id::new(args.id as u64);
+        let xy = [args.x, args.y];
+        let phase = match args.touch {
+            ::piston_input::Touch::Start => input::touch::Phase::Start,
+            ::piston_input::Touch::Move => input::touch::Phase::Move,
+            ::piston_input::Touch::Cancel => input::touch::Phase::Cancel,
+            ::piston_input::Touch::End => input::touch::Phase::End,
+        };
+        let touch = input::Touch { id: id, xy: xy, phase: phase };
+        return Some(Input::Touch(touch));
+    }
+
+    if let Some(button) = event.press_args() {
+        return Some(Input::Press(button));
+    }
+
+    if let Some(button) = event.release_args() {
+        return Some(Input::Release(button));
+    }
+
+    if let Some(text) = event.text_args() {
+        return Some(Input::Text(text));
+    }
+
+    if let Some(dim) = event.resize_args() {
+        return Some(Input::Resize(dim[0], dim[1]));
+    }
+
+    if let Some(b) = event.focus_args() {
+        return Some(Input::Focus(b));
+    }
+
+    None
+    */
+}
+
+fn convert_mouse_btn(btn: MouseButton) -> mouse::Button {
+    match btn {
+        MouseButton::Left => mouse::Button::Left,
+        MouseButton::Right => mouse::Button::Right,
+        MouseButton::Middle => mouse::Button::Middle,
+        MouseButton::X1 => mouse::Button::X1,
+        MouseButton::X2 => mouse::Button::X2,
+        MouseButton::Unknown => mouse::Button::Unknown,
+    }
+}

--- a/src/backend/sdl2/mod.rs
+++ b/src/backend/sdl2/mod.rs
@@ -1,0 +1,6 @@
+//! An SDL2 rendering backend.
+
+extern crate sdl2;
+
+pub mod draw;
+pub mod event;


### PR DESCRIPTION
This implements an SDL2 backend that works similar to the piston_graphics backend. It uses the `sdl2` crate, the core SDL2 library, as well as SDL_gfx, a library that can draw more complex 2D shapes like polygons (core SDL is limited to rects, points and lines).

Missing:

* [ ] Event conversion is incomplete
* [ ] Scroll events get multiplied by a rather large value because conrod scrolls far too slow otherwise
* [ ] Graphical glitches in the provided example (the scrollbar is black when scrolled down, the rounded rectangle gets a thick black border when at the edge of the screen - but only sometimes)
* [ ] Handling of line caps
* [ ] DPI handling