### PR TITLE
[WIP] Update gfx winit example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,18 +48,24 @@ rusttype = "0.2.0"
 glium = { version = "0.17", optional = true }
 winit = { version = "0.7", optional = true }
 piston2d-graphics = { version = "0.21.1", optional = true }
+glutin = { version = "0.9", optional = true }
 
 [features]
 piston = ["piston2d-graphics"]
+glutin_winit = ["glutin"]
+
 
 [dev-dependencies]
 find_folder = "0.3.0"
 image = "0.13.0"
 rand = "0.3.13"
 # glutin_gfx.rs example dependencies
-gfx = "0.15.1"
-gfx_core = "0.7.0"
-gfx_window_glutin = "0.15.0"
-glutin = "0.7.0"
+# gfx = "0.15.1"
+# gfx_core = "0.7.0"
+# gfx_window_glutin = "0.15.0"
+# glutin = "0.7.0"
+gfx = { git = "https://github.com/gfx-rs/gfx.git" } 
+gfx_core = { git = "https://github.com/gfx-rs/gfx.git" } 
+gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx.git" } 
 # piston_window.rs example dependencies
 piston_window = "0.65.0"

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -6,6 +6,7 @@ use Scalar;
 use event::Input;
 use input;
 #[cfg(feature = "glium")] use glium;
+#[cfg(feature = "glutin_winit")] use glutin;
 
 
 /// Types that have access to a `winit::Window` and can provide the necessary dimensions and hidpi
@@ -28,6 +29,17 @@ impl WinitWindow for winit::Window {
         winit::Window::hidpi_factor(self)
     }
 }
+
+#[cfg(feature = "glutin_winit")]
+impl WinitWindow for glutin::GlWindow {
+    fn get_inner_size(&self) -> Option<(u32, u32)> {
+        glutin::Window::get_inner_size(self.window())
+    }
+    fn hidpi_factor(&self) -> f32 {
+        glutin::Window::hidpi_factor(self.window())
+    }
+}
+
 
 #[cfg(feature = "glium")]
 impl WinitWindow for glium::Display {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate input as piston_input;
 extern crate rusttype;
 
 #[cfg(feature="glium")] #[macro_use] pub extern crate glium;
+#[cfg(feature = "glutin_winit")] pub extern crate glutin;
 
 pub use color::{Color, Colorable};
 pub use border::{Bordering, Borderable};


### PR DESCRIPTION
There's one quite hacky commit I had to make to get this to compile with the current version dependency hell, but the basic goal here is to get on track with the `all_winit_gfx` example to show where I'm headed with it. I'm sure we'll be able to put most of this boilerplate in `mod backend`.

Run it with:
`cargo run --example all_winit_gfx --features "winit glutin_winit"`