### PR TITLE
 Add helper triangle iterators to several widget modules

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -359,7 +359,7 @@ impl<'a> Primitives<'a> {
                             let cap = line_style.get_cap(theme);
                             let thickness = line_style.get_thickness(theme);
                             let points = array.iter().cloned();
-                            let triangles = match widget::triangles::from_lines(points, cap, thickness) {
+                            let triangles = match widget::point_path::triangles(points, cap, thickness) {
                                 None => &[],
                                 Some(iter) => {
                                     triangles.extend(iter);
@@ -404,7 +404,7 @@ impl<'a> Primitives<'a> {
                     match *style {
 
                         ShapeStyle::Fill(_) => {
-                            let triangles = match widget::triangles::from_polygon(points) {
+                            let triangles = match widget::polygon::triangles(points) {
                                 None => &[],
                                 Some(iter) => {
                                     triangles.extend(iter);
@@ -421,7 +421,7 @@ impl<'a> Primitives<'a> {
                         ShapeStyle::Outline(ref line_style) => {
                             let cap = line_style.get_cap(theme);
                             let thickness = line_style.get_thickness(theme);
-                            let triangles = match widget::triangles::from_lines(points, cap, thickness) {
+                            let triangles = match widget::point_path::triangles(points, cap, thickness) {
                                 None => &[],
                                 Some(iter) => {
                                     triangles.extend(iter);
@@ -448,7 +448,7 @@ impl<'a> Primitives<'a> {
                     match *style {
 
                         ShapeStyle::Fill(_) => {
-                            let triangles = match widget::triangles::from_polygon(points) {
+                            let triangles = match widget::polygon::triangles(points) {
                                 None => &[],
                                 Some(iter) => {
                                     triangles.extend(iter);
@@ -465,7 +465,7 @@ impl<'a> Primitives<'a> {
                         ShapeStyle::Outline(ref line_style) => {
                             let cap = line_style.get_cap(theme);
                             let thickness = line_style.get_thickness(theme);
-                            let triangles = match widget::triangles::from_lines(points, cap, thickness) {
+                            let triangles = match widget::point_path::triangles(points, cap, thickness) {
                                 None => &[],
                                 Some(iter) => {
                                     triangles.extend(iter);
@@ -489,7 +489,7 @@ impl<'a> Primitives<'a> {
                     let cap = style.get_cap(theme);
                     let thickness = style.get_thickness(theme);
                     let points = std::iter::once(state.start).chain(std::iter::once(state.end));
-                    let triangles = match widget::triangles::from_lines(points, cap, thickness) {
+                    let triangles = match widget::point_path::triangles(points, cap, thickness) {
                         None => &[],
                         Some(iter) => {
                             triangles.extend(iter);
@@ -511,7 +511,7 @@ impl<'a> Primitives<'a> {
                     let cap = style.get_cap(theme);
                     let thickness = style.get_thickness(theme);
                     let points = state.points.iter().map(|&t| t);
-                    let triangles = match widget::triangles::from_lines(points, cap, thickness) {
+                    let triangles = match widget::point_path::triangles(points, cap, thickness) {
                         None => &[],
                         Some(iter) => {
                             triangles.extend(iter);

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -116,6 +116,13 @@ pub fn circumference(rect: Rect, resolution: usize) -> Circumference {
     }
 }
 
+/// An iterator yielding the triangles that describe the given oval.
+///
+/// Returns `None` if the `resolution` is less than `3`.
+pub fn triangles(rect: Rect, resolution: usize) -> Option<Triangles> {
+    widget::polygon::triangles(circumference(rect, resolution))
+}
+
 /// An iterator yielding the `Oval`'s edges as a circumference represented as a series of edges.
 #[derive(Clone)]
 #[allow(missing_copy_implementations)]
@@ -127,6 +134,9 @@ pub struct Circumference {
     half_w: Scalar,
     half_h: Scalar,
 }
+
+/// An iterator yielding the triangles that describe an oval.
+pub type Triangles = widget::polygon::Triangles<Circumference>;
 
 impl Iterator for Circumference {
     type Item = Point;

--- a/src/widget/primitive/shape/rectangle.rs
+++ b/src/widget/primitive/shape/rectangle.rs
@@ -3,9 +3,10 @@
 //! Due to the frequency of its use in GUIs, the `Rectangle` gets its own widget to allow backends
 //! to specialise their rendering implementations.
 
-use {Color, Colorable, Dimensions, Sizeable, Widget};
+use {Color, Colorable, Dimensions, Point, Rect, Sizeable, Widget};
 use super::Style as Style;
 use widget;
+use widget::triangles::Triangle;
 
 
 /// A basic, non-interactive rectangle shape widget.
@@ -104,4 +105,12 @@ impl Colorable for Rectangle {
         self.style.set_color(color);
         self
     }
+}
+
+
+/// The two triangles that describe the given `Rect`.
+pub fn triangles(rect: Rect) -> (Triangle<Point>, Triangle<Point>) {
+    let (l, r, b, t) = rect.l_r_b_t();
+    let quad = [[l, t], [r, t], [r, b], [l, b]];
+    widget::triangles::from_quad(quad)
 }

--- a/src/widget/primitive/shape/triangles.rs
+++ b/src/widget/primitive/shape/triangles.rs
@@ -1,6 +1,6 @@
 //! A primitive widget that allows for drawing using a list of triangles.
 
-use {Rect, Point, Positionable, Scalar, Sizeable, Widget};
+use {Rect, Point, Positionable, Sizeable, Widget};
 use color;
 use std;
 use utils::{vec2_add, vec2_sub};
@@ -339,47 +339,6 @@ impl<S, I> Widget for Triangles<S, I>
 }
 
 
-
-/// An iterator that triangulates a polygon represented by a sequence of points.
-#[derive(Clone)]
-pub struct FromPolygon<I> {
-    first: Point,
-    prev: Point,
-    points: I,
-}
-
-/// An iterator that triangulates a series of lines represented by a sequence of points.
-#[derive(Clone)]
-pub struct FromLines<I> {
-    next: Option<Triangle<Point>>,
-    prev: Point,
-    points: I,
-    thickness: Scalar,
-    cap: widget::line::Cap,
-}
-
-/// Triangulate the polygon given as a list of `Point`s describing its sides.
-///
-/// Returns `None` if the given iterator yields less than two points.
-pub fn from_polygon<I>(points: I) -> Option<FromPolygon<I::IntoIter>>
-    where I: IntoIterator<Item=Point>,
-{
-    let mut points = points.into_iter();
-    let first = match points.next() {
-        Some(p) => p,
-        None => return None,
-    };
-    let prev = match points.next() {
-        Some(p) => p,
-        None => return None,
-    };
-    Some(FromPolygon {
-        first: first,
-        prev: prev,
-        points: points,
-    })
-}
-
 /// Triangulates the given quad, represented by four points that describe its edges in either
 /// clockwise or anti-clockwise order.
 ///
@@ -432,76 +391,4 @@ pub fn from_polygon<I>(points: I) -> Option<FromPolygon<I::IntoIter>>
 pub fn from_quad(points: [Point; 4]) -> (Triangle<Point>, Triangle<Point>) {
     let (a, b, c, d) = (points[0], points[1], points[2], points[3]);
     (Triangle([a, b, c]), Triangle([a, c, d]))
-}
-
-/// Triangulate a series of lines represented by a sequence of points.
-///
-/// Returns `None` if the given iterator yields less than one point.
-pub fn from_lines<I>(points: I, cap: widget::line::Cap, thickness: Scalar)
-    -> Option<FromLines<I::IntoIter>>
-    where I: IntoIterator<Item=Point>,
-{
-    let mut points = points.into_iter();
-    let first = match points.next() {
-        Some(point) => point,
-        None => return None,
-    };
-    Some(FromLines {
-        next: None,
-        prev: first,
-        points: points,
-        thickness: thickness,
-        cap: cap,
-    })
-}
-
-impl<I> Iterator for FromPolygon<I>
-    where I: Iterator<Item=Point>,
-{
-    type Item = Triangle<Point>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.points.next().map(|point| {
-            let t = Triangle([self.first, self.prev, point]);
-            self.prev = point;
-            t
-        })
-    }
-}
-
-impl<I> Iterator for FromLines<I>
-    where I: Iterator<Item=Point>,
-{
-    type Item = Triangle<Point>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(triangle) = self.next.take() {
-            return Some(triangle);
-        }
-
-        self.points.next().map(|point| {
-            let (a, b) = (self.prev, point);
-            self.prev = point;
-
-            let direction = [b[0] - a[0], b[1] - a[1]];
-            let mag = (direction[0] * direction[0] + direction[1] * direction[1]).sqrt();
-            let unit = [direction[0] / mag, direction[1] / mag];
-            let normal = [-unit[1], unit[0]];
-            let half_thickness = self.thickness / 2.0;
-
-            // A perpendicular line with length half the thickness.
-            let n = [normal[0] * half_thickness, normal[1] * half_thickness];
-
-            // The corners of the rectangle.
-            let r1 = [a[0] + n[0], a[1] + n[1]];
-            let r2 = [a[0] - n[0], a[1] - n[1]];
-            let r3 = [b[0] + n[0], b[1] + n[1]];
-            let r4 = [b[0] - n[0], b[1] - n[1]];
-
-            // The pair of triangles that make up the rectangle.
-            let t1 = Triangle([r1, r4, r2]);
-            let t2 = Triangle([r1, r4, r3]);
-
-            self.next = Some(t2);
-            t1
-        })
-    }
 }


### PR DESCRIPTION
Includes triangle iterators for:

- The border of the BordererdRectangle widget
- PointPath
- Oval
- Polygon
- Rectangle

As well as a new `triangles::from_quad` function.

Updates the `render` module to use these accordingly.

Also fixes transparency issues with the Slider widget by drawing it with one `Triangles` widget rather than two `Rectangle` widgets.