### PR TITLE
Publish version 0.54. Publish 0.1 of `conrod_derive`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.53.0"
+version = "0.54.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -19,7 +19,7 @@ name = "conrod"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_derive = { path = "conrod_derive" }
+conrod_derive = "0.1"
 daggy = "0.5.0"
 fnv = "1.0"
 num = "0.1.30"

--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -2,6 +2,11 @@
 name = "conrod_derive"
 version = "0.1.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
+description = "A crate providing procedural macros for the conrod library"
+license = "MIT OR Apache-2.0"
+keywords = ["conrod", "gui", "derive", "procedural", "macro"]
+repository = "https://github.com/pistondevelopers/conrod.git"
+homepage = "https://github.com/pistondevelopers/conrod"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This includes the following breaking changes:

- Add new `Triangles` primitive: #1021, #1025, #1026
- Update to glium 0.17 and winit 0.7: #1015, #1016
- Add new derive implementations, remove widget_style!: #1006

Non-breaking changes include:

- Add new `Grid` widget: #1011
- Fix Button widget to give feedback during touch events: #1023
- Allow specifying hover and press colors for Button: #1024