### PR TITLE
Finish all_winit_gfx example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,17 +48,18 @@ rusttype = "0.2.0"
 glium = { version = "0.17", optional = true }
 winit = { version = "0.7", optional = true }
 piston2d-graphics = { version = "0.21.1", optional = true }
+gfx = { version = "0.16.1", optional = true }
+gfx_core = { version = "0.7.0", optional = true }
 
 [features]
 piston = ["piston2d-graphics"]
+gfx_rs=["gfx","gfx_core"]
 
 [dev-dependencies]
 find_folder = "0.3.0"
 image = "0.13.0"
 rand = "0.3.13"
 # glutin_gfx.rs example dependencies
-gfx = "0.16.1"
-gfx_core = "0.7.0"
 gfx_window_glutin = "0.17.0"
 glutin = "0.9.0"
 # piston_window.rs example dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ find_folder = "0.3.0"
 image = "0.13.0"
 rand = "0.3.13"
 # glutin_gfx.rs example dependencies
-gfx = "0.15.1"
+gfx = "0.16.1"
 gfx_core = "0.7.0"
-gfx_window_glutin = "0.15.0"
-glutin = "0.7.0"
+gfx_window_glutin = "0.17.0"
+glutin = "0.9.0"
 # piston_window.rs example dependencies
 piston_window = "0.65.0"

--- a/examples/all_winit_gfx.rs
+++ b/examples/all_winit_gfx.rs
@@ -203,31 +203,11 @@ mod feature {
         let mut events_loop = winit::EventsLoop::new();
 
         // Initialize gfx things
-        let (window, mut device, mut factory, main_color, _) =
+        let (window, mut device, mut factory, rtv, _) =
             gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder, context, &events_loop );
         let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 
-
-        // Create texture sampler
-        let sampler_info = texture::SamplerInfo::new(
-            texture::FilterMethod::Bilinear,
-            texture::WrapMode::Clamp
-        );
-        let sampler = factory.create_sampler(sampler_info);
-
-        // Dummy values for initialization
-        let vbuf = factory.create_vertex_buffer(&[]);
-        let (_, fake_texture) = create_texture(&mut factory, 2, 2, &[0;4]);
-        let (_, blank_texture) = create_texture(&mut factory, 2, 2, &[255;4]);
-
-        let mut data = pipe::Data {
-            vbuf: vbuf,
-            color: (fake_texture.clone(), sampler),
-            out: main_color.clone(),
-        };
-
-        // Compile GL program
-        let pso = factory.create_pipeline_simple(VERTEX_SHADER, FRAGMENT_SHADER, pipe::new()).unwrap();
+        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, window.hidpi_factor()).unwrap();
 
         // Create Ui and Ids of widgets to instantiate
         let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
@@ -237,26 +217,6 @@ mod feature {
         let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();
         let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
         ui.fonts.insert_from_file(font_path).unwrap();
-
-        // Create glyph cache and its texture
-        let (mut glyph_cache, cache_tex, cache_tex_view) = {
-            let dpi = window.hidpi_factor();
-            let width = (WIN_W as f32 * dpi) as u32;
-            let height = (WIN_H as f32 * dpi) as u32;
-
-            const SCALE_TOLERANCE: f32 = 0.1;
-            const POSITION_TOLERANCE: f32 = 0.1;
-
-            let cache = conrod::text::GlyphCache::new(width, height,
-                                                      SCALE_TOLERANCE,
-                                                      POSITION_TOLERANCE);
-
-            let data = vec![0; (width * height * 4) as usize];
-
-            let (texture, texture_view) = create_texture(&mut factory, width, height, &data);
-
-            (cache, texture, texture_view)
-        };
 
         // FIXME: We don't yet load the rust logo, so just insert nothing for now so we can get an
         // identifier used to construct the DemoApp. This should be changed to *actually* load a
@@ -277,120 +237,14 @@ mod feature {
 
             let dpi_factor = window.hidpi_factor();
 
-            if let Some(mut primitives) = ui.draw_if_changed() {
-                let (screen_width, screen_height) = (win_w as f32 * dpi_factor, win_h as f32 * dpi_factor);
-                let mut vertices = Vec::new();
-                let mut text_vertices = Vec::new();
+            if let Some(primitives) = ui.draw_if_changed() {
+                let dims = (win_w as f32 * dpi_factor, win_h as f32 * dpi_factor);
 
-                // Create vertices
-                while let Some(render::Primitive { id, kind, scizzor, rect }) = primitives.next() {
-                    match kind {
-                        render::PrimitiveKind::Rectangle { color } => {
-                            let color = gamma_srgb_to_linear(color.to_fsa());
+                //Clear the window
+                encoder.clear(&self.rtv, CLEAR_COLOR);
 
-                            let mut v = |x,y| vertices.push(Vertex::new([2.0 * x as f32 / screen_width, 2.0 * y as f32 / screen_height], [0.0, 0.0], color));
-                            
-                            v(rect.x.start, rect.y.end  );
-                            v(rect.x.start, rect.y.start);
-                            v(rect.x.end  , rect.y.start);
-                            v(rect.x.end  , rect.y.start);
-                            v(rect.x.end  , rect.y.end  );
-                            v(rect.x.start, rect.y.end  );
-                        },
-                        render::PrimitiveKind::TrianglesSingleColor { color, triangles } => {
-                            let color = gamma_srgb_to_linear(color.into());
-                            use conrod::position::Point;
-                            let mut v = |pos: Point| vertices.push(Vertex::new([2.0 * pos[0] as f32 / screen_width, 2.0 * pos[1] as f32 / screen_height], [0.0, 0.0], color));
+                renderer.draw(&mut factory,&mut encoder,&mut device,primitives,dims);
 
-                            for triangle in triangles{
-                                v(triangle[0]);
-                                v(triangle[1]);
-                                v(triangle[2]);
-                            }
-                        },
-                        render::PrimitiveKind::TrianglesMultiColor { triangles } => {
-                            use conrod::widget::primitive::shape::triangles::ColoredPoint;
-                            let mut v = |(pos,rgba): ColoredPoint| vertices.push(Vertex::new([2.0 * pos[0] as f32 / screen_width, 2.0 * pos[1] as f32 / screen_height], [0.0, 0.0], gamma_srgb_to_linear(rgba.into())));
-
-                            for triangle in triangles{
-                                v(triangle[0]);
-                                v(triangle[1]);
-                                v(triangle[2]);
-                            }
-                        },
-                        render::PrimitiveKind::Image { image_id, color, source_rect } => {
-                            //TODO
-                        },
-                        render::PrimitiveKind::Text { color, text, font_id } => {
-                            let positioned_glyphs = text.positioned_glyphs(dpi_factor);
-
-                            // Queue the glyphs to be cached
-                            for glyph in positioned_glyphs {
-                                glyph_cache.queue_glyph(font_id.index(), glyph.clone());
-                            }
-
-                            glyph_cache.cache_queued(|rect, data| {
-                                let offset = [rect.min.x as u16, rect.min.y as u16];
-                                let size = [rect.width() as u16, rect.height() as u16];
-
-                                let new_data = data.iter().map(|x| [255, 255, 255, *x]).collect::<Vec<_>>();
-
-                                update_texture(&mut encoder, &cache_tex, offset, size, &new_data);
-                            }).unwrap();
-
-                            let color = gamma_srgb_to_linear(color.to_fsa());
-                            let cache_id = font_id.index();
-                            let origin = rt::point(0.0, 0.0);
-
-                            // A closure to convert RustType rects to GL rects
-                            let to_gl_rect = |screen_rect: rt::Rect<i32>| rt::Rect {
-                                min: origin
-                                    + (rt::vector(screen_rect.min.x as f32 / screen_width - 0.5,
-                                                  1.0 - screen_rect.min.y as f32 / screen_height - 0.5)) * 2.0,
-                                max: origin
-                                    + (rt::vector(screen_rect.max.x as f32 / screen_width - 0.5,
-                                                  1.0 - screen_rect.max.y as f32 / screen_height - 0.5)) * 2.0,
-                            };
-
-                            // Create new vertices
-                            let extension = positioned_glyphs.into_iter()
-                                .filter_map(|g| glyph_cache.rect_for(cache_id, g).ok().unwrap_or(None))
-                                .flat_map(|(uv_rect, screen_rect)| {
-                                    use std::iter::once;
-
-                                    let gl_rect = to_gl_rect(screen_rect);
-                                    let v = |pos, uv| once(Vertex::new(pos, uv, color));
-
-                                    v([gl_rect.min.x, gl_rect.max.y], [uv_rect.min.x, uv_rect.max.y])
-                                        .chain(v([gl_rect.min.x, gl_rect.min.y], [uv_rect.min.x, uv_rect.min.y]))
-                                        .chain(v([gl_rect.max.x, gl_rect.min.y], [uv_rect.max.x, uv_rect.min.y]))
-                                        .chain(v([gl_rect.max.x, gl_rect.min.y], [uv_rect.max.x, uv_rect.min.y]))
-                                        .chain(v([gl_rect.max.x, gl_rect.max.y], [uv_rect.max.x, uv_rect.max.y]))
-                                        .chain(v([gl_rect.min.x, gl_rect.max.y], [uv_rect.min.x, uv_rect.max.y]))
-                                });
-
-                            text_vertices.extend(extension);
-                        },
-                        render::PrimitiveKind::Other(_) => {},
-                    }
-                }
-
-                // Clear the window
-                encoder.clear(&main_color, CLEAR_COLOR);
-
-                // Draw the vertices
-                data.color.0 = blank_texture.clone();
-                let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&vertices, ());
-                data.vbuf = vbuf;
-                encoder.draw(&slice, &pso, &data);
-
-                // Draw the text vertices
-                data.color.0 = cache_tex_view.clone();
-                let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&text_vertices, ());
-                data.vbuf = vbuf;
-                encoder.draw(&slice, &pso, &data);
-
-                // Display the results
                 encoder.flush(&mut device);
                 window.swap_buffers().unwrap();
                 device.cleanup();

--- a/examples/all_winit_gfx.rs
+++ b/examples/all_winit_gfx.rs
@@ -8,8 +8,8 @@
 #[cfg(feature="winit")] #[macro_use] extern crate conrod;
 #[cfg(feature="winit")] extern crate glutin;
 #[cfg(feature="winit")] extern crate winit;
-#[macro_use] extern crate gfx;
-extern crate gfx_core;
+#[cfg(feature="gfx_rs")] extern crate gfx;
+#[cfg(feature="gfx_rs")] extern crate gfx_core;
 
 #[cfg(feature="winit")]
 mod support;
@@ -19,7 +19,7 @@ fn main() {
     feature::main();
 }
 
-#[cfg(feature="winit")]
+#[cfg(all(feature="winit",feature="gfx_rs"))]
 mod feature {
     extern crate gfx_window_glutin;
     extern crate find_folder;
@@ -31,165 +31,14 @@ mod feature {
     use winit;
 
     use glutin::GlContext;
-    use gfx::{Factory, Device, texture};
-    use gfx::traits::FactoryExt;
-    use conrod::render;
-    use conrod::text::rt;
+    use gfx::Device;
 
-    const FRAGMENT_SHADER: &'static [u8] = b"
-        #version 140
-
-        uniform sampler2D t_Color;
-
-        in vec2 v_Uv;
-        in vec4 v_Color;
-
-        out vec4 f_Color;
-
-        void main() {
-            vec4 tex = texture(t_Color, v_Uv);
-            f_Color = v_Color * tex;
-        }
-    ";
-
-    const VERTEX_SHADER: &'static [u8] = b"
-        #version 140
-
-        in vec2 a_Pos;
-        in vec2 a_Uv;
-        in vec4 a_Color;
-
-        out vec2 v_Uv;
-        out vec4 v_Color;
-
-        void main() {
-            v_Uv = a_Uv;
-            v_Color = a_Color;
-            gl_Position = vec4(a_Pos, 0.0, 1.0);
-        }
-    ";
-
-    // Format definitions (must be pub for  gfx_defines to use them)
-    pub type ColorFormat = gfx::format::Srgba8;
-    type DepthFormat = gfx::format::DepthStencil;
-    type SurfaceFormat = gfx::format::R8_G8_B8_A8;
-    type FullFormat = (SurfaceFormat, gfx::format::Unorm);
-
-    // Vertex and pipeline declarations
-    gfx_defines! {
-        vertex Vertex {
-            pos: [f32; 2] = "a_Pos",
-            uv: [f32; 2] = "a_Uv",
-            color: [f32; 4] = "a_Color",
-        }
-
-        pipeline pipe {
-            vbuf: gfx::VertexBuffer<Vertex> = (),
-            color: gfx::TextureSampler<[f32; 4]> = "t_Color",
-            out: gfx::BlendTarget<ColorFormat> = ("f_Color", ::gfx::state::MASK_ALL, ::gfx::preset::blend::ALPHA),
-        }
-    }
-
-    // Convenience constructor
-    impl Vertex {
-        fn new(pos: [f32; 2], uv: [f32; 2], color: [f32; 4]) -> Vertex {
-            Vertex {
-                pos: pos,
-                uv: uv,
-                color: color,
-            }
-        }
-    }
 
     const WIN_W: u32 = support::WIN_W;
     const WIN_H: u32 = support::WIN_H;
     const CLEAR_COLOR: [f32; 4] = [0.2, 0.2, 0.2, 1.0];
 
-    fn gamma_srgb_to_linear(c: [f32; 4]) -> [f32; 4] {
-        fn component(f: f32) -> f32 {
-            // Taken from https://github.com/PistonDevelopers/graphics/src/color.rs#L42
-            if f <= 0.04045 {
-                f / 12.92
-            } else {
-                ((f + 0.055) / 1.055).powf(2.4)
-            }
-        }
-        [component(c[0]), component(c[1]), component(c[2]), c[3]]
-    }
-
-    // Creates a gfx texture with the given data
-    fn create_texture<F, R>(factory: &mut F, width: u32, height: u32, data: &[u8])
-        -> (gfx::handle::Texture<R, SurfaceFormat>, gfx::handle::ShaderResourceView<R, [f32; 4]>)
-
-        where R: gfx::Resources, F: gfx::Factory<R>
-    {
-        // Modified `Factory::create_texture_immutable_u8` for dynamic texture.
-        fn create_texture<T, F, R>(
-            factory: &mut F,
-            kind: gfx::texture::Kind,
-            data: &[&[u8]]
-        ) -> Result<(
-            gfx::handle::Texture<R, T::Surface>,
-            gfx::handle::ShaderResourceView<R, T::View>
-        ), gfx::CombinedError>
-            where F: gfx::Factory<R>,
-                  R: gfx::Resources,
-                  T: gfx::format::TextureFormat
-        {
-            use gfx::{format, texture};
-            use gfx::memory::{Usage, SHADER_RESOURCE};
-            use gfx_core::memory::Typed;
-
-            let surface = <T::Surface as format::SurfaceTyped>::get_surface_type();
-            let num_slices = kind.get_num_slices().unwrap_or(1) as usize;
-            let num_faces = if kind.is_cube() {6} else {1};
-            let desc = texture::Info {
-                kind: kind,
-                levels: (data.len() / (num_slices * num_faces)) as texture::Level,
-                format: surface,
-                bind: SHADER_RESOURCE,
-                usage: Usage::Dynamic,
-            };
-            let cty = <T::Channel as format::ChannelTyped>::get_channel_type();
-            let raw = try!(factory.create_texture_raw(desc, Some(cty), Some(data)));
-            let levels = (0, raw.get_info().levels - 1);
-            let tex = Typed::new(raw);
-            let view = try!(factory.view_texture_as_shader_resource::<T>(
-                &tex, levels, format::Swizzle::new()
-            ));
-            Ok((tex, view))
-        }
-
-        let kind = texture::Kind::D2(
-            width as texture::Size,
-            height as texture::Size,
-            texture::AaMode::Single
-        );
-        create_texture::<ColorFormat, F, R>(factory, kind, &[data]).unwrap()
-    }
-
-    // Updates a texture with the given data (used for updating the GlyphCache texture)
-    fn update_texture<R, C>(encoder: &mut gfx::Encoder<R, C>,
-                            texture: &gfx::handle::Texture<R, SurfaceFormat>,
-                            offset: [u16; 2],
-                            size: [u16; 2],
-                            data: &[[u8; 4]])
-
-        where R: gfx::Resources, C: gfx::CommandBuffer<R>
-    {
-        let info = texture::ImageInfoCommon {
-                xoffset: offset[0],
-                yoffset: offset[1],
-                zoffset: 0,
-                width: size[0],
-                height: size[1],
-                depth: 0,
-                format: (),
-                mipmap: 0,
-        };
-
-        encoder.update_texture::<SurfaceFormat, FullFormat>(texture, None, info, data).unwrap();
-    }
+    type DepthFormat = gfx::format::DepthStencil;
 
     pub fn main() {
         // Builder for window
@@ -204,7 +53,7 @@ mod feature {
 
         // Initialize gfx things
         let (window, mut device, mut factory, rtv, _) =
-            gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder, context, &events_loop );
+            gfx_window_glutin::init::<conrod::backend::gfx::ColorFormat, DepthFormat>(builder, context, &events_loop );
         let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 
         let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, window.hidpi_factor()).unwrap();
@@ -241,7 +90,7 @@ mod feature {
                 let dims = (win_w as f32 * dpi_factor, win_h as f32 * dpi_factor);
 
                 //Clear the window
-                encoder.clear(&self.rtv, CLEAR_COLOR);
+                encoder.clear(&rtv, CLEAR_COLOR);
 
                 renderer.draw(&mut factory,&mut encoder,&mut device,primitives,dims);
 
@@ -281,10 +130,10 @@ mod feature {
     }
 }
 
-#[cfg(not(feature="winit"))]
+#[cfg(not(all(feature="winit",feature="gfx_rs")))]
 mod feature {
     pub fn main() {
-        println!("This example requires the `winit` feature. \
-                 Try running `cargo run --release --no-default-features --features=\"winit\" --example <example_name>`");
+        println!("This example requires the `winit` feature and the `gfx_rs` feature. \
+                 Try running `cargo run --release --no-default-features --features=\"winit gf_rs\" --example <example_name>`");
    }
 }

--- a/src/backend/gfx.rs
+++ b/src/backend/gfx.rs
@@ -1,0 +1,365 @@
+use gfx::{self,Resources,Factory, Device, texture,PipelineState};
+use gfx::handle::{Buffer,Sampler,RenderTargetView};
+use gfx::traits::FactoryExt;
+use render;
+use text::{rt,GlyphCache};
+use image;
+use std;
+
+const FRAGMENT_SHADER: &'static [u8] = b"
+    #version 140
+
+    uniform sampler2D t_Color;
+
+    in vec2 v_Uv;
+    in vec4 v_Color;
+
+    out vec4 f_Color;
+
+    void main() {
+        vec4 tex = texture(t_Color, v_Uv);
+        f_Color = v_Color * tex;
+    }
+";
+
+const VERTEX_SHADER: &'static [u8] = b"
+    #version 140
+
+    in vec2 a_Pos;
+    in vec2 a_Uv;
+    in vec4 a_Color;
+
+    out vec2 v_Uv;
+    out vec4 v_Color;
+
+    void main() {
+        v_Uv = a_Uv;
+        v_Color = a_Color;
+        gl_Position = vec4(a_Pos, 0.0, 1.0);
+    }
+";
+
+/// Possible errors that may occur during a call to `Renderer::new`.
+#[derive(Debug)]
+pub enum RendererCreationError {
+    /// Errors that might occur when creating the pipeline.
+    PipelineState(gfx::PipelineStateError<String>),
+}
+
+// Format definitions (must be pub for  gfx_defines to use them)
+pub type ColorFormat = gfx::format::Srgba8;
+type DepthFormat = gfx::format::DepthStencil;
+type SurfaceFormat = gfx::format::R8_G8_B8_A8;
+type FullFormat = (SurfaceFormat, gfx::format::Unorm);
+
+// Vertex and pipeline declarations
+gfx_defines! {
+    vertex Vertex {
+        pos: [f32; 2] = "a_Pos",
+        uv: [f32; 2] = "a_Uv",
+        color: [f32; 4] = "a_Color",
+    }
+
+    pipeline pipe {
+        vbuf: gfx::VertexBuffer<Vertex> = (),
+        color: gfx::TextureSampler<[f32; 4]> = "t_Color",
+        out: gfx::BlendTarget<ColorFormat> = ("f_Color", ::gfx::state::MASK_ALL, ::gfx::preset::blend::ALPHA),
+    }
+}
+
+// Convenience constructor
+impl Vertex {
+    fn new(pos: [f32; 2], uv: [f32; 2], color: [f32; 4]) -> Vertex {
+        Vertex {
+            pos: pos,
+            uv: uv,
+            color: color,
+        }
+    }
+}
+
+pub struct Renderer<R: Resources>{
+    pipeline: PipelineState<R, pipe::Meta>,
+    glyph_cache: GlyphCache,
+    cache_tex: gfx::handle::Texture<R, SurfaceFormat>,
+    cache_tex_view: gfx::handle::ShaderResourceView<R, [f32; 4]>,
+    fake_texture: gfx::handle::ShaderResourceView<R, [f32; 4]>,
+    blank_texture: gfx::handle::ShaderResourceView<R, [f32; 4]>,
+    data: pipe::Data<R>,
+    dpi_factor: f32,
+    rtv: RenderTargetView<R, (gfx::format::R8_G8_B8_A8, gfx::format::Srgb)>,
+}
+
+impl<R: Resources> Renderer<R>{
+    pub fn new<F: Factory<R>>(factory: &mut F, rtv: &RenderTargetView<R, (gfx::format::R8_G8_B8_A8, gfx::format::Srgb)>, dpi_factor: f32) -> Result<Self,RendererCreationError>
+    {
+        let sampler_info = texture::SamplerInfo::new(
+            texture::FilterMethod::Bilinear,
+            texture::WrapMode::Clamp
+        );
+        let sampler = factory.create_sampler(sampler_info);
+
+        let vbuf = factory.create_vertex_buffer(&[]);
+        let (_, fake_texture) = create_texture(factory, 2, 2, &[0;4]);
+        let (_, blank_texture) = create_texture(factory, 2, 2, &[255;4]);
+
+        let mut data = pipe::Data {
+            vbuf,
+            color: (fake_texture.clone(), sampler),
+            out: rtv.clone(),
+        };
+
+        let pipeline = factory.create_pipeline_simple(VERTEX_SHADER, FRAGMENT_SHADER, pipe::new())?;
+
+        let (glyph_cache, cache_tex, cache_tex_view) = {
+            let (width,height,_depth,_samples) = rtv.get_dimensions();
+
+            let width = (width as f32 * dpi_factor) as u32;
+            let height = (height as f32 * dpi_factor) as u32;
+
+            const SCALE_TOLERANCE: f32 = 0.1;
+            const POSITION_TOLERANCE: f32 = 0.1;
+
+            let cache = GlyphCache::new(width, height,
+                                                      SCALE_TOLERANCE,
+                                                      POSITION_TOLERANCE);
+
+            let data = vec![0; (width * height * 4) as usize];
+
+            let (texture, texture_view) = create_texture(factory, width, height, &data);
+
+            (cache, texture, texture_view)
+        };
+        Ok(Renderer{
+            pipeline,
+            glyph_cache,
+            cache_tex,
+            cache_tex_view,
+            fake_texture,
+            blank_texture,
+            data,
+            dpi_factor,
+            rtv: rtv.clone(),
+        })
+    }
+
+    pub fn draw<'a,F: Factory<R>,C: gfx::CommandBuffer<R>,D: gfx::Device<Resources=R,CommandBuffer=C>>(&mut self, factory: &mut F, encoder: &mut gfx::Encoder<R,C>, device: &mut D,primitives: render::Primitives<'a>, dims: (f32,f32)/*, image_map: &image::Map<gfx::handle::ShaderResourceView<R, [f32; 4]>>*/)
+    {
+        let (screen_width, screen_height) = dims;
+        let mut vertices = Vec::new();
+        let mut text_vertices = Vec::new();
+
+        // Create vertices
+        while let Some(render::Primitive { id, kind, scizzor, rect }) = primitives.next() {
+            match kind {
+                render::PrimitiveKind::Rectangle { color } => {
+                    let color = gamma_srgb_to_linear(color.to_fsa());
+
+                    let mut v = |x,y| vertices.push(Vertex::new([2.0 * x as f32 / screen_width, 2.0 * y as f32 / screen_height], [0.0, 0.0], color));
+                    
+                    v(rect.x.start, rect.y.end  );
+                    v(rect.x.start, rect.y.start);
+                    v(rect.x.end  , rect.y.start);
+                    v(rect.x.end  , rect.y.start);
+                    v(rect.x.end  , rect.y.end  );
+                    v(rect.x.start, rect.y.end  );
+                },
+                render::PrimitiveKind::TrianglesSingleColor { color, triangles } => {
+                    let color = gamma_srgb_to_linear(color.into());
+                    use position::Point;
+                    let mut v = |pos: Point| vertices.push(Vertex::new([2.0 * pos[0] as f32 / screen_width, 2.0 * pos[1] as f32 / screen_height], [0.0, 0.0], color));
+
+                    for triangle in triangles{
+                        v(triangle[0]);
+                        v(triangle[1]);
+                        v(triangle[2]);
+                    }
+                },
+                render::PrimitiveKind::TrianglesMultiColor { triangles } => {
+                    use widget::primitive::shape::triangles::ColoredPoint;
+                    let mut v = |(pos,rgba): ColoredPoint| vertices.push(Vertex::new([2.0 * pos[0] as f32 / screen_width, 2.0 * pos[1] as f32 / screen_height], [0.0, 0.0], gamma_srgb_to_linear(rgba.into())));
+
+                    for triangle in triangles{
+                        v(triangle[0]);
+                        v(triangle[1]);
+                        v(triangle[2]);
+                    }
+                },
+                render::PrimitiveKind::Image { image_id, color, source_rect } => {
+                    //TODO
+                },
+                render::PrimitiveKind::Text { color, text, font_id } => {
+                    let positioned_glyphs = text.positioned_glyphs(self.dpi_factor);
+
+                    // Queue the glyphs to be cached
+                    for glyph in positioned_glyphs {
+                        self.glyph_cache.queue_glyph(font_id.index(), glyph.clone());
+                    }
+
+                    self.glyph_cache.cache_queued(|rect, data| {
+                        let offset = [rect.min.x as u16, rect.min.y as u16];
+                        let size = [rect.width() as u16, rect.height() as u16];
+
+                        let new_data = data.iter().map(|x| [255, 255, 255, *x]).collect::<Vec<_>>();
+
+                        update_texture(&mut encoder, &self.cache_tex, offset, size, &new_data);
+                    }).unwrap();
+
+                    let color = gamma_srgb_to_linear(color.to_fsa());
+                    let cache_id = font_id.index();
+                    let origin = rt::point(0.0, 0.0);
+
+                    // A closure to convert RustType rects to GL rects
+                    let to_gl_rect = |screen_rect: rt::Rect<i32>| rt::Rect {
+                        min: origin
+                            + (rt::vector(screen_rect.min.x as f32 / screen_width - 0.5,
+                                            1.0 - screen_rect.min.y as f32 / screen_height - 0.5)) * 2.0,
+                        max: origin
+                            + (rt::vector(screen_rect.max.x as f32 / screen_width - 0.5,
+                                            1.0 - screen_rect.max.y as f32 / screen_height - 0.5)) * 2.0,
+                    };
+
+                    // Create new vertices
+                    let extension = positioned_glyphs.into_iter()
+                        .filter_map(|g| self.glyph_cache.rect_for(cache_id, g).ok().unwrap_or(None))
+                        .flat_map(|(uv_rect, screen_rect)| {
+                            use std::iter::once;
+
+                            let gl_rect = to_gl_rect(screen_rect);
+                            let v = |pos, uv| once(Vertex::new(pos, uv, color));
+
+                            v([gl_rect.min.x, gl_rect.max.y], [uv_rect.min.x, uv_rect.max.y])
+                                .chain(v([gl_rect.min.x, gl_rect.min.y], [uv_rect.min.x, uv_rect.min.y]))
+                                .chain(v([gl_rect.max.x, gl_rect.min.y], [uv_rect.max.x, uv_rect.min.y]))
+                                .chain(v([gl_rect.max.x, gl_rect.min.y], [uv_rect.max.x, uv_rect.min.y]))
+                                .chain(v([gl_rect.max.x, gl_rect.max.y], [uv_rect.max.x, uv_rect.max.y]))
+                                .chain(v([gl_rect.min.x, gl_rect.max.y], [uv_rect.min.x, uv_rect.max.y]))
+                        });
+
+                    text_vertices.extend(extension);
+                },
+                render::PrimitiveKind::Other(_) => {},
+            }
+        }
+
+        // Draw the vertices
+        self.data.color.0 = self.blank_texture.clone();
+        let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&vertices, ());
+        self.data.vbuf = vbuf;
+        encoder.draw(&slice, &self.pipeline, &self.data);
+
+        // Draw the text vertices
+        self.data.color.0 = self.cache_tex_view.clone();
+        let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&text_vertices, ());
+        self.data.vbuf = vbuf;
+        self.encoder.draw(&slice, &self.pipeline, &self.data);
+    }
+}
+
+fn gamma_srgb_to_linear(c: [f32; 4]) -> [f32; 4] {
+    fn component(f: f32) -> f32 {
+        // Taken from https://github.com/PistonDevelopers/graphics/src/color.rs#L42
+        if f <= 0.04045 {
+            f / 12.92
+        } else {
+            ((f + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    [component(c[0]), component(c[1]), component(c[2]), c[3]]
+}
+
+// Creates a gfx texture with the given data
+fn create_texture<F, R>(factory: &mut F, width: u32, height: u32, data: &[u8])
+    -> (gfx::handle::Texture<R, SurfaceFormat>, gfx::handle::ShaderResourceView<R, [f32; 4]>)
+
+    where R: gfx::Resources, F: gfx::Factory<R>
+{
+    // Modified `Factory::create_texture_immutable_u8` for dynamic texture.
+    fn create_texture<T, F, R>(
+        factory: &mut F,
+        kind: gfx::texture::Kind,
+        data: &[&[u8]]
+    ) -> Result<(
+        gfx::handle::Texture<R, T::Surface>,
+        gfx::handle::ShaderResourceView<R, T::View>
+    ), gfx::CombinedError>
+        where F: gfx::Factory<R>,
+                R: gfx::Resources,
+                T: gfx::format::TextureFormat
+    {
+        use gfx::{format, texture};
+        use gfx::memory::{Usage, SHADER_RESOURCE};
+        use gfx_core::memory::Typed;
+
+        let surface = <T::Surface as format::SurfaceTyped>::get_surface_type();
+        let num_slices = kind.get_num_slices().unwrap_or(1) as usize;
+        let num_faces = if kind.is_cube() {6} else {1};
+        let desc = texture::Info {
+            kind: kind,
+            levels: (data.len() / (num_slices * num_faces)) as texture::Level,
+            format: surface,
+            bind: SHADER_RESOURCE,
+            usage: Usage::Dynamic,
+        };
+        let cty = <T::Channel as format::ChannelTyped>::get_channel_type();
+        let raw = try!(factory.create_texture_raw(desc, Some(cty), Some(data)));
+        let levels = (0, raw.get_info().levels - 1);
+        let tex = Typed::new(raw);
+        let view = try!(factory.view_texture_as_shader_resource::<T>(
+            &tex, levels, format::Swizzle::new()
+        ));
+        Ok((tex, view))
+    }
+
+    let kind = texture::Kind::D2(
+        width as texture::Size,
+        height as texture::Size,
+        texture::AaMode::Single
+    );
+    create_texture::<ColorFormat, F, R>(factory, kind, &[data]).unwrap()
+}
+
+// Updates a texture with the given data (used for updating the GlyphCache texture)
+fn update_texture<R, C>(encoder: &mut gfx::Encoder<R, C>,
+                        texture: &gfx::handle::Texture<R, SurfaceFormat>,
+                        offset: [u16; 2],
+                        size: [u16; 2],
+                        data: &[[u8; 4]])
+
+    where R: gfx::Resources, C: gfx::CommandBuffer<R>
+{
+    let info = texture::ImageInfoCommon {
+            xoffset: offset[0],
+            yoffset: offset[1],
+            zoffset: 0,
+            width: size[0],
+            height: size[1],
+            depth: 0,
+            format: (),
+            mipmap: 0,
+    };
+
+    encoder.update_texture::<SurfaceFormat, FullFormat>(texture, None, info, data).unwrap();
+}
+
+impl From<gfx::PipelineStateError<String>> for RendererCreationError {
+    fn from(err: gfx::PipelineStateError<String>) -> Self {
+        RendererCreationError::PipelineState(err)
+    }
+}
+
+impl std::error::Error for RendererCreationError {
+    fn description(&self) -> &str {
+        match *self {
+            RendererCreationError::PipelineState(ref e) => std::error::Error::description(e),
+        }
+    }
+}
+
+impl std::fmt::Display for RendererCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match *self {
+            RendererCreationError::PipelineState(ref e) => std::fmt::Display::fmt(e, f),
+        }
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,3 +10,4 @@
 #[cfg(feature="glium")] pub mod glium;
 #[cfg(feature="winit")] pub mod winit;
 #[cfg(feature="piston")] pub mod piston;
+#[cfg(feature="gfx_rs")] pub mod gfx;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ extern crate input as piston_input;
 extern crate rusttype;
 
 #[cfg(feature="glium")] #[macro_use] pub extern crate glium;
+#[cfg(feature="gfx_rs")] #[macro_use] pub extern crate gfx;
+#[cfg(feature="gfx_rs")] pub extern crate gfx_core;
 
 pub use color::{Color, Colorable};
 pub use border::{Bordering, Borderable};


### PR DESCRIPTION
The `all_winit_gfx` example now draws triangle primitives.
Drawing images is still left to do, but the example is now relatively usable as a base if you want to add conrod to a gfx app.
