### PR TITLE
Add Input::Redraw

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -154,6 +154,10 @@ pub fn convert_window_event<W>(e: winit::WindowEvent, window: &W) -> Option<Inpu
                 Some(Input::Release(input::Button::Mouse(map_mouse(button))).into()),
         },
 
+        winit::WindowEvent::Refresh => {
+            Some(Input::Rerender),
+        },
+
         _ => None,
     }
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -155,7 +155,7 @@ pub fn convert_window_event<W>(e: winit::WindowEvent, window: &W) -> Option<Inpu
         },
 
         winit::WindowEvent::Refresh => {
-            Some(Input::Rerender),
+            Some(Input::Redraw)
         },
 
         _ => None,

--- a/src/event.rs
+++ b/src/event.rs
@@ -72,6 +72,8 @@ pub enum Input {
     Text(String),
     /// The window was focused or lost focus.
     Focus(bool),
+    /// The backed requested to rerender.
+    Rerender,
 }
 
 
@@ -82,7 +84,7 @@ pub enum Event {
     Raw(Input),
     /// Events that have been interpreted from `backend::RawEvent`s by the `Ui`.
     ///
-    /// Most events usually 
+    /// Most events usually
     Ui(Ui)
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -72,8 +72,8 @@ pub enum Input {
     Text(String),
     /// The window was focused or lost focus.
     Focus(bool),
-    /// The backed requested to rerender.
-    Rerender,
+    /// The backed requested to redraw.
+    Redraw,
 }
 
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -891,7 +891,7 @@ impl Ui {
 
             Input::Focus(_focused) => (),
 
-            Input::Rerender => self.needs_redraw(),
+            Input::Redraw => self.needs_redraw(),
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -890,6 +890,8 @@ impl Ui {
             },
 
             Input::Focus(_focused) => (),
+
+            Input::Rerender => self.needs_redraw(),
         }
     }
 


### PR DESCRIPTION
This is a request from the backend to rerender the UI.

This also adds support to the winit backend to convert the
WindowEvent::Refresh event to new Input::Rerender event.

Closes #1036.