### PR TITLE
fix #1057

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ rand = "0.3.13"
 gfx_window_glutin = "0.17.0"
 glutin = "0.9.0"
 # piston_window.rs example dependencies
-piston_window = "0.65.0"
+piston_window = "0.70.0"


### PR DESCRIPTION
The old version of piston_window included some really old version of 'core-graphics'