### PR TITLE
Mouse Cursor Support

### DIFF
--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -8,11 +8,9 @@ fn main() {
 #[cfg(all(feature="winit", feature="glium"))]
 mod feature {
     extern crate find_folder;
-    extern crate winit;
     use conrod;
     use conrod::backend::glium::glium;
     use conrod::backend::glium::glium::Surface;
-    use conrod::backend::winit::WinitWindow;
     use support;
 
     widget_ids! {
@@ -93,7 +91,9 @@ mod feature {
             // Instnatiate all widgets in the GUI.
             set_ui(ui.set_widgets(), &ids, &mut demo_text);
 
-            display.set_mouse_cursor(ui.mouse_cursor());
+            // Get the underlying winit window and update the mouse cursor as set by conrod.
+            display.gl_window().window()
+                .set_cursor(conrod::backend::winit::convert_mouse_cursor(ui.mouse_cursor()));
 
             // Render the `Ui` and then display it on the screen.
             if let Some(primitives) = ui.draw_if_changed() {

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -8,9 +8,11 @@ fn main() {
 #[cfg(all(feature="winit", feature="glium"))]
 mod feature {
     extern crate find_folder;
+    extern crate winit;
     use conrod;
     use conrod::backend::glium::glium;
     use conrod::backend::glium::glium::Surface;
+    use conrod::backend::winit::WinitWindow;
     use support;
 
     widget_ids! {
@@ -90,6 +92,8 @@ mod feature {
 
             // Instnatiate all widgets in the GUI.
             set_ui(ui.set_widgets(), &ids, &mut demo_text);
+
+            display.set_mouse_cursor(ui.mouse_cursor());
 
             // Render the `Ui` and then display it on the screen.
             if let Some(primitives) = ui.draw_if_changed() {

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -20,8 +20,6 @@ pub trait WinitWindow {
     fn get_inner_size(&self) -> Option<(u32, u32)>;
     /// Return the window's DPI factor so that we can convert from pixel values to scalar values.
     fn hidpi_factor(&self) -> f32;
-    /// Set the mouse cursor.
-    fn set_mouse_cursor(&self, cur: cursor::MouseCursor);
 }
 
 impl WinitWindow for winit::Window {
@@ -30,9 +28,6 @@ impl WinitWindow for winit::Window {
     }
     fn hidpi_factor(&self) -> f32 {
         winit::Window::hidpi_factor(self)
-    }
-    fn set_mouse_cursor(&self, cur: cursor::MouseCursor) {
-        set_mouse_cursor(cur, self);
     }
 }
 
@@ -43,9 +38,6 @@ impl WinitWindow for glium::Display {
     }
     fn hidpi_factor(&self) -> f32 {
         self.gl_window().hidpi_factor()
-    }
-    fn set_mouse_cursor(&self, cur: cursor::MouseCursor) {
-        set_mouse_cursor(cur, &self.gl_window().window());
     }
 }
 
@@ -319,18 +311,18 @@ pub fn map_mouse(mouse_button: winit::MouseButton) -> input::MouseButton {
     }
 }
 
-/// Helper method to set the mouse cursor using winit.
-fn set_mouse_cursor(cursor: cursor::MouseCursor, window: &winit::Window) {
+/// Convert a given conrod mouse cursor to the corresponding winit cursor type.
+pub fn convert_mouse_cursor(cursor: cursor::MouseCursor) -> winit::MouseCursor {
     match cursor {
-        cursor::MouseCursor::Text => window.set_cursor(winit::MouseCursor::Text),
-        cursor::MouseCursor::VerticalText => window.set_cursor(winit::MouseCursor::VerticalText),
-        cursor::MouseCursor::Hand=> window.set_cursor(winit::MouseCursor::Hand),
-        cursor::MouseCursor::Grab => window.set_cursor(winit::MouseCursor::Grab),
-        cursor::MouseCursor::Grabbing => window.set_cursor(winit::MouseCursor::Grabbing),
-        cursor::MouseCursor::ResizeVertical => window.set_cursor(winit::MouseCursor::NsResize),
-        cursor::MouseCursor::ResizeHorizontal => window.set_cursor(winit::MouseCursor::EwResize),
-        cursor::MouseCursor::ResizeTopLeftBottomRight => window.set_cursor(winit::MouseCursor::NwseResize),
-        cursor::MouseCursor::ResizeTopRightBottomLeft => window.set_cursor(winit::MouseCursor::NeswResize),
-        _ => window.set_cursor(winit::MouseCursor::Arrow),
+        cursor::MouseCursor::Text => winit::MouseCursor::Text,
+        cursor::MouseCursor::VerticalText => winit::MouseCursor::VerticalText,
+        cursor::MouseCursor::Hand => winit::MouseCursor::Hand,
+        cursor::MouseCursor::Grab => winit::MouseCursor::Grab,
+        cursor::MouseCursor::Grabbing => winit::MouseCursor::Grabbing,
+        cursor::MouseCursor::ResizeVertical => winit::MouseCursor::NsResize,
+        cursor::MouseCursor::ResizeHorizontal => winit::MouseCursor::EwResize,
+        cursor::MouseCursor::ResizeTopLeftBottomRight => winit::MouseCursor::NwseResize,
+        cursor::MouseCursor::ResizeTopRightBottomLeft => winit::MouseCursor::NeswResize,
+        _ => winit::MouseCursor::Arrow,
     }
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -323,12 +323,14 @@ pub fn map_mouse(mouse_button: winit::MouseButton) -> input::MouseButton {
 fn set_mouse_cursor(cursor: cursor::MouseCursor, window: &winit::Window) {
     match cursor {
         cursor::MouseCursor::Text => window.set_cursor(winit::MouseCursor::Text),
+        cursor::MouseCursor::VerticalText => window.set_cursor(winit::MouseCursor::VerticalText),
+        cursor::MouseCursor::Hand=> window.set_cursor(winit::MouseCursor::Hand),
         cursor::MouseCursor::Grab => window.set_cursor(winit::MouseCursor::Grab),
         cursor::MouseCursor::Grabbing => window.set_cursor(winit::MouseCursor::Grabbing),
         cursor::MouseCursor::ResizeVertical => window.set_cursor(winit::MouseCursor::NsResize),
         cursor::MouseCursor::ResizeHorizontal => window.set_cursor(winit::MouseCursor::EwResize),
-        cursor::MouseCursor::ResizeTopLeftDownRight => window.set_cursor(winit::MouseCursor::NwseResize),
-        cursor::MouseCursor::ResizeTopRightDownLeft => window.set_cursor(winit::MouseCursor::NeswResize),
+        cursor::MouseCursor::ResizeTopLeftBottomRight => window.set_cursor(winit::MouseCursor::NwseResize),
+        cursor::MouseCursor::ResizeTopRightBottomLeft => window.set_cursor(winit::MouseCursor::NeswResize),
         _ => window.set_cursor(winit::MouseCursor::Arrow),
     }
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -5,11 +5,13 @@ extern crate winit;
 use Scalar;
 use event::Input;
 use input;
+use cursor;
 #[cfg(feature = "glium")] use glium;
 
 
 /// Types that have access to a `winit::Window` and can provide the necessary dimensions and hidpi
-/// factor for converting `winit::Event`s to `conrod::event::Input`.
+/// factor for converting `winit::Event`s to `conrod::event::Input`, as well as set the mouse
+/// cursor.
 ///
 /// This allows users to pass either `glium::Display`, `glium::glutin::Window` or `winit::Window`
 /// to the `conrod::backend::winit::convert` function defined below.
@@ -18,6 +20,8 @@ pub trait WinitWindow {
     fn get_inner_size(&self) -> Option<(u32, u32)>;
     /// Return the window's DPI factor so that we can convert from pixel values to scalar values.
     fn hidpi_factor(&self) -> f32;
+    /// Set the mouse cursor.
+    fn set_mouse_cursor(&self, cur: cursor::MouseCursor);
 }
 
 impl WinitWindow for winit::Window {
@@ -26,6 +30,9 @@ impl WinitWindow for winit::Window {
     }
     fn hidpi_factor(&self) -> f32 {
         winit::Window::hidpi_factor(self)
+    }
+    fn set_mouse_cursor(&self, cur: cursor::MouseCursor) {
+        set_mouse_cursor(cur, self);
     }
 }
 
@@ -36,6 +43,9 @@ impl WinitWindow for glium::Display {
     }
     fn hidpi_factor(&self) -> f32 {
         self.gl_window().hidpi_factor()
+    }
+    fn set_mouse_cursor(&self, cur: cursor::MouseCursor) {
+        set_mouse_cursor(cur, &self.gl_window().window());
     }
 }
 
@@ -306,5 +316,19 @@ pub fn map_mouse(mouse_button: winit::MouseButton) -> input::MouseButton {
         winit::MouseButton::Other(3) => MouseButton::Button7,
         winit::MouseButton::Other(4) => MouseButton::Button8,
         _ => MouseButton::Unknown
+    }
+}
+
+/// Helper method to set the mouse cursor using winit.
+fn set_mouse_cursor(cursor: cursor::MouseCursor, window: &winit::Window) {
+    match cursor {
+        cursor::MouseCursor::Text => window.set_cursor(winit::MouseCursor::Text),
+        cursor::MouseCursor::Grab => window.set_cursor(winit::MouseCursor::Grab),
+        cursor::MouseCursor::Grabbing => window.set_cursor(winit::MouseCursor::Grabbing),
+        cursor::MouseCursor::ResizeVertical => window.set_cursor(winit::MouseCursor::NsResize),
+        cursor::MouseCursor::ResizeHorizontal => window.set_cursor(winit::MouseCursor::EwResize),
+        cursor::MouseCursor::ResizeTopLeftDownRight => window.set_cursor(winit::MouseCursor::NwseResize),
+        cursor::MouseCursor::ResizeTopRightDownLeft => window.set_cursor(winit::MouseCursor::NeswResize),
+        _ => window.set_cursor(winit::MouseCursor::Arrow),
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,16 @@
+/// This enum specifies cursor types used by prebuilt widgets. For custom widgets using custom
+/// cursor types, you can still use this enum by specifying a numbered custom variant.
+#[derive(Copy, Clone, Debug)]
+pub enum MouseCursor {
+    Arrow,
+    Text,
+    VerticalText,
+    Hand,
+    Grab,
+    Grabbing,
+    ResizeVertical,
+    ResizeHorizontal,
+    ResizeTopLeftDownRight,
+    ResizeTopRightDownLeft,
+    Custom(u8),
+}

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,16 +1,34 @@
-/// This enum specifies cursor types used by prebuilt widgets. For custom widgets using custom
+//! Contains an extendable enum of supported mouse cursor types.
+//!
+//! Use this module to map from the conrod's mouse cursor types to the types known to the window
+//! backend you are using. A lot of these are already implemented in `conrod::backend`. Unless you
+//! are using custom mouse cursor types not provided here, then using one of the implementations in
+//! `conrod::backend` should be sufficient.
+
+/// This enum specifies cursor types used by internal widgets. For custom widgets using custom
 /// cursor types, you can still use this enum by specifying a numbered custom variant.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MouseCursor {
+    /// Default mouse cursor.
     Arrow,
+    /// Text input curosr.
     Text,
+    /// Text input for vertical text.
     VerticalText,
+    /// Open hand with index finger pointing up.
     Hand,
+    /// Open hand.
     Grab,
+    /// Closed hand.
     Grabbing,
+    /// Vertical resize cursor.
     ResizeVertical,
+    /// Horizontal resize cursor.
     ResizeHorizontal,
-    ResizeTopLeftDownRight,
-    ResizeTopRightDownLeft,
+    /// Diagonal resize cursor pointing to top left and bottom right corners.
+    ResizeTopLeftBottomRight,
+    /// Diagonal resize cursor pointing to top right to bottom left corners.
+    ResizeTopRightBottomLeft,
+    /// Custom cursor variant. Encode your favourite cursor with a u8.
     Custom(u8),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,5 +43,6 @@ pub mod theme;
 mod ui;
 pub mod utils;
 pub mod widget;
+pub mod cursor;
 
 #[cfg(test)] mod tests;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,6 +10,7 @@ use text;
 use theme::Theme;
 use utils;
 use widget::{self, Widget};
+use cursor;
 
 /// A constructor type for building a `Ui` instance with a set of optional parameters.
 pub struct UiBuilder {
@@ -81,6 +82,8 @@ pub struct Ui {
     /// the end of the `Ui::set_widgets` method. This ensures that the events are received by the
     /// target widgets during the next call to `Ui::set_widgets`.
     pending_scroll_events: Vec<event::Ui>,
+    /// Mouse cursor
+    mouse_cursor: cursor::MouseCursor,
 
     // TODO: Remove the following fields as they should now be handled by `input::Global`.
 
@@ -198,6 +201,7 @@ impl Ui {
             prev_updated_widgets: prev_updated_widgets,
             global_input: input::Global::new(),
             pending_scroll_events: Vec::new(),
+            mouse_cursor: cursor::MouseCursor::Arrow,
         }
     }
 
@@ -1051,6 +1055,8 @@ impl Ui {
 
         ui_cell.ui.maybe_current_parent_id = Some(ui_cell.window.into());
 
+        ui_cell.set_mouse_cursor(cursor::MouseCursor::Arrow);
+
         ui_cell
     }
 
@@ -1142,6 +1148,10 @@ impl Ui {
         graph::algo::cropped_area_of_widget(&self.widget_graph, id)
     }
 
+    /// Get mouse cursor state.
+    pub fn mouse_cursor(&self) -> cursor::MouseCursor {
+        self.mouse_cursor
+    }
 }
 
 
@@ -1206,6 +1216,10 @@ impl<'a> UiCell<'a> {
         }
     }
 
+    /// Sets the mouse cursor
+    pub fn set_mouse_cursor(&mut self, cursor: cursor::MouseCursor) {
+        self.ui.mouse_cursor = cursor;
+    }
 }
 
 impl<'a> Drop for UiCell<'a> {

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -8,6 +8,7 @@ use std;
 use text;
 use utils;
 use widget;
+use cursor;
 use widget::primitive::text::Wrap;
 
 
@@ -738,6 +739,11 @@ impl<'a> Widget for TextEdit<'a> {
 
                 _ => (),
             }
+        }
+
+        let hover = ui.widget_input(id).mouse().map_or(false, |_| { true });
+        if hover {
+            ui.set_mouse_cursor(cursor::MouseCursor::Text);
         }
 
         let cursor_has_changed = state.cursor != cursor;

--- a/src/widget/text_edit.rs
+++ b/src/widget/text_edit.rs
@@ -741,8 +741,7 @@ impl<'a> Widget for TextEdit<'a> {
             }
         }
 
-        let hover = ui.widget_input(id).mouse().map_or(false, |_| { true });
-        if hover {
+        if let Some(_) = ui.widget_input(id).mouse() {
             ui.set_mouse_cursor(cursor::MouseCursor::Text);
         }
 


### PR DESCRIPTION
I included a usage example in the text_edit example.
The winit backend is also extended to take Conrod MouseCursor types and set the
corresponding mouse cursor using winit.