### PR TITLE
Add support for directory-only FileNavigator

### DIFF
--- a/src/widget/file_navigator/directory_view.rs
+++ b/src/widget/file_navigator/directory_view.rs
@@ -150,6 +150,7 @@ fn check_hidden(show_hidden: bool, types: super::Types, path: &std::path::PathBu
                 return false
             }
         },
+        super::Types::Directories => return path.is_dir(),
     }
 }
 

--- a/src/widget/file_navigator/mod.rs
+++ b/src/widget/file_navigator/mod.rs
@@ -48,6 +48,8 @@ pub enum Types<'a> {
     ///
     /// i.e. `&["wav", "wave", "aiff"]`.
     WithExtension(&'a [&'a str]),
+    /// Indicates only directories should be shown
+    Directories,
 }
 
 /// Unique state stored within the widget graph for each `FileNavigator`.
@@ -155,6 +157,10 @@ impl<'a> FileNavigator<'a> {
     /// list of extensions: `&["wav", "wave", "aiff"]`.
     pub fn with_extension(starting_directory: &'a std::path::Path, exts: &'a [&'a str]) -> Self {
         Self::new(starting_directory, Types::WithExtension(exts))
+    }
+
+    pub fn directories(starting_directory: &'a std::path::Path) -> Self {
+        Self::new(starting_directory, Types::Directories)
     }
 
     /// The color of the unselected entries within each `DirectoryView`.


### PR DESCRIPTION
Small change that adds a third variant to `file_navigator::Types` that causes FileNavigator to only show directories.