### PR TITLE
SDL2 backend and an example using it and gfx in all_sdl2_gfx_rs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rusttype = "0.2.0"
 glium = { version = "0.17", optional = true }
 winit = { version = "0.7", optional = true }
 piston2d-graphics = { version = "0.21.1", optional = true }
+sdl2 = { version = "0.29", optional = true }
 gfx = { version = "0.16.1", optional = true }
 gfx_core = { version = "0.7.0", optional = true }
 
@@ -57,10 +58,11 @@ gfx_rs=["gfx","gfx_core"]
 
 [dev-dependencies]
 find_folder = "0.3.0"
-image = "0.13.0"
-rand = "0.3.13"
+image = "0.15.0"
+rand = "0.3.16"
 # glutin_gfx.rs example dependencies
 gfx_window_glutin = "0.17.0"
-glutin = "0.9.0"
+gfx_window_sdl = "0.6.0"
+glutin = "0.9.2"
 # piston_window.rs example dependencies
-piston_window = "0.65.0"
+piston_window = "0.69.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ rusttype = "0.2.0"
 # - Converting piston `GenericEvent` types to `conrod::event::Raw`s.
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston` module.
+glium = { version = "0.17", optional = true }
+winit = { version = "0.7", optional = true }
+piston2d-graphics = { version = "0.21.1", optional = true }
 sdl2 = { version = "0.29", optional = true }
 gfx = { version = "0.16.1", optional = true }
 gfx_core = { version = "0.7.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ conrod_derive = "0.1"
 daggy = "0.5.0"
 fnv = "1.0"
 num = "0.1.30"
-pistoncore-input = "0.18.0"
+pistoncore-input = "0.19.0"
 rusttype = "0.2.0"
 
 # Optional dependencies and features
@@ -65,4 +65,4 @@ gfx_window_glutin = "0.17.0"
 gfx_window_sdl = "0.6.0"
 glutin = "0.9.2"
 # piston_window.rs example dependencies
-piston_window = "0.69.0"
+piston_window = "0.70.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.54.0"
+version = "0.55.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -59,7 +59,7 @@ gfx_rs=["gfx","gfx_core"]
 [dev-dependencies]
 find_folder = "0.3.0"
 image = "0.15.0"
-rand = "0.3.16"
+rand = "0.3.13"
 # glutin_gfx.rs example dependencies
 gfx_window_glutin = "0.17.0"
 gfx_window_sdl = "0.6.0"

--- a/examples/all_sdl2_gfx_rs.rs
+++ b/examples/all_sdl2_gfx_rs.rs
@@ -1,0 +1,174 @@
+//! A demonstration of using `sdl2` to provide events and GFX to draw the UI.
+
+#![allow(unused_variables)]
+
+#[cfg(feature="sdl2")] #[macro_use] extern crate conrod;
+#[cfg(feature="sdl2")] extern crate sdl2;
+#[cfg(feature="gfx_rs")] extern crate gfx;
+#[cfg(feature="gfx_rs")] extern crate gfx_core;
+
+#[cfg(feature="sdl2")]
+mod support;
+
+
+fn main() {
+    feature::main();
+}
+
+#[cfg(all(feature="sdl2",feature="gfx_rs"))]
+mod feature {
+    extern crate gfx_window_sdl;
+    extern crate find_folder;
+    extern crate image;
+
+    use std;
+
+    use conrod;
+    use gfx;
+    use gfx_core;
+    use support;
+    use sdl2;
+
+    use gfx::Device;
+
+
+    const WIN_W: u32 = support::WIN_W;
+    const WIN_H: u32 = support::WIN_H;
+    const CLEAR_COLOR: [f32; 4] = [0.2, 0.2, 0.2, 1.0];
+
+    type DepthFormat = gfx::format::DepthStencil;
+    use conrod::backend::gfx::ColorFormat;
+
+    pub fn main() {
+        // Initialize sdl2 context
+        let sdl_context = sdl2::init().unwrap();
+        let video_subsystem = sdl_context.video().unwrap();
+
+        { // setup multisampling and opengl version
+            let gl_attr = video_subsystem.gl_attr();
+            gl_attr.set_multisample_buffers(1);
+            gl_attr.set_multisample_samples(8);
+            gl_attr.set_context_version(3u8, 2u8);
+            gl_attr.set_context_profile(sdl2::video::GLProfile::Core);
+        }
+
+        let mut builder = video_subsystem
+            .window("Conrod with GFX and Sdl2", WIN_W, WIN_H);
+
+        builder.position_centered();
+        builder.resizable();
+        builder.allow_highdpi();
+
+        // Initialize gfx things
+        let (window, glcontext, mut device, mut factory, rtv, _) =
+            gfx_window_sdl::init::<ColorFormat, DepthFormat>(builder)
+            .expect("gfx_window_sdl::init failed!");
+
+        video_subsystem.gl_set_swap_interval(1); // vsync on
+
+        let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
+
+        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, 1.0f64).unwrap();
+
+        // Create Ui and Ids of widgets to instantiate
+        let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
+        let ids = support::Ids::new(ui.widget_id_generator());
+
+        // Load font from file
+        let assets = find_folder::Search::KidsThenParents(3, 5).for_folder("assets").unwrap();
+        let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
+        ui.fonts.insert_from_file(font_path).unwrap();
+
+        // Load the Rust logo from our assets folder to use as an example image.
+        fn load_rust_logo<T: gfx::format::TextureFormat,R: gfx_core::Resources, F: gfx::Factory<R>>(factory: &mut F) -> (gfx::handle::ShaderResourceView<R, <T as gfx::format::Formatted>::View>,(u32,u32)) {
+            use gfx::{format, texture};
+            use gfx::memory::Usage;
+            let assets = find_folder::Search::ParentsThenKids(3, 3).for_folder("assets").unwrap();
+            let path = assets.join("images/rust.png");
+            let rgba_image = image::open(&std::path::Path::new(&path)).unwrap().to_rgba();
+            let image_dimensions = rgba_image.dimensions();
+            let kind = texture::Kind::D2(
+                image_dimensions.0 as texture::Size,
+                image_dimensions.1 as texture::Size,
+                texture::AaMode::Single
+            );
+            let info = texture::Info {
+                kind: kind,
+                levels: 1,
+                format: <T::Surface as format::SurfaceTyped>::get_surface_type(),
+                bind: gfx::SHADER_RESOURCE,
+                usage: Usage::Dynamic,
+            };
+            let raw = factory.create_texture_raw(info, Some(<T::Channel as format::ChannelTyped>::get_channel_type()) , Some(&[rgba_image.into_raw().as_slice()])).unwrap();
+            let tex = gfx_core::memory::Typed::new(raw);
+            let view = factory.view_texture_as_shader_resource::<T>(
+                &tex, (0,0), format::Swizzle::new()
+            ).unwrap();
+            (view,image_dimensions)
+        }
+
+        let mut image_map = conrod::image::Map::new();
+        let rust_logo = image_map.insert(load_rust_logo::<conrod::backend::gfx::ColorFormat,_,_>(&mut factory));
+
+        // Demonstration app state that we'll control with our conrod GUI.
+        let mut app = support::DemoApp::new(rust_logo);
+
+        let mut events = sdl_context.event_pump().unwrap(); // poll sdl2 events
+
+        'main: loop {
+            if let Some(primitives) = ui.draw_if_changed() {
+                let (win_w, win_h) = window.drawable_size();
+                let dims = (win_w as f32, win_h as f32);
+
+                //Clear the window
+                encoder.clear(&rtv, CLEAR_COLOR);
+
+                renderer.fill(&mut encoder,dims,primitives,&image_map);
+
+                renderer.draw(&mut factory,&mut encoder,&image_map);
+
+                encoder.flush(&mut device);
+                window.gl_swap_window(); // swap buffers
+                device.cleanup();
+            }
+
+            for event in events.poll_iter() {
+                //let (win_w, win_h) = window.drawable_size();
+                //let (w, h) = (win_w as conrod::Scalar, win_h as conrod::Scalar);
+
+                // Convert winit event to conrod event, requires conrod to be built with the `winit` feature
+                if let (Some(event), mb_extra_event) = conrod::backend::sdl2::convert_event(event.clone(), &window) {
+                    ui.handle_event(event);
+                    if let Some(extra_event) = mb_extra_event {
+                        ui.handle_event(extra_event);
+                    }
+                }
+
+                // Close window if the escape key or the exit button is pressed
+                match event {
+                    sdl2::event::Event::Quit { .. } => break 'main,
+                    sdl2::event::Event::KeyDown { keycode: Some(keycode), .. } => {
+                        if keycode == sdl2::keyboard::Keycode::Escape {
+                            break 'main
+                        }
+                    },
+                    _ => {},
+                }
+            }
+
+            // Update widgets if any event has happened
+            if ui.global_input().events().next().is_some() {
+                let mut ui = ui.set_widgets();
+                support::gui(&mut ui, &ids, &mut app);
+            }
+        }
+    }
+}
+
+#[cfg(not(all(feature="sdl2",feature="gfx_rs")))]
+mod feature {
+    pub fn main() {
+        println!("This example requires the `sdl2` feature and the `gfx_rs` feature. \
+                 Try running `cargo run --release --no-default-features --features=\"sdl2 gfx_rs\" --example <example_name>`");
+   }
+}

--- a/examples/all_sdl2_gfx_rs.rs
+++ b/examples/all_sdl2_gfx_rs.rs
@@ -68,7 +68,9 @@ mod feature {
 
         let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 
-        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, 1.0f64).unwrap();
+        let dpi_factor = window.drawable_size().0 / window.size().0;
+
+        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, dpi_factor as f64).unwrap();
 
         // Create Ui and Ids of widgets to instantiate
         let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
@@ -133,11 +135,13 @@ mod feature {
             }
 
             for event in events.poll_iter() {
-                //let (win_w, win_h) = window.drawable_size();
-                //let (w, h) = (win_w as conrod::Scalar, win_h as conrod::Scalar);
+                let (win_w, win_h) = {
+                    let (w,h) = window.size();
+                    (w as f64, h as f64)
+                };
 
-                // Convert winit event to conrod event, requires conrod to be built with the `winit` feature
-                if let (Some(event), mb_extra_event) = conrod::backend::sdl2::convert_event(event.clone(), &window) {
+                // Convert sdl2 event to conrod event, requires conrod to be built with the `sdl2` feature
+                if let (Some(event), mb_extra_event) = conrod::backend::sdl2::convert_event(event.clone(), win_w, win_h) {
                     ui.handle_event(event);
                     if let Some(extra_event) = mb_extra_event {
                         ui.handle_event(extra_event);

--- a/examples/all_sdl2_gfx_rs.rs
+++ b/examples/all_sdl2_gfx_rs.rs
@@ -68,9 +68,9 @@ mod feature {
 
         let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 
-        let dpi_factor = window.drawable_size().0 / window.size().0;
+        let dpi_factor = window.drawable_size().0 as f64 / window.size().0 as f64;
 
-        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, dpi_factor as f64).unwrap();
+        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, dpi_factor).unwrap();
 
         // Create Ui and Ids of widgets to instantiate
         let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,4 +10,5 @@
 #[cfg(feature="glium")] pub mod glium;
 #[cfg(feature="winit")] pub mod winit;
 #[cfg(feature="piston")] pub mod piston;
+#[cfg(feature="sdl2")] pub mod sdl2;
 #[cfg(feature="gfx_rs")] pub mod gfx;

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -1,0 +1,133 @@
+//! A function for converting a `winit::Event` to a `conrod::event::Input`.
+
+use Scalar;
+use event::Input;
+use input;
+use sdl2::{event, video};
+use sdl2;
+use piston_input::{ControllerAxisArgs};
+
+/// A function for converting a `sdl2::event::Event` to a `conrod::event::Input`.
+///
+/// This can be useful for single-window applications.
+///
+/// NOTE: The sdl2 MouseMotion event is a combination of a MouseCursor and MouseRelative conrod
+/// events. Thus we may sometimes return two events in place of one, hence the tuple return type
+pub fn convert_event(e: event::Event, window: &video::Window) -> (Option<Input>, Option<Input>)
+{
+    use sdl2::event::{Event, WindowEvent};
+
+    // The window size in points.
+    let (win_w, win_h) = {
+        let (w,h) = window.drawable_size();
+        (w as Scalar, h as Scalar)
+    };
+
+    // Translate the coordinates from top-left-origin-with-y-down to centre-origin-with-y-up.
+    //
+    // winit produces input events in pixels, so these positions need to be divided by the width
+    // and height of the window in order to be DPI agnostic.
+    let tx = |x: f32| ((x as Scalar) - win_w / 2.0) as Scalar;
+    let ty = |y: f32| -((y as Scalar) - win_h / 2.0) as Scalar;
+
+    match e {
+        Event::Window { win_event, .. } =>
+            (match win_event {
+                WindowEvent::Resized(w, h) => {
+                    Some(Input::Resize(w as u32, h as u32))
+                },
+
+                WindowEvent::FocusGained =>
+                    Some(Input::Focus(true)),
+
+                WindowEvent::FocusLost =>
+                    Some(Input::Focus(false)),
+
+                _ => None,
+            }, None),
+        Event::TextInput { text, .. } => {
+            (Some(Input::Text(text)), None)
+        },
+
+        Event::KeyDown { keycode: Some(key), .. } => {
+            (Some(Input::Press(input::Button::Keyboard(map_key(key)))), None)
+        },
+
+        Event::KeyUp { keycode: Some(key), .. } => {
+            (Some(Input::Release(input::Button::Keyboard(map_key(key)))), None)
+        },
+
+        Event::FingerDown { touch_id, x, y, .. } => {
+            let xy = [x as f64, y as f64];
+            let id = input::touch::Id::new(touch_id as u64);
+            let phase = input::touch::Phase::Start;
+            let touch = input::Touch { phase, id, xy };
+            (Some(Input::Touch(touch)), None)
+        },
+
+        Event::FingerMotion { touch_id, x, y, .. } => {
+            let xy = [x as f64, y as f64];
+            let id = input::touch::Id::new(touch_id as u64);
+            let phase = input::touch::Phase::Move;
+            let touch = input::Touch { phase, id, xy };
+            (Some(Input::Touch(touch)), None)
+        },
+
+        Event::FingerUp { touch_id, x, y, .. } => {
+            let xy = [x as f64, y as f64];
+            let id = input::touch::Id::new(touch_id as u64);
+            let phase = input::touch::Phase::End;
+            let touch = input::Touch { phase, id, xy };
+            (Some(Input::Touch(touch)), None)
+        },
+
+        Event::MouseMotion { x, y, xrel, yrel, .. } => {
+            let cursor = input::Motion::MouseCursor { x: tx(x as f32), y: ty(y as f32) };
+            let relative = input::Motion::MouseRelative { x: tx(xrel as f32), y: ty(yrel as f32) };
+            (Some(Input::Motion(cursor)), Some(Input::Motion(relative)))
+        },
+
+        Event::MouseWheel { x, y, .. } => {
+            // Invert the scrolling of the *y* axis as *y* is up in conrod.
+            let x = x as Scalar;
+            let y = -y as Scalar;
+            let motion = input::Motion::Scroll { x, y };
+            (Some(Input::Motion(motion)), None)
+        },
+
+        Event::MouseButtonDown { mouse_btn, .. } =>
+            (Some(Input::Press(input::Button::Mouse(map_mouse(mouse_btn)))), None),
+
+        Event::MouseButtonUp { mouse_btn, .. } =>
+            (Some(Input::Release(input::Button::Mouse(map_mouse(mouse_btn)))), None),
+
+        Event::JoyAxisMotion{ which, axis_idx, value, .. } => {
+            // Axis motion is an absolute value in the range
+            // [-32768, 32767]. Normalize it down to a float.
+            use std::i16::MAX;
+            let normalized_value = value as f64 / MAX as f64;
+            (Some(Input::Motion(input::Motion::ControllerAxis(ControllerAxisArgs::new(
+                            which, axis_idx, normalized_value)))), None)
+        }
+
+        _ => (None, None),
+    }
+}
+
+/// Maps sdl2's key to a conrod `Key`.
+pub fn map_key(keycode: sdl2::keyboard::Keycode) -> input::keyboard::Key {
+    (keycode as u32).into()
+}
+
+/// Maps sdl2's mouse button to conrod's mouse button.
+pub fn map_mouse(mouse_button: sdl2::mouse::MouseButton) -> input::MouseButton {
+    use input::MouseButton;
+    match mouse_button {
+        sdl2::mouse::MouseButton::Left => MouseButton::Left,
+        sdl2::mouse::MouseButton::Right => MouseButton::Right,
+        sdl2::mouse::MouseButton::Middle => MouseButton::Middle,
+        sdl2::mouse::MouseButton::X1 => MouseButton::X1,
+        sdl2::mouse::MouseButton::X2 => MouseButton::X2,
+        _ => MouseButton::Unknown
+    }
+}

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -84,8 +84,9 @@ pub fn convert_event(e: event::Event, win_w: Scalar, win_h: Scalar) -> (Option<I
 
         Event::MouseWheel { x, y, .. } => {
             // Invert the scrolling of the *y* axis as *y* is up in conrod.
-            let x = x as Scalar;
-            let y = -y as Scalar;
+            const ARBITRARY_POINTS_PER_LINE_FACTOR: Scalar = 10.0;
+            let x = ARBITRARY_POINTS_PER_LINE_FACTOR * x as Scalar;
+            let y = ARBITRARY_POINTS_PER_LINE_FACTOR * (-y) as Scalar;
             let motion = input::Motion::Scroll { x, y };
             (Some(Input::Motion(motion)), None)
         },

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -1,4 +1,4 @@
-//! A function for converting a `winit::Event` to a `conrod::event::Input`.
+//! A function for converting a `sdl2::event::Event` to a `conrod::event::Input`.
 
 use Scalar;
 use event::Input;
@@ -9,7 +9,8 @@ use piston_input::{ControllerAxisArgs};
 
 /// A function for converting a `sdl2::event::Event` to a `conrod::event::Input`.
 ///
-/// This can be useful for single-window applications.
+/// This can be useful for single-window applications. Note that win_w and win_h should be the dpi
+/// agnostic values (i.e. pass window.size() values and NOT window.drawable_size())
 ///
 /// NOTE: The sdl2 MouseMotion event is a combination of a MouseCursor and MouseRelative conrod
 /// events. Thus we may sometimes return two events in place of one, hence the tuple return type

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -3,7 +3,7 @@
 use Scalar;
 use event::Input;
 use input;
-use sdl2::{event, video};
+use sdl2::{event};
 use sdl2;
 use piston_input::{ControllerAxisArgs};
 
@@ -13,15 +13,9 @@ use piston_input::{ControllerAxisArgs};
 ///
 /// NOTE: The sdl2 MouseMotion event is a combination of a MouseCursor and MouseRelative conrod
 /// events. Thus we may sometimes return two events in place of one, hence the tuple return type
-pub fn convert_event(e: event::Event, window: &video::Window) -> (Option<Input>, Option<Input>)
+pub fn convert_event(e: event::Event, win_w: Scalar, win_h: Scalar) -> (Option<Input>, Option<Input>)
 {
     use sdl2::event::{Event, WindowEvent};
-
-    // The window size in points.
-    let (win_w, win_h) = {
-        let (w,h) = window.drawable_size();
-        (w as Scalar, h as Scalar)
-    };
 
     // Translate the coordinates from top-left-origin-with-y-down to centre-origin-with-y-up.
     //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate input as piston_input;
 extern crate rusttype;
 
 #[cfg(feature="glium")] #[macro_use] pub extern crate glium;
+#[cfg(feature="sdl2")] pub extern crate sdl2;
 #[cfg(feature="gfx_rs")] #[macro_use] pub extern crate gfx;
 #[cfg(feature="gfx_rs")] pub extern crate gfx_core;
 


### PR DESCRIPTION
Continuation of #1055
This PR adds the sdl2 backend without sdl2_gfx.
To demonstrate that it works, we also add an example using gfx-rs.