### PR TITLE
Added an extra level to the link

### DIFF
--- a/src/widget/canvas.rs
+++ b/src/widget/canvas.rs
@@ -23,7 +23,7 @@ use widget;
 /// "children" widgets.
 ///
 /// Widgets can be placed on a **Canvas** in a variety of ways using methods from the
-/// [**Positionable**](../position/trait.Positionable) trait.
+/// [**Positionable**](../../position/trait.Positionable.html) trait.
 ///
 /// **Canvas** provides methods for padding the kid widget area which can make using the
 /// **Place**-related **Positionable** methods a little easier.


### PR DESCRIPTION
Currently the documentation links to 
`https://docs.rs/conrod/0.56.0/conrod/widget/position/trait.Positionable`
 giving a 404. This change should make it link to 
`https://docs.rs/conrod/0.56.0/conrod/position/trait.Positionable.html`