### PR TITLE
Add support for `Oval` subsections with `Point` and `Triangle` iterators. Add `Point` and `Triangle` iterators for `RoundedRectangle` and rounded border.

### DIFF
--- a/src/widget/bordered_rectangle.rs
+++ b/src/widget/bordered_rectangle.rs
@@ -160,3 +160,68 @@ pub fn border_triangles(rect: Rect, border: Scalar) -> Option<[Triangle<Point>; 
 
     Some([r1a, r1b, r2a, r2b, r3a, r3b, r4a, r4b])
 }
+
+/// An iterator yielding triangles for a rounded border.
+///
+/// Clamps the thickness of the border to half the smallest dimension of the rectangle to
+/// ensure the bounds of the `rect` are not exceeded.
+pub fn rounded_border_triangles(
+    rect: Rect,
+    thickness: Scalar,
+    radius: Scalar,
+    corner_resolution: usize,
+) -> RoundedBorderTriangles {
+    RoundedBorderTriangles::new(rect, thickness, radius, corner_resolution)
+}
+
+/// An iterator yielding triangles for a rounded border.
+#[derive(Clone)]
+pub struct RoundedBorderTriangles {
+    outer: widget::rounded_rectangle::Points,
+    inner: widget::rounded_rectangle::Points,
+    last_points: [Point; 2],
+    is_next_outer: bool,
+}
+
+impl RoundedBorderTriangles {
+    /// Constructor for an iterator yielding triangles for a rounded border.
+    ///
+    /// Clamps the thickness of the border to half the smallest dimension of the rectangle to
+    /// ensure the bounds of the `rect` are not exceeded.
+    pub fn new(
+        rect: Rect,
+        mut thickness: Scalar,
+        radius: Scalar,
+        corner_resolution: usize,
+    ) -> Self {
+        thickness = {
+            let (w, h) = rect.w_h();
+            thickness.min(w * 0.5).min(h * 0.5)
+        };
+        let inner_rect = rect.pad(thickness);
+        let mut outer = widget::rounded_rectangle::points(rect, radius, corner_resolution);
+        let mut inner = widget::rounded_rectangle::points(inner_rect, radius, corner_resolution);
+        // A rounded_rectangle should always yield at least four points.
+        let last_points = [outer.next().unwrap(), inner.next().unwrap()];
+        let is_next_outer = true;
+        RoundedBorderTriangles { outer, inner, is_next_outer, last_points }
+    }
+}
+
+impl Iterator for RoundedBorderTriangles {
+    type Item = Triangle<Point>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let next_point = match self.is_next_outer {
+            true => self.outer.next(),
+            false => self.inner.next(),
+        };
+        next_point.map(|c| {
+            self.is_next_outer = !self.is_next_outer;
+            let a = self.last_points[0];
+            let b = self.last_points[1];
+            self.last_points[0] = b;
+            self.last_points[1] = c;
+            Triangle([a, b, c])
+        })
+    }
+}

--- a/src/widget/primitive/shape/circle.rs
+++ b/src/widget/primitive/shape/circle.rs
@@ -1,7 +1,7 @@
 //! An adaptation of the **Oval** type where the width and height are equal.
 
 use {Color, Dimensions, Scalar};
-use super::oval::Oval;
+use super::oval::{Full, Oval};
 use super::Style as Style;
 use widget;
 
@@ -17,31 +17,29 @@ fn rad_to_dim(radius: Scalar) -> Dimensions {
 
 
 impl Circle {
-
     /// Build a circular **Oval** with the given dimensions and style.
-    pub fn styled(radius: Scalar, style: Style) -> Oval {
+    pub fn styled(radius: Scalar, style: Style) -> Oval<Full> {
         Oval::styled(rad_to_dim(radius), style)
     }
 
     /// Build a new **Fill**ed circular **Oval**.
-    pub fn fill(radius: Scalar) -> Oval {
+    pub fn fill(radius: Scalar) -> Oval<Full> {
         Oval::fill(rad_to_dim(radius))
     }
 
     /// Build a new circular **Oval** **Fill**ed with the given color.
-    pub fn fill_with(radius: Scalar, color: Color) -> Oval {
+    pub fn fill_with(radius: Scalar, color: Color) -> Oval<Full> {
         Oval::fill_with(rad_to_dim(radius), color)
     }
 
     /// Build a new circular **Outline**d **Oval** widget.
-    pub fn outline(radius: Scalar) -> Oval {
+    pub fn outline(radius: Scalar) -> Oval<Full> {
         Oval::outline(rad_to_dim(radius))
     }
 
     /// Build a new circular **Oval** **Outline**d with the given style.
-    pub fn outline_styled(radius: Scalar, line_style: widget::line::Style) -> Oval {
+    pub fn outline_styled(radius: Scalar, line_style: widget::line::Style) -> Oval<Full> {
         Oval::outline_styled(rad_to_dim(radius), line_style)
     }
-
 }
 

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -1,13 +1,15 @@
 //! A simple, non-interactive widget for drawing a single **Oval**.
 
 use {Color, Colorable, Dimensions, Point, Rect, Scalar, Sizeable, Widget};
+use std;
 use super::Style as Style;
 use widget;
+use widget::triangles::Triangle;
 
 
 /// A simple, non-interactive widget for drawing a single **Oval**.
 #[derive(Copy, Clone, Debug, WidgetCommon_)]
-pub struct Oval {
+pub struct Oval<S> {
     /// Data necessary and common for all widget builder types.
     #[conrod(common_builder)]
     pub common: widget::CommonBuilder,
@@ -15,27 +17,56 @@ pub struct Oval {
     pub style: Style,
     /// The number of lines used to draw the edge.
     pub resolution: usize,
+    /// A type describing the section of the `Oval` that is to be drawn.
+    pub section: S,
 }
+
+/// Types that may be used to describe the visible section of the `Oval`.
+pub trait OvalSection: 'static + Copy + PartialEq + Send {}
+
+/// The entire `Oval` will be drawn.
+///
+/// To draw only a section of the oval, use the `section` builder method.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Full;
+
+impl OvalSection for Full {}
+
+/// A section of the oval will be drawn where the section is specified by the given radians.
+///
+/// A section with `radians` of `2.0 * PI` would be equivalent to the full `Oval`.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Section {
+    /// The angle occuppied by the section's circumference.
+    pub radians: Scalar,
+    /// The radians at which the section will begin.
+    ///
+    /// A value of `0.0` will begin at the right of the oval.
+    pub offset_radians: Scalar,
+}
+
+impl OvalSection for Section {}
 
 /// Unique state for the **Oval**.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct State {
+pub struct State<S> {
     /// The number of lines used to draw the edge.
     pub resolution: usize,
+    /// A type describing the section of the `Oval` that is to be drawn.
+    pub section: S,
 }
 
 /// The default circle resolution if none is specified.
 pub const DEFAULT_RESOLUTION: usize = 50;
 
-
-impl Oval {
-
+impl Oval<Full> {
     /// Build an **Oval** with the given dimensions and style.
     pub fn styled(dim: Dimensions, style: Style) -> Self {
         Oval {
             common: widget::CommonBuilder::default(),
             style: style,
             resolution: DEFAULT_RESOLUTION,
+            section: Full,
         }.wh(dim)
     }
 
@@ -58,7 +89,9 @@ impl Oval {
     pub fn outline_styled(dim: Dimensions, line_style: widget::line::Style) -> Self {
         Oval::styled(dim, Style::outline_styled(line_style))
     }
+}
 
+impl<S> Oval<S> {
     /// The number of lines used to draw the edge.
     ///
     /// By default, `DEFAULT_RESOLUTION` is used.
@@ -66,17 +99,39 @@ impl Oval {
         self.resolution = resolution;
         self
     }
+
+    /// Produces an `Oval` where only a section is drawn.
+    ///
+    /// The given `radians` describes the angle occuppied by the section's circumference.
+    pub fn section(self, radians: Scalar) -> Oval<Section> {
+        let Oval { common, style, resolution, .. } = self;
+        let section = Section { radians, offset_radians: 0.0 };
+        Oval { common, style, resolution, section }
+    }
 }
 
+impl Oval<Section> {
+    /// The radians at which the section will begin.
+    ///
+    /// A value of `0.0` will begin at the rightmost point of the oval.
+    pub fn offset_radians(mut self, offset_radians: Scalar) -> Self {
+        self.section.offset_radians = offset_radians;
+        self
+    }
+}
 
-impl Widget for Oval {
-    type State = State;
+impl<S> Widget for Oval<S>
+where
+    S: OvalSection,
+{
+    type State = State<S>;
     type Style = Style;
     type Event = ();
 
     fn init_state(&self, _: widget::id::Generator) -> Self::State {
         State {
             resolution: DEFAULT_RESOLUTION,
+            section: self.section,
         }
     }
 
@@ -90,20 +145,21 @@ impl Widget for Oval {
             state.update(|state| state.resolution = self.resolution);
         }
     }
-
 }
 
-
-impl Colorable for Oval {
+impl<S> Colorable for Oval<S> {
     fn color(mut self, color: Color) -> Self {
         self.style.set_color(color);
         self
     }
 }
 
-
-/// An iterator yielding the `Oval`'s edges as a circumference represented as a series of edges.
-pub fn circumference(rect: Rect, resolution: usize) -> Circumference {
+/// An iterator yielding the `Oval`'s edges as a circumference represented as a series of points.
+///
+/// `resolution` is clamped to a minimum of `1` as to avoid creating a `Circumference` that
+/// produces `NaN` values.
+pub fn circumference(rect: Rect, mut resolution: usize) -> Circumference {
+    resolution = std::cmp::max(resolution, 1);
     use std::f64::consts::PI;
     let (x, y, w, h) = rect.x_y_w_h();
     Circumference {
@@ -113,17 +169,17 @@ pub fn circumference(rect: Rect, resolution: usize) -> Circumference {
         half_w: w / 2.0,
         half_h: h / 2.0,
         rad_step: 2.0 * PI / resolution as Scalar,
+        rad_offset: 0.0,
     }
 }
 
 /// An iterator yielding the triangles that describe the given oval.
-///
-/// Returns `None` if the `resolution` is less than `3`.
-pub fn triangles(rect: Rect, resolution: usize) -> Option<Triangles> {
-    widget::polygon::triangles(circumference(rect, resolution))
+pub fn triangles(rect: Rect, resolution: usize) -> Triangles {
+    circumference(rect, resolution).triangles()
 }
 
-/// An iterator yielding the `Oval`'s edges as a circumference represented as a series of edges.
+/// An iterator yielding the edges of an `Oval` (or some section of an `Oval`) as a circumference
+/// represented as a series of edges.
 #[derive(Clone)]
 #[allow(missing_copy_implementations)]
 pub struct Circumference {
@@ -131,20 +187,78 @@ pub struct Circumference {
     num_points: usize,
     point: Point,
     rad_step: Scalar,
+    rad_offset: Scalar,
     half_w: Scalar,
     half_h: Scalar,
 }
 
-/// An iterator yielding the triangles that describe an oval.
-pub type Triangles = widget::polygon::Triangles<Circumference>;
+/// An iterator yielding triangles that describe an oval or some section of an oval.
+#[derive(Clone)]
+pub struct Triangles {
+    // The last circumference point yielded by the `CircumferenceOffset` iterator.
+    last: Point,
+    // The circumference points used to yield yielded by the `CircumferenceOffset` iterator.
+    points: Circumference,
+}
+
+impl Circumference {
+    /// Produces a new iterator that yields only a section of the `Oval`'s circumference, where the
+    /// section is described via its angle in radians.
+    pub fn section(mut self, radians: Scalar) -> Self {
+        let resolution = self.num_points - 1;
+        self.rad_step = radians / resolution as Scalar;
+        self
+    }
+
+    /// Rotates the position at which the iterator starts yielding points by the given radians.
+    ///
+    /// This is particularly useful for yielding a different section of the circumference when
+    /// using `circumference_section`
+    pub fn offset_radians(mut self, radians: Scalar) -> Self {
+        self.rad_offset = radians;
+        self
+    }
+
+    /// Produces an `Iterator` yielding `Triangle`s.
+    ///
+    /// Triangles are created by joining each edge yielded by the inner `Circumference` to the
+    /// middle of the `Oval`.
+    pub fn triangles(mut self) -> Triangles {
+        let last = self.next().unwrap_or(self.point);
+        Triangles { last, points: self }
+    }
+}
 
 impl Iterator for Circumference {
     type Item = Point;
     fn next(&mut self) -> Option<Self::Item> {
-        let Circumference { ref mut index, num_points, point, rad_step, half_w, half_h } = *self;
-        if *index >= num_points { return None; } else { *index += 1; }
-        let x = point[0] + half_w * (rad_step * *index as Scalar).cos();
-        let y = point[1] + half_h * (rad_step * *index as Scalar).sin();
+        let Circumference {
+            ref mut index,
+            num_points,
+            point,
+            rad_step,
+            rad_offset,
+            half_w,
+            half_h,
+        } = *self;
+        if *index >= num_points {
+            return None;
+        }
+        let x = point[0] + half_w * (rad_offset + rad_step * *index as Scalar).cos();
+        let y = point[1] + half_h * (rad_offset + rad_step * *index as Scalar).sin();
+        *index += 1;
         Some([x, y])
+    }
+}
+
+impl Iterator for Triangles {
+    type Item = Triangle<Point>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Triangles { ref mut points, ref mut last } = *self;
+        points.next().map(|next| {
+            let triangle = Triangle([points.point, *last, next]);
+            *last = next;
+            triangle
+        })
     }
 }

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -212,7 +212,7 @@ impl Circumference {
     /// `resolution` is clamped to a minimum of `1` as to avoid creating a `Circumference` that
     /// produces `NaN` values.
     pub fn new_section(rect: Rect, resolution: usize, radians: Scalar) -> Self {
-        Self::new_inner(rect, resolution, radians / resolution as Scalar)
+        Self::new_inner(rect, resolution + 1, radians / resolution as Scalar)
     }
 }
 

--- a/src/widget/primitive/shape/triangles.rs
+++ b/src/widget/primitive/shape/triangles.rs
@@ -108,6 +108,18 @@ impl<V> Triangle<V>
     }
 }
 
+impl Triangle<Point> {
+    /// Convert the `Triangle<Point>` to a `Triangle<ColoredPoint>`.
+    pub fn color(self, a: color::Rgba, b: color::Rgba, c: color::Rgba) -> Triangle<ColoredPoint> {
+        Triangle([(self[0], a), (self[1], b), (self[2], c)])
+    }
+
+    /// Convert the `Triangle<Point>` to a `Triangle<ColoredPoint>` using the given color.
+    pub fn color_all(self, color: color::Rgba) -> Triangle<ColoredPoint> {
+        Triangle([(self[0], color), (self[1], color), (self[2], color)])
+    }
+}
+
 impl<V> std::ops::Deref for Triangle<V>
     where V: Vertex,
 {

--- a/src/widget/rounded_rectangle.rs
+++ b/src/widget/rounded_rectangle.rs
@@ -3,10 +3,11 @@
 //! The roundedness of the corners is specified with a `radius`. This indicates the radius of the
 //! circle used to draw the corners.
 
-use {Color, Colorable, Dimensions, Point, Positionable, Scalar, Sizeable, Widget};
-use std;
-use super::primitive::shape::Style;
+use {Color, Colorable, Dimensions, Point, Positionable, Range, Rect, Scalar, Sizeable, Widget};
+use std::f64::consts::PI;
 use widget;
+use widget::primitive::shape::Style;
+use widget::primitive::shape::oval::Circumference;
 
 
 /// Draws a rectangle with corners rounded via the given radius.
@@ -36,7 +37,6 @@ pub struct State {
 }
 
 impl RoundedRectangle {
-
     /// Build a rounded rectangle with the given dimensions and style.
     pub fn styled(dim: Dimensions, radius: Scalar, style: Style) -> Self {
         RoundedRectangle {
@@ -72,7 +72,6 @@ impl RoundedRectangle {
         self.corner_resolution = res;
         self
     }
-
 }
 
 impl Widget for RoundedRectangle {
@@ -94,34 +93,7 @@ impl Widget for RoundedRectangle {
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { id, state, style, rect, ui, .. } = args;
         let RoundedRectangle { radius, corner_resolution, .. } = self;
-
-        let (l, r, b, t) = rect.l_r_b_t();
-        // The rectangle edges with the radius subtracted.
-        let (in_l, in_r, in_b, in_t) = (l + radius, r - radius, b + radius, t - radius);
-
-        // Circle logic for the rounded corners of the rectangle.
-        let circle_resolution = corner_resolution * 4;
-        let t = 2.0 * std::f64::consts::PI / circle_resolution as Scalar;
-        fn f(r: Scalar, i: Scalar, t: Scalar) -> Point {
-            [r * (t*i).cos(), r * (t*i).sin()]
-        }
-
-        const NUM_CORNERS: usize = 4;
-        let points = (0..NUM_CORNERS).flat_map(move |corner| {
-            let (in_x, in_y, step) = match corner {
-                0 => (in_r, in_t, 0),
-                1 => (in_l, in_t, corner_resolution),
-                2 => (in_l, in_b, corner_resolution + corner_resolution),
-                3 => (in_r, in_b, corner_resolution + corner_resolution + corner_resolution),
-                _ => unreachable!(),
-            };
-            (0..corner_resolution+1).map(move |res| {
-                let i = step + res;
-                let circle_offset = f(radius, i as f64, t);
-                [in_x + circle_offset[0], in_y + circle_offset[1]]
-            })
-        });
-
+        let points = points(rect, radius, corner_resolution);
         let (x, y, w, h) = rect.x_y_w_h();
         widget::Polygon::styled(points, *style)
             .x_y(x, y)
@@ -130,7 +102,6 @@ impl Widget for RoundedRectangle {
             .graphics_for(id)
             .set(state.ids.polygon, ui);
     }
-
 }
 
 impl Colorable for RoundedRectangle {
@@ -139,3 +110,69 @@ impl Colorable for RoundedRectangle {
         self
     }
 }
+
+/// An iterator yielding the outer points of a `RoundedRectangle`
+#[derive(Clone)]
+pub struct Points {
+    rect: Rect,
+    corner_rect: Rect,
+    corner_index: usize,
+    corner_resolution: usize,
+    corner_points: Circumference,
+}
+
+const CORNER_RADIANS: Scalar = PI * 0.5;
+
+/// Produce an iterator yielding the outer points of a rounded rectangle.
+///
+/// - `rect` describes the location and dimensions
+/// - `radius` describes the radius of the corner circles.
+/// - `corner_resolution` the number of lines used to draw each corner.
+pub fn points(rect: Rect, radius: Scalar, corner_resolution: usize) -> Points {
+    let (r, t) = (rect.x.end, rect.y.end);
+    // First corner is the top right corner.
+    let radius_2 = radius * 2.0;
+    let corner_rect = Rect {
+        x: Range { start: r - radius_2, end: r },
+        y: Range { start: t - radius_2, end: t },
+    };
+    let corner = Circumference::new_section(corner_rect, corner_resolution, CORNER_RADIANS);
+    Points {
+        rect,
+        corner_rect,
+        corner_index: 0,
+        corner_resolution,
+        corner_points: corner,
+    }
+}
+
+impl Iterator for Points {
+    type Item = Point;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Points {
+            ref mut corner_rect,
+            ref mut corner_index,
+            ref mut corner_points,
+            corner_resolution,
+            rect,
+        } = *self;
+        loop {
+            if let Some(point) = corner_points.next() {
+                return Some(point);
+            }
+            *corner_rect = match *corner_index {
+                0 => corner_rect.align_left_of(rect),
+                1 => corner_rect.align_bottom_of(rect),
+                2 => corner_rect.align_right_of(rect),
+                _ => return None,
+            };
+            *corner_index += 1;
+            let offset_radians = *corner_index as Scalar * CORNER_RADIANS;
+            *corner_points = Circumference::new_section(*corner_rect, corner_resolution, CORNER_RADIANS)
+                .offset_radians(offset_radians);
+        }
+    }
+}
+
+/// An iterator yielding triangles for a `RoundedRectangle`.
+pub type Triangles = widget::polygon::Triangles<Points>;


### PR DESCRIPTION
This supports both concave and convex sections of the `Oval`.

`Oval`s are now parameterised over their `OvalSection` - either `Full`
or `Section`.

`oval::Triangles` now triangulate from the middle of the oval rather
than the first point in order to make coloring them with gradients
easier.

Also adds `color(a, b, c)` and `color_all(color)` convenience methods
for mapping `Triangle<Point>` to `Triangle<ColoredPoint>`.