### PR TITLE
 Add `Widget::is_over` method - allows for more precise widget picking

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -94,6 +94,21 @@ pub struct Container {
     /// i.e. if foo's `instantiation_order_idx` is lower than bar's, it means that foo was
     /// instantiated before bar.
     pub instantiation_order_idx: usize,
+    /// A function specified by the widget to use when determining whether or not a point is over
+    /// it.
+    ///
+    /// NOTE: See `Wiget::is_over` for more details and a note on possible future plans.
+    pub is_over: IsOverFn,
+}
+
+/// A wrapper around a `widget::IsOverFn` to make implementing `Debug` easier for `Container`.
+#[derive(Copy, Clone)]
+pub struct IsOverFn(pub widget::IsOverFn);
+
+impl std::fmt::Debug for IsOverFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "IsOverFn")
+    }
 }
 
 /// A node for use within the **Graph**.
@@ -610,7 +625,7 @@ impl Graph {
         let widget::PreUpdateCache {
             type_id, id, maybe_parent_id, maybe_x_positioned_relatively_id,
             maybe_y_positioned_relatively_id, rect, depth, kid_area, maybe_floating,
-            crop_kids, maybe_x_scroll_state, maybe_y_scroll_state, maybe_graphics_for,
+            crop_kids, maybe_x_scroll_state, maybe_y_scroll_state, maybe_graphics_for, is_over,
         } = widget;
 
         assert!(self.node(id).is_some(), "No node found for the given widget::Id {:?}", id);
@@ -627,6 +642,7 @@ impl Graph {
             maybe_x_scroll_state: maybe_x_scroll_state,
             maybe_y_scroll_state: maybe_y_scroll_state,
             instantiation_order_idx: instantiation_order_idx,
+            is_over: IsOverFn(is_over),
         };
 
         // Retrieves the widget's parent index.
@@ -678,6 +694,7 @@ impl Graph {
                 container.maybe_x_scroll_state = maybe_x_scroll_state;
                 container.maybe_y_scroll_state = maybe_y_scroll_state;
                 container.instantiation_order_idx = instantiation_order_idx;
+                container.is_over = IsOverFn(is_over);
             },
 
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -331,7 +331,9 @@ impl Ui {
         self.global_input.current.widget_under_mouse =
             graph::algo::pick_widgets(&self.depth_order.indices,
                                       self.global_input.current.mouse.xy)
-                                      .next(&self.widget_graph, &self.depth_order.indices);
+                                      .next(&self.widget_graph,
+                                            &self.depth_order.indices,
+                                            &self.theme);
 
         // If MouseButton::Left is up and `widget_under_mouse` has changed, capture new widget
         // under mouse.
@@ -675,7 +677,8 @@ impl Ui {
                         // direction.
                         while let Some(idx) =
                             scrollable_widgets.next(&self.widget_graph,
-                                                    &self.depth_order.indices)
+                                                    &self.depth_order.indices,
+                                                    &self.theme)
                         {
 
                             let (kid_area, maybe_x_scroll, maybe_y_scroll) =
@@ -802,7 +805,7 @@ impl Ui {
                     // Find the widget under the touch.
                     let widget_under_touch =
                         graph::algo::pick_widgets(&self.depth_order.indices, touch.xy)
-                            .next(&self.widget_graph, &self.depth_order.indices);
+                            .next(&self.widget_graph, &self.depth_order.indices, &self.theme);
 
                     // The start of the touch interaction state to be stored.
                     let start = input::state::touch::Start {
@@ -840,7 +843,9 @@ impl Ui {
                         Some(touch) => {
                             touch.widget =
                                 graph::algo::pick_widgets(&self.depth_order.indices, touch.xy)
-                                    .next(&self.widget_graph, &self.depth_order.indices);
+                                    .next(&self.widget_graph,
+                                          &self.depth_order.indices,
+                                          &self.theme);
                             touch.xy = touch.xy;
                             touch.start.widget
                         },
@@ -875,7 +880,7 @@ impl Ui {
                     // of the touch, that widget receives the `Tap`.
                     let tapped_widget =
                         graph::algo::pick_widgets(&self.depth_order.indices, touch.xy)
-                            .next(&self.widget_graph, &self.depth_order.indices)
+                            .next(&self.widget_graph, &self.depth_order.indices, &self.theme)
                             .and_then(|widget| match Some(widget) == widget_capturing {
                                 true => Some(widget),
                                 false => None,

--- a/src/widget/plot_path.rs
+++ b/src/widget/plot_path.rs
@@ -1,6 +1,7 @@
 //! A widget for plotting a series of lines using the given function *x -> y*.
 
-use {Color, Colorable, Positionable, Scalar, Sizeable, Widget};
+use {Color, Colorable, Point, Positionable, Scalar, Sizeable, Theme, Widget};
+use graph;
 use num;
 use utils;
 use widget;
@@ -84,6 +85,14 @@ impl<X, Y, F> Widget for PlotPath<X, Y, F>
 
     fn style(&self) -> Self::Style {
         self.style.clone()
+    }
+
+    fn is_over(&self) -> widget::IsOverFn {
+        fn is_over_widget(widget: &graph::Container, _: Point, _: &Theme) -> widget::IsOver {
+            let unique = widget.state_and_style::<State, Style>().unwrap();
+            unique.state.ids.point_path.into()
+        }
+        is_over_widget
     }
 
     /// Update the state of the PlotPath.

--- a/src/widget/primitive/line.rs
+++ b/src/widget/primitive/line.rs
@@ -1,8 +1,10 @@
 //! A simple, non-interactive widget for drawing a single straight Line.
 
 use {Color, Colorable, Point, Positionable, Rect, Scalar, Sizeable, Theme};
+use graph;
 use utils::{vec2_add, vec2_sub};
 use widget::{self, Widget};
+use widget::triangles::Triangle;
 
 
 /// A simple, non-interactive widget for drawing a single straight Line.
@@ -270,6 +272,10 @@ impl Widget for Line {
         self.style.clone()
     }
 
+    fn is_over(&self) -> widget::IsOverFn {
+        is_over_widget
+    }
+
     /// Update the state of the Line.
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { rect, state, .. } = args;
@@ -300,4 +306,48 @@ impl Colorable for Line {
         self.style.maybe_color = Some(color);
         self
     }
+}
+
+/// Given two points and half the line thickness, return the four corners of the rectangle
+/// describing the line.
+pub fn rect_corners(a: Point, b: Point, half_thickness: Scalar) -> [Point; 4] {
+    let direction = [b[0] - a[0], b[1] - a[1]];
+    let mag = (direction[0] * direction[0] + direction[1] * direction[1]).sqrt();
+    let unit = [direction[0] / mag, direction[1] / mag];
+    let normal = [-unit[1], unit[0]];
+    let n = [normal[0] * half_thickness, normal[1] * half_thickness];
+    let r1 = [a[0] + n[0], a[1] + n[1]];
+    let r2 = [a[0] - n[0], a[1] - n[1]];
+    let r3 = [b[0] + n[0], b[1] + n[1]];
+    let r4 = [b[0] - n[0], b[1] - n[1]];
+    [r1, r2, r3, r4]
+}
+
+/// Given two points and half the line thickness, return the two triangles that describe the line.
+pub fn triangles(a: Point, b: Point, half_thickness: Scalar) -> [Triangle<Point>; 2] {
+    let r = rect_corners(a, b, half_thickness);
+    let t1 = Triangle([r[0], r[3], r[1]]);
+    let t2 = Triangle([r[0], r[3], r[2]]);
+    [t1, t2]
+}
+
+/// Describes whether or not the given point touches the line described by *a -> b* with the given
+/// thickness.
+pub fn is_over(a: Point, b: Point, thickness: Scalar, point: Point) -> bool {
+    let half_thickness = thickness * 0.5;
+    let tris = triangles(a, b, half_thickness);
+    widget::triangles::is_over(tris.iter().cloned(), point)
+}
+
+/// The function to use for picking whether a given point is over the line.
+pub fn is_over_widget(widget: &graph::Container, point: Point, theme: &Theme) -> widget::IsOver {
+    widget
+        .unique_widget_state::<Line>()
+        .map(|widget| {
+            let thickness = widget.style.get_thickness(theme);
+            let (a, b) = (widget.state.start, widget.state.end);
+            is_over(a, b, thickness, point)
+        })
+        .unwrap_or_else(|| widget.rect.is_over(point))
+        .into()
 }

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -23,7 +23,10 @@ pub struct Oval<S> {
 }
 
 /// Types that may be used to describe the visible section of the `Oval`.
-pub trait OvalSection: 'static + Copy + PartialEq + Send {}
+pub trait OvalSection: 'static + Copy + PartialEq + Send {
+    /// The function used to determine if a point is over the oval section widget.
+    const IS_OVER: widget::IsOverFn;
+}
 
 /// The entire `Oval` will be drawn.
 ///
@@ -31,7 +34,9 @@ pub trait OvalSection: 'static + Copy + PartialEq + Send {}
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Full;
 
-impl OvalSection for Full {}
+impl OvalSection for Full {
+    const IS_OVER: widget::IsOverFn = is_over_widget;
+}
 
 /// A section of the oval will be drawn where the section is specified by the given radians.
 ///
@@ -46,7 +51,9 @@ pub struct Section {
     pub offset_radians: Scalar,
 }
 
-impl OvalSection for Section {}
+impl OvalSection for Section {
+    const IS_OVER: widget::IsOverFn = is_over_section_widget;
+}
 
 /// Unique state for the **Oval**.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -141,13 +148,16 @@ where
     }
 
     fn is_over(&self) -> widget::IsOverFn {
-        is_over_widget
+        S::IS_OVER
     }
 
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         let widget::UpdateArgs { state, .. } = args;
         if state.resolution != self.resolution {
             state.update(|state| state.resolution = self.resolution);
+        }
+        if state.section != self.section {
+            state.update(|state| state.section = self.section);
         }
     }
 }
@@ -304,4 +314,25 @@ pub fn is_over(r: Rect, p: Point) -> bool {
 /// The function to use for picking whether a given point is over the oval.
 pub fn is_over_widget(widget: &graph::Container, point: Point, _: &Theme) -> widget::IsOver {
     is_over(widget.rect, point).into()
+}
+
+/// Returns whether or not the given point is over the section described
+pub fn is_over_section(circumference: Circumference, p: Point) -> bool {
+    widget::triangles::is_over(circumference.triangles(), p)
+}
+
+/// The function to use for picking whether a given point is over the oval section.
+pub fn is_over_section_widget(widget: &graph::Container, p: Point, _: &Theme) -> widget::IsOver {
+    widget
+        .state_and_style::<State<Section>, Style>()
+        .map(|unique| {
+            let res = unique.state.resolution;
+            let offset_rad = unique.state.section.offset_radians;
+            let rad = unique.state.section.radians;
+            let circumference = Circumference::new_section(widget.rect, res, rad)
+                .offset_radians(offset_rad);
+            is_over_section(circumference, p)
+        })
+        .unwrap_or_else(|| widget.rect.is_over(p))
+        .into()
 }

--- a/src/widget/primitive/shape/oval.rs
+++ b/src/widget/primitive/shape/oval.rs
@@ -1,6 +1,7 @@
 //! A simple, non-interactive widget for drawing a single **Oval**.
 
-use {Color, Colorable, Dimensions, Point, Rect, Scalar, Sizeable, Widget};
+use {Color, Colorable, Dimensions, Point, Rect, Scalar, Sizeable, Theme, Widget};
+use graph;
 use std;
 use super::Style as Style;
 use widget;
@@ -137,6 +138,10 @@ where
 
     fn style(&self) -> Self::Style {
         self.style.clone()
+    }
+
+    fn is_over(&self) -> widget::IsOverFn {
+        is_over_widget
     }
 
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
@@ -285,4 +290,18 @@ impl Iterator for Triangles {
             triangle
         })
     }
+}
+
+/// Returns `true` if the given `Point` is over an oval at the given rect.
+pub fn is_over(r: Rect, p: Point) -> bool {
+    let (px, py) = (p[0], p[1]);
+    let (ox, oy, w, h) = r.x_y_w_h();
+    let rx = w * 0.5;
+    let ry = h * 0.5;
+    ((px - ox).powi(2) / rx.powi(2) + (py - oy).powi(2) / ry.powi(2)) < 1.0
+}
+
+/// The function to use for picking whether a given point is over the oval.
+pub fn is_over_widget(widget: &graph::Container, point: Point, _: &Theme) -> widget::IsOver {
+    is_over(widget.rect, point).into()
 }

--- a/src/widget/primitive/shape/triangles.rs
+++ b/src/widget/primitive/shape/triangles.rs
@@ -1,7 +1,8 @@
 //! A primitive widget that allows for drawing using a list of triangles.
 
-use {Rect, Point, Positionable, Sizeable, Widget};
+use {Rect, Point, Positionable, Scalar, Sizeable, Theme, Widget};
 use color;
+use graph;
 use std;
 use utils::{vec2_add, vec2_sub};
 use widget;
@@ -105,6 +106,11 @@ impl<V> Triangle<V>
         let b = self[1].add(amount);
         let c = self[2].add(amount);
         Triangle([a, b, c])
+    }
+
+    /// The three points that make up the triangle.
+    pub fn points(self) -> [Point; 3] {
+        [self[0].point(), self[1].point(), self[2].point()]
     }
 }
 
@@ -314,6 +320,10 @@ impl<S, I> Widget for Triangles<S, I>
         self.style.clone()
     }
 
+    fn is_over(&self) -> widget::IsOverFn {
+        is_over_widget::<S>
+    }
+
     fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
         use utils::{iter_diff, IterDiff};
         let widget::UpdateArgs { rect, state, .. } = args;
@@ -403,4 +413,54 @@ impl<S, I> Widget for Triangles<S, I>
 pub fn from_quad(points: [Point; 4]) -> (Triangle<Point>, Triangle<Point>) {
     let (a, b, c, d) = (points[0], points[1], points[2], points[3]);
     (Triangle([a, b, c]), Triangle([a, c, d]))
+}
+
+impl<V> AsRef<Triangle<V>> for Triangle<V>
+where
+    V: Vertex,
+{
+    fn as_ref(&self) -> &Triangle<V> {
+        self
+    }
+}
+
+/// Returns `true` if the given `Point` is over the given `Triangle`.
+pub fn is_over_triangle<V>(t: &Triangle<V>, p: Point) -> bool
+where
+    V: Vertex,
+{
+    let ps = t.points();
+    let (a, b, c) = (ps[0], ps[1], ps[2]);
+
+    fn sign(a: Point, b: Point, c: Point) -> Scalar {
+        (a[0] - c[0]) * (b[1] - c[1]) - (b[0] - c[0]) * (a[1] - c[1])
+    }
+
+    let b1 = sign(p, a, b) < 0.0;
+    let b2 = sign(p, b, c) < 0.0;
+    let b3 = sign(p, c, a) < 0.0;
+
+    (b1 == b2) && (b2 == b3)
+}
+
+/// Returns `true` if the given `Point` is over any of the given `Triangle`s.
+pub fn is_over<V, I, T>(ts: I, p: Point) -> bool
+where
+    V: Vertex,
+    T: AsRef<Triangle<V>>,
+    I: IntoIterator<Item=T>,
+{
+    ts.into_iter().any(|t| is_over_triangle(t.as_ref(), p))
+}
+
+/// The function to use for picking whether a given point is over the line.
+pub fn is_over_widget<S>(widget: &graph::Container, point: Point, _: &Theme) -> widget::IsOver
+where
+    S: Style,
+{
+    widget
+        .state_and_style::<State<Vec<Triangle<S::Vertex>>>, S>()
+        .map(|widget| is_over(widget.state.triangles.iter().cloned(), point))
+        .unwrap_or_else(|| widget.rect.is_over(point))
+        .into()
 }

--- a/src/widget/rounded_rectangle.rs
+++ b/src/widget/rounded_rectangle.rs
@@ -3,7 +3,9 @@
 //! The roundedness of the corners is specified with a `radius`. This indicates the radius of the
 //! circle used to draw the corners.
 
-use {Color, Colorable, Dimensions, Point, Positionable, Range, Rect, Scalar, Sizeable, Widget};
+use {Color, Colorable, Dimensions, Point, Positionable, Range, Rect, Scalar, Sizeable, Theme,
+     Widget};
+use graph;
 use std::f64::consts::PI;
 use widget;
 use widget::primitive::shape::Style;
@@ -87,6 +89,10 @@ impl Widget for RoundedRectangle {
 
     fn style(&self) -> Self::Style {
         self.style.clone()
+    }
+
+    fn is_over(&self) -> widget::IsOverFn {
+        is_over_widget
     }
 
     /// Update the state of the Rectangle.
@@ -176,3 +182,11 @@ impl Iterator for Points {
 
 /// An iterator yielding triangles for a `RoundedRectangle`.
 pub type Triangles = widget::polygon::Triangles<Points>;
+
+/// The function to use for picking whether a given point is over the polygon.
+pub fn is_over_widget(widget: &graph::Container, point: Point, _: &Theme) -> widget::IsOver {
+    widget
+        .unique_widget_state::<RoundedRectangle>()
+        .map(|widget| widget.state.ids.polygon.into())
+        .unwrap_or_else(|| widget.rect.is_over(point).into())
+}


### PR DESCRIPTION
*Based on #1100*

This adds a new API for allowing a widget to optionally specify a
function that can be used for determining whether or not a given point
is over the widget. By default, a function that simply checks the
bounding rectangle is used.

This has been implemented for all existing widgets with non-rectangular
bounds (other than `Text`) including:

- `Line`
- `Oval`
- `PlotPath`
- `PointPath`
- `Polygon`
- `RoundedRectangle`
- `Triangles`

Each of the containing modules also provide helper functions that may
aid in the implementation of custom widgets.