### PR TITLE
 Add new `Graph` widget along with helper `Node` container widget 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ gfx_rs=["gfx","gfx_core"]
 [dev-dependencies]
 find_folder = "0.3.0"
 image = "0.17.0"
+petgraph = "0.4"
 rand = "0.3.13"
 # glutin_gfx.rs example dependencies
 gfx_window_glutin = "0.19.0"

--- a/examples/graph.rs
+++ b/examples/graph.rs
@@ -1,0 +1,256 @@
+//! A simple example that demonstrates the **Graph** widget functionality.
+
+#[cfg(all(feature="winit", feature="glium"))] #[macro_use] extern crate conrod;
+#[cfg(all(feature="winit", feature="glium"))] mod support;
+
+fn main() {
+    feature::main();
+}
+
+#[cfg(all(feature="winit", feature="glium"))]
+mod feature {
+    extern crate petgraph;
+    use conrod::{self, widget, Borderable, Colorable, Labelable, Positionable, Sizeable, Widget};
+    use conrod::backend::glium::glium::{self, Surface};
+    use conrod::widget::graph::{node, Event, EdgeEvent, Node, NodeEvent, NodeSocket};
+    use std::collections::HashMap;
+    use support;
+
+    widget_ids! {
+        struct Ids {
+            graph,
+        }
+    }
+
+    type MyGraph = petgraph::Graph<&'static str, (usize, usize)>;
+    type Layout = widget::graph::Layout<petgraph::graph::NodeIndex>;
+
+    pub fn main() {
+        const WIDTH: u32 = 900;
+        const HEIGHT: u32 = 500;
+
+        // Demo Graph.
+        let mut graph = MyGraph::new();
+        let a = graph.add_node("A");
+        let b = graph.add_node("B");
+        let c = graph.add_node("C");
+        let d = graph.add_node("D");
+        let e = graph.add_node("E");
+        graph.extend_with_edges(&[
+            (a, c, (1, 0)),
+            (a, d, (0, 1)),
+            (b, d, (0, 0)),
+            (c, d, (0, 2)),
+            (d, e, (0, 0)),
+        ]);
+
+        // Construct a starting layout for the nodes.
+        let mut layout_map = HashMap::new();
+        layout_map.insert(b, [-100.0, 100.0]);
+        layout_map.insert(a, [-300.0, 0.0]);
+        layout_map.insert(c, [-100.0, -100.0]);
+        layout_map.insert(d, [100.0, 0.0]);
+        layout_map.insert(e, [300.0, 0.0]);
+        let mut layout = Layout::from(layout_map);
+
+        // Build the window.
+        let mut events_loop = glium::glutin::EventsLoop::new();
+        let window = glium::glutin::WindowBuilder::new()
+            .with_title("Conrod Graph Widget")
+            .with_dimensions(WIDTH, HEIGHT);
+        let context = glium::glutin::ContextBuilder::new()
+            .with_multisampling(4)
+            .with_vsync(true);
+        let display = glium::Display::new(window, context, &events_loop).unwrap();
+
+        // construct our `Ui`.
+        let mut ui = conrod::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
+
+        // Generate the widget identifiers.
+        let ids = Ids::new(ui.widget_id_generator());
+
+        // Add a `Font` to the `Ui`'s `font::Map` from file.
+        const FONT_PATH: &'static str =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/assets/fonts/NotoSans/NotoSans-Regular.ttf");
+        ui.fonts.insert_from_file(FONT_PATH).unwrap();
+
+        // A type used for converting `conrod::render::Primitives` into `Command`s that can be used
+        // for drawing to the glium `Surface`.
+        let mut renderer = conrod::backend::glium::Renderer::new(&display).unwrap();
+
+        // The image map describing each of our widget->image mappings (in our case, none).
+        let image_map = conrod::image::Map::<glium::texture::Texture2d>::new();
+
+        // Begin the event loop.
+        let mut event_loop = support::EventLoop::new();
+        'main: loop {
+            // Handle all events.
+            for event in event_loop.next(&mut events_loop) {
+
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = conrod::backend::winit::convert_event(event.clone(), &display) {
+                    ui.handle_event(event);
+                    event_loop.needs_update();
+                }
+
+                // Break from the loop upon `Escape` or closed window.
+                match event.clone() {
+                    glium::glutin::Event::WindowEvent { event, .. } => {
+                        match event {
+                            glium::glutin::WindowEvent::Closed |
+                            glium::glutin::WindowEvent::KeyboardInput {
+                                input: glium::glutin::KeyboardInput {
+                                    virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                                ..
+                            } => break 'main,
+                            _ => (),
+                        }
+                    }
+                    _ => (),
+                }
+            }
+
+            // Set the widgets.
+            set_widgets(&mut ui.set_widgets(), &ids, &mut graph, &mut layout);
+
+            // Draw the `Ui` if it has changed.
+            if let Some(primitives) = ui.draw_if_changed() {
+                renderer.fill(&display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(&display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
+            }
+        }
+    }
+
+    fn set_widgets(ui: &mut conrod::UiCell, ids: &Ids, graph: &mut MyGraph, layout: &mut Layout) {
+
+        /////////////////
+        ///// GRAPH /////
+        /////////////////
+        //
+        // Set the `Graph` widget.
+        //
+        // This returns a session on which we can begin setting nodes and edges.
+        //
+        // The session is used in multiple stages:
+        //
+        // 1. `Nodes` for setting a node widget for each node.
+        // 2. `Edges` for setting an edge widget for each edge.
+        // 3. `Final` for optionally displaying zoom percentage and cam position.
+
+        let session = {
+            // An identifier for each node in the graph.
+            let node_indices = graph.node_indices();
+            // Describe each edge in the graph as NodeSocket -> NodeSocket.
+            let edges = graph.raw_edges()
+                .iter()
+                .map(|e| {
+                    let start = NodeSocket { id: e.source(), socket_index: e.weight.0 };
+                    let end = NodeSocket { id: e.target(), socket_index: e.weight.1 };
+                    (start, end)
+                });
+            widget::Graph::new(node_indices, edges, layout)
+                .background_color(conrod::color::rgb(0.31, 0.33, 0.35))
+                .wh_of(ui.window)
+                .middle_of(ui.window)
+                .set(ids.graph, ui)
+        };
+
+        //////////////////
+        ///// EVENTS /////
+        //////////////////
+        //
+        // Graph events that have occurred since the last time the graph was instantiated.
+
+        for event in session.events() {
+            match event {
+                Event::Node(event) => match event {
+                    // NodeEvent::Add(node_kind) => {
+                    // },
+                    NodeEvent::Remove(node_id) => {
+                    },
+                    NodeEvent::Dragged { node_id, to, .. } => {
+                        *layout.get_mut(&node_id).unwrap() = to;
+                    },
+                },
+                Event::Edge(event) => match event {
+                    EdgeEvent::AddStart(node_socket) => {
+                    },
+                    EdgeEvent::Add { start, end } => {
+                    },
+                    EdgeEvent::Cancelled(node_socket) => {
+                    },
+                    EdgeEvent::Remove { start, end } => {
+                    },
+                },
+            }
+        }
+
+        /////////////////
+        ///// NODES /////
+        /////////////////
+        //
+        // Instantiate a widget for each node within the graph.
+
+        let mut session = session.next();
+        for node in session.nodes() {
+            // Each `Node` contains:
+            //
+            // `id` - The unique node identifier for this node.
+            // `point` - The position at which this node will be set.
+            // `inputs`
+            // `outputs`
+            //
+            // Calling `node.widget(some_widget)` returns a `NodeWidget`, which contains:
+            //
+            // `wiget_id` - The widget identifier for the widget that will represent this node.
+            let node_id = node.node_id();
+            let inputs = graph.neighbors_directed(node_id, petgraph::Incoming).count();
+            let outputs = graph.neighbors_directed(node_id, petgraph::Outgoing).count();
+            let button = widget::Button::new()
+                .label(&graph[node_id])
+                .border(0.0);
+            let widget = Node::new(button)
+                .inputs(inputs)
+                .outputs(outputs)
+                //.socket_color(conrod::color::LIGHT_RED)
+                .w_h(100.0, 60.0);
+            for _click in node.widget(widget).set(ui).widget_event {
+                println!("{} was clicked!", &graph[node_id]);
+            }
+        }
+
+        /////////////////
+        ///// EDGES /////
+        /////////////////
+        //
+        // Instantiate a widget for each edge within the graph.
+
+        let mut session = session.next();
+        for edge in session.edges() {
+            let (a, b) = node::edge_socket_rects(&edge, ui);
+            let line = widget::Line::abs(a.xy(), b.xy())
+                .color(conrod::color::DARK_CHARCOAL)
+                .thickness(3.0);
+
+            // Each edge contains:
+            //
+            // `start` - The unique node identifier for the node at the start of the edge with point.
+            // `end` - The unique node identifier for the node at the end of the edge with point.
+            // `widget_id` - The wiget identifier for this edge.
+            edge.widget(line).set(ui);
+        }
+    }
+}
+
+#[cfg(not(all(feature="winit", feature="glium")))]
+mod feature {
+    pub fn main() {
+        println!("This example requires the `winit` and `glium` features. \
+                 Try running `cargo run --release --features=\"winit glium\" --example <example_name>`");
+    }
+}

--- a/src/widget/graph/mod.rs
+++ b/src/widget/graph/mod.rs
@@ -1,0 +1,914 @@
+//! A widget for viewing and controlling graph structures.
+
+use {color, widget, Color, Colorable, Point, Positionable, Scalar, Widget, Ui, UiCell};
+use std::any::{Any, TypeId};
+use std::cell::Cell;
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Mutex, Weak};
+use utils::{iter_diff, IterDiff};
+
+pub use self::node::{Node, SocketLayout, SocketSide};
+
+pub mod node;
+
+/// Traits required by types that may be used as a graph node identifier.
+///
+/// This trait has a blanket implementation for all types that satisfy the bounds.
+pub trait NodeId: 'static + Copy + Clone + PartialEq + Eq + Hash + Send {}
+impl<T> NodeId for T where T: 'static + Copy + Clone + PartialEq + Eq + Hash + Send {}
+
+/// Stores the layout of all nodes within the graph.
+///
+/// All positions are relative to the centre of the `Graph` widget.
+///
+/// Nodes can be moved by 
+#[derive(Clone, Debug, PartialEq)]
+pub struct Layout<NI>
+where
+    NI: Eq + Hash,
+{
+    map: HashMap<NI, Point>,
+}
+
+impl<NI> Deref for Layout<NI>
+where
+    NI: NodeId,
+{
+    type Target = HashMap<NI, Point>;
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<NI> DerefMut for Layout<NI>
+where
+    NI: NodeId,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.map
+    }
+}
+
+/// A widget used for visualising and manipulating **Graph** types.
+#[derive(Clone, Debug, WidgetCommon_)]
+pub struct Graph<'a, N, E>
+where
+    N: Iterator,
+    N::Item: NodeId,
+    E: Iterator<Item=(NodeSocket<N::Item>, NodeSocket<N::Item>)>,
+{
+    /// Data necessary and common for all widget builder types.
+    #[conrod(common_builder)]
+    pub common: widget::CommonBuilder,
+    /// Unique styling for the **Graph**.
+    pub style: Style,
+    /// All nodes within the graph that the widget is to represent.
+    pub nodes: N,
+    /// All edges within the graph.
+    pub edges: E,
+    /// The position of each node within the graph.
+    pub layout: &'a Layout<N::Item>,
+}
+
+/// Unique styling for the **BorderedRectangle** widget.
+#[derive(Copy, Clone, Debug, Default, PartialEq, WidgetStyle_)]
+pub struct Style {
+    /// Shape styling for the inner rectangle.
+    #[conrod(default = "color::TRANSPARENT")]
+    pub background_color: Option<Color>,
+}
+
+widget_ids! {
+    struct Ids {
+        // The rectangle over which all nodes are placed.
+        background,
+    }
+}
+
+/// Unique state for the `Graph`.
+pub struct State<NI>
+where
+    NI: NodeId,
+{
+    ids: Ids,
+    shared: Arc<Mutex<Shared<NI>>>,
+}
+
+// State shared between the **Graph**'s **State** and the returned **Session**.
+struct Shared<NI>
+where
+    NI: NodeId,
+{
+    // A queue of events collected during `set` so that they may be emitted during
+    // **SessionEvents**.
+    events: VecDeque<Event<NI>>,
+    // A mapping from node IDs to their data.
+    nodes: HashMap<NI, NodeInner>,
+    // A list of indices, one for each node in the graph.
+    node_ids: Vec<NI>,
+    // A list of all edges where (a, b) represents the directed edge a -> b.
+    edges: Vec<(NodeSocket<NI>, NodeSocket<NI>)>,
+    // A map from type identifiers to available `widget::Id`s for those types.
+    widget_id_map: WidgetIdMap<NI>,
+}
+
+// A type for managing the input and output socket layouts.
+#[derive(Copy, Clone, Debug)]
+struct SocketLayouts {
+    input: SocketLayout,
+    output: SocketLayout,
+}
+
+// A list of `widget::Id`s for a specific type.
+#[derive(Default)]
+struct TypeWidgetIds {
+    // The index of the next `widget::Id` to use for this type.
+    next_index: usize,
+    // The list of widget IDs.
+    widget_ids: Vec<widget::Id>,
+}
+
+impl TypeWidgetIds {
+    // Return the next `widget::Id` for a widget of the given type.
+    //
+    // If there are no more `Id`s available for the type, a new one will be generated from the
+    // given `widget::id::Generator`.
+    fn next_id(&mut self, generator: &mut widget::id::Generator) -> widget::Id {
+        loop {
+            match self.widget_ids.get(self.next_index).map(|&id| id) {
+                None => self.widget_ids.push(generator.next()),
+                Some(id) => {
+                    self.next_index += 1;
+                    break id;
+                }
+            }
+        }
+    }
+}
+
+// A mapping from types to their list of IDs.
+#[derive(Default)]
+struct WidgetIdMap<NI>
+where
+    NI: NodeId,
+{
+    // A map from types to their available `widget::Id`s
+    type_widget_ids: HashMap<TypeId, TypeWidgetIds>,
+    // A map from node IDs to their `widget::Id`.
+    //
+    // This is cleared at the end of each `Widget::update` and filled during the `Node`
+    // instantiation phase.
+    node_widget_ids: HashMap<NI, widget::Id>,
+}
+
+impl<NI> WidgetIdMap<NI>
+where
+    NI: NodeId,
+{
+    // Resets the index for every `TypeWidgetIds` list to `0`.
+    //
+    // This should be called at the beginning of the `Graph` update to ensure each widget
+    // receives a unique ID. If this is not called, the graph will request more and more
+    // `widget::Id`s every update and quickly bloat the `Ui`'s inner widget graph.
+    fn reset_indices(&mut self) {
+        for type_widget_ids in self.type_widget_ids.values_mut() {
+            type_widget_ids.next_index = 0;
+        }
+    }
+
+    // Clears the `node_id` -> `widget_id` mappings so that they may be recreated during the next
+    // node instantiation stage.
+    fn clear_node_mappings(&mut self) {
+        self.node_widget_ids.clear();
+    }
+
+    // Return the next `widget::Id` for a widget of the given type.
+    //
+    // If there are no more `Id`s available for the type, a new one will be generated from the
+    // given `widget::id::Generator`.
+    fn next_id_for_node<T>(&mut self, node_id: NI, generator: &mut widget::id::Generator) -> widget::Id
+    where
+        T: Any,
+    {
+        let type_id = TypeId::of::<T>();
+        let type_widget_ids = self.type_widget_ids.entry(type_id).or_insert_with(TypeWidgetIds::default);
+        let widget_id = type_widget_ids.next_id(generator);
+        self.node_widget_ids.insert(node_id, widget_id);
+        widget_id
+    }
+
+    // Return the next `widget::Id` for a widget of the given type.
+    //
+    // If there are no more `Id`s available for the type, a new one will be generated from the
+    // given `widget::id::Generator`.
+    fn next_id_for_edge<T>(&mut self, generator: &mut widget::id::Generator) -> widget::Id
+    where
+        T: Any,
+    {
+        let type_id = TypeId::of::<T>();
+        let type_widget_ids = self.type_widget_ids.entry(type_id).or_insert_with(TypeWidgetIds::default);
+        let widget_id = type_widget_ids.next_id(generator);
+        widget_id
+    }
+}
+
+/// An interaction has caused some event to occur.
+//
+// TODO:
+//
+// - Hovered near outlet.
+// - Edge end hovered near an outlet?
+#[derive(Clone, Debug, PartialEq)]
+pub enum Event<NI> {
+    /// Events associated with nodes.
+    Node(NodeEvent<NI>),
+    /// Events associated with edges.
+    Edge(EdgeEvent<NI>),
+}
+
+/// Represents a socket connection on a node.
+///
+/// Assumed to be either an input or output socket based on its usage within a tuple. E.g. given
+/// two sockets *(a, b)*, socket *a*'s `socket_index` refers its index within `a`'s ***output***
+/// socket list, while *b*'s refers its index within `b`'s ***input*** socket list.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NodeSocket<NI> {
+    /// The unique identifier for the node.
+    pub id: NI,
+    /// The index of the socket on one side of the node.
+    ///
+    /// E.g. if the socket is the 3rd output socket, index would be `2`.
+    pub socket_index: usize,
+}
+
+/// Events related to adding and removing nodes.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum NodeEvent<NI> {
+    /// The user attempted to remove the node with the given identifier.
+    Remove(NI),
+    /// The widget used to represent this `Node` has been dragged.
+    Dragged {
+        /// Unique identifier of the node being dragged.
+        node_id: NI,
+        /// The origin of the drag relative to the `Graph` widget position.
+        from: Point,
+        /// The end of the drag relative to the `Graph` widget position.
+        to: Point,
+    },
+}
+
+/// Events related to adding and removing edges.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum EdgeEvent<NI> {
+    /// The user has pressed the given node socket with the left mouse button to begin creating an
+    /// edge.
+    AddStart(NodeSocket<NI>),
+    /// The user has attempted to create an edge between the two given node sockets.
+    Add {
+        start: NodeSocket<NI>,
+        end: NodeSocket<NI>,
+    },
+    /// The user has cancelled creating an edge from the given socket.
+    Cancelled(NodeSocket<NI>),
+    /// The user has attempted to remove the edge connecting the two given sockets.
+    Remove {
+        start: NodeSocket<NI>,
+        end: NodeSocket<NI>,
+    },
+}
+
+/// The camera used to view the graph.
+///
+/// The camera supports 2D positioning and zoom.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct Camera {
+    // The position of the camera over the floorplan.
+    //
+    // [0.0, 0.0] - the centre of the graph.
+    point: Point,
+    // The higher the zoom, the closer the floorplan appears.
+    //
+    // The zoom can be multiplied by a distance in metres to get the equivalent distance as a GUI
+    // scalar value.
+    //
+    // 1.0 - Original resolution.
+    // 0.5 - 50% view.
+    zoom: Scalar,
+}
+
+/// A context for moving through the modes of graph widget instantiation in a type-safe manner.
+///
+/// The **Session** is shared between 3 stages:
+///
+/// 1. **SessionEvents**: Emit all graph events that have occurred since the last instantiation.
+/// 2. **SessionNodes**: Instantiate all node widgets in the graph.
+/// 3. **SessionEdges**: Instantiate all edge widgets in the graph.
+///
+/// NOTE: This should allow for different instantiation orders, e.g: nodes then edges, all
+/// connected components in topo order, edges then nodes, etc.
+pub struct Session<NI: NodeId> {
+    // The unique identifier used to instantiate the graph widget.
+    graph_id: widget::Id,
+    // State shared with the `Graph` widget.
+    shared: Weak<Mutex<Shared<NI>>>,
+}
+
+/// The first stage of the graph's **Session** event.
+pub struct SessionEvents<NI: NodeId> {
+    session: Session<NI>,
+}
+
+/// The second stage of the graph's **Session** event.
+pub struct SessionNodes<NI: NodeId> {
+    session: Session<NI>,
+}
+
+/// The third stage of the graph's **Session** event.
+pub struct SessionEdges<NI: NodeId> {
+    session: Session<NI>,
+}
+
+/// An iterator yielding all pending events.
+pub struct Events<'a, NI: NodeId> {
+    shared: Arc<Mutex<Shared<NI>>>,
+    // Bind the lifetime to the `SessionEvents` so the user can't leak the `Shared` state.
+    lifetime: PhantomData<&'a ()>,
+}
+
+/// An iterator-like type yielding a `NodeContext` for every node in the graph.
+///
+/// Each `NodeContext` can be used for instantiating a widget for each node in the graph.
+pub struct Nodes<'a, NI: 'a + NodeId> {
+    // Index into the `node_ids`, indicating which node we're up to.
+    index: usize,
+    shared: Arc<Mutex<Shared<NI>>>,
+    // The `widget::Id` of the parent graph widget.
+    graph_id: widget::Id,
+    // Bind the lifetime to the `SessionNodes` so the user can't leak the `Shared` state.
+    lifetime: PhantomData<&'a NI>,
+}
+
+// Node data stored within the 
+#[derive(Copy, Clone)]
+struct NodeInner {
+    point: Point,
+}
+
+/// A context for a node yielded during the node instantiation stage.
+///
+/// This type can be used to:
+///
+/// 1. Get the position of the node via `point()`.
+/// 2. Get the ID for this node via `node_id()`.
+/// 3. Convert into a `NodeWidget` ready for instantiation within the `Ui` via `widget(a_widget)`.
+pub struct NodeContext<'a, NI: 'a + NodeId> {
+    node_id: NI,
+    point: Point,
+    // The `widget::Id` of the `NodeContext`'s parent `Graph` widget.
+    graph_id: widget::Id,
+    shared: Arc<Mutex<Shared<NI>>>,
+    // Bind the lifetime to the `SessionNodes` so the user can't leak the `Shared` state.
+    lifetime: PhantomData<&'a NI>,
+}
+
+/// Returned when a `NodeContext` is assigned a widget.
+///
+/// This intermediary type allows for accessing the `widget::Id` before the widget itself is
+/// instantiated.
+pub struct NodeWidget<'a, NI: 'a + NodeId, W> {
+    node: NodeContext<'a, NI>,
+    widget: W,
+    // `None` if not yet requested the `WidgetIdMap`. `Some` if it has.
+    widget_id: Cell<Option<widget::Id>>,
+}
+
+/// An iterator-like type yielding a `NodeContext` for every node in the graph.
+///
+/// Each `NodeContext` can be used for instantiating a widget for each node in the graph.
+pub struct Edges<'a, NI: 'a + NodeId> {
+    // The index into the `shared.edges` `Vec` that for the next `Edge` that is to be yielded.
+    index: usize,
+    shared: Arc<Mutex<Shared<NI>>>,
+    // The `widget::Id` of the parent graph widget.
+    graph_id: widget::Id,
+    // Bind the lifetime to the `SessionEdges` so the user can't leak the `Shared` state.
+    lifetime: PhantomData<&'a ()>,
+}
+
+/// A context for an edge yielded during the edge instantiation stage.
+///
+/// Tyis type can 
+pub struct Edge<'a, NI: NodeId> {
+    // The `widget::Id` of the `Edge`'s parent `Graph` widget.
+    graph_id: widget::Id,
+    // The data shared with the graph state, used to access the `WidgetIdMap`.
+    shared: Arc<Mutex<Shared<NI>>>,
+    // The start of the edge.
+    start: NodeSocket<NI>,
+    // The end of the edge.
+    end: NodeSocket<NI>,
+    // Bind the lifetime to the `SessionEdges` so the user can't leak the `Shared` state.
+    lifetime: PhantomData<&'a ()>,
+}
+
+/// Returned when an `Edge` is assigned a widget.
+///
+/// This intermediary type allows for accessing the `widget::Id` before the widget itself is
+/// instantiated.
+pub struct EdgeWidget<'a, NI: 'a + NodeId, W> {
+    edge: Edge<'a, NI>,
+    widget: W,
+    // `None` if not yet requested the `WidgetIdMap`. `Some` if it has.
+    widget_id: Cell<Option<widget::Id>>,
+}
+
+// impl<NI> Layout<NI>
+// where
+//     NI: Eq + Hash,
+// {
+//     /// The position of the node at the given node identifier.
+//     pub fn get(&self, node_id: NI) -> Option<&Point> {
+//         self.map.get(&node_id)
+//     }
+//     /// The position of the node at the given node identifier.
+//     pub fn get_mut(&mut self, node_id: NI) -> Option<&mut Point> {
+//         self.map.get_mut(&node_id)
+//     }
+// }
+
+impl<NI> From<HashMap<NI, Point>> for Layout<NI>
+where
+    NI: NodeId,
+{
+    fn from(map: HashMap<NI, Point>) -> Self {
+        Layout { map }
+    }
+}
+
+impl<NI> Into<HashMap<NI, Point>> for Layout<NI>
+where
+    NI: NodeId,
+{
+    fn into(self) -> HashMap<NI, Point> {
+        let Layout { map } = self;
+        map
+    }
+}
+
+impl<NI> SessionEvents<NI>
+where
+    NI: NodeId,
+{
+    /// All events that have occurred since the last 
+    pub fn events(&self) -> Events<NI> {
+        let shared = self.session.shared.upgrade().expect("failed to access `Shared` state");
+        Events { shared, lifetime: PhantomData }
+    }
+
+    /// Transition from the **SessionEvents** into **SessionNodes** for instantiating nodes.
+    pub fn next(self) -> SessionNodes<NI> {
+        let SessionEvents { session } = self;
+        SessionNodes { session }
+    }
+}
+
+impl<'a, NI> Iterator for Events<'a, NI>
+where
+    NI: NodeId,
+{
+    type Item = Event<NI>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.shared.lock()
+            .ok()
+            .and_then(|mut guard| guard.events.pop_front())
+    }
+}
+
+impl<NI> SessionNodes<NI>
+where
+    NI: NodeId,
+{
+    /// Produce an iterator yielding a `NodeContext` for each node present in the graph.
+    pub fn nodes(&mut self) -> Nodes<NI> {
+        let graph_id = self.session.graph_id;
+        let shared = self.session.shared.upgrade().expect("failed to access `Shared` state");
+        Nodes { index: 0, shared, graph_id, lifetime: PhantomData }
+    }
+
+    /// Transition from the **SessionNodes** into **SessionEdges** for instantiating edges.
+    pub fn next(self) -> SessionEdges<NI> {
+        let SessionNodes { session } = self;
+        SessionEdges { session }
+    }
+}
+
+impl<'a, NI> Iterator for Nodes<'a, NI>
+where
+    NI: NodeId,
+{
+    type Item = NodeContext<'a, NI>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.index;
+        self.index += 1;
+        self.shared.lock()
+            .ok()
+            .and_then(|guard| {
+                guard.node_ids
+                    .get(index)
+                    .and_then(|&id| guard.nodes.get(&id).map(|&inner| (id, inner)))
+            })
+            .map(|(node_id, NodeInner { point })| {
+                NodeContext {
+                    node_id,
+                    point,
+                    graph_id: self.graph_id,
+                    shared: self.shared.clone(),
+                    lifetime: PhantomData,
+                }
+            })
+    }
+}
+
+impl<NI> SessionEdges<NI>
+where
+    NI: NodeId,
+{
+    /// Produce an iterator yielding an `Edge` for each node present in the graph.
+    pub fn edges(&mut self) -> Edges<NI> {
+        let graph_id = self.session.graph_id;
+        let shared = self.session.shared.upgrade().expect("failed to access `Shared` state");
+        Edges { index: 0, shared, graph_id, lifetime: PhantomData }
+    }
+}
+
+impl<'a, NI> Iterator for Edges<'a, NI>
+where
+    NI: NodeId,
+{
+    type Item = Edge<'a, NI>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.index;
+        self.index += 1;
+        self.shared.lock()
+            .ok()
+            .and_then(|guard| {
+                guard.edges.get(index).map(|&(start, end)| {
+                    Edge {
+                        graph_id: self.graph_id,
+                        shared: self.shared.clone(),
+                        start: start,
+                        end: end,
+                        lifetime: PhantomData,
+                    }
+                })
+            })
+    }
+}
+
+impl<'a, NI> NodeContext<'a, NI>
+where
+    NI: NodeId,
+{
+    /// The unique identifier associated with this node.
+    pub fn node_id(&self) -> NI {
+        self.node_id
+    }
+
+    /// The location of the node.
+    pub fn point(&self) -> Point {
+        self.point
+    }
+
+    /// Specify the widget to use 
+    pub fn widget<W>(self, widget: W) -> NodeWidget<'a, NI, W> {
+        NodeWidget {
+            node: self,
+            widget,
+            widget_id: Cell::new(None),
+        }
+    }
+}
+
+impl<'a, NI, W> NodeWidget<'a, NI, W>
+where
+    NI: NodeId,
+    W: 'static + Widget,
+{
+    /// Retrieve the `widget::Id` that will be used to instantiate this node's widget.
+    pub fn widget_id(&self, ui: &mut UiCell) -> widget::Id {
+        match self.widget_id.get() {
+            Some(id) => id,
+            None => {
+                // Request a `widget::Id` from the `WidgetIdMap`.
+                let mut shared = self.node.shared.lock().unwrap();
+                let id = shared.widget_id_map
+                    .next_id_for_node::<W>(self.node_id, &mut ui.widget_id_generator());
+                self.widget_id.set(Some(id));
+                id
+            },
+        }
+    }
+
+    /// Map over the inner widget.
+    pub fn map<M>(self, map: M) -> Self
+    where
+        M: FnOnce(W) -> W,
+    {
+        let NodeWidget { node, mut widget, widget_id } = self;
+        widget = map(widget);
+        NodeWidget { node, widget, widget_id }
+    }
+
+    /// Set the given widget for the node at `node_id()`.
+    pub fn set(self, ui: &mut UiCell) -> W::Event {
+        let widget_id = self.widget_id(ui);
+        let NodeWidget { node, widget, .. } = self;
+        widget
+            .xy_relative_to(node.graph_id, node.point)
+            .parent(node.graph_id)
+            .set(widget_id, ui)
+    }
+}
+
+impl<'a, NI, W> Deref for NodeWidget<'a, NI, W>
+where
+    NI: NodeId,
+{
+    type Target = NodeContext<'a, NI>;
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+impl<'a, NI> Edge<'a, NI>
+where
+    NI: NodeId,
+{
+    /// The start (or "input") for the edge.
+    ///
+    /// This is described via the node's `Id` and the position of its output socket.
+    pub fn start(&self) -> NodeSocket<NI> {
+        self.start
+    }
+
+    /// The end (or "output") for the edge.
+    ///
+    /// This is described via the node's `Id` and the position of its input socket.
+    pub fn end(&self) -> NodeSocket<NI> {
+        self.end
+    }
+
+    /// The start and end sockets.
+    pub fn sockets(&self) -> (NodeSocket<NI>, NodeSocket<NI>) {
+        (self.start, self.end)
+    }
+
+    /// Specify the widget to use 
+    pub fn widget<W>(self, widget: W) -> EdgeWidget<'a, NI, W> {
+        EdgeWidget {
+            edge: self,
+            widget,
+            widget_id: Cell::new(None),
+        }
+    }
+}
+
+/// Returns the `widget::Id` for a node if one exists.
+///
+/// Returns `None` if there is no `Graph` for the given `graph_id` or if there is not yet a
+/// `widget::Id` for the given `node_id`.
+///
+/// This will always return `None` if called between calls to the `Graph::set` and node
+/// instantiation stages, as `widget::Id`s for nodes are only populated during the node
+/// instantiation stage.
+pub fn node_widget_id<NI>(node_id: NI, graph_id: widget::Id, ui: &Ui) -> Option<widget::Id>
+where
+    NI: NodeId,
+{
+    ui.widget_graph()
+        .widget(graph_id)
+        .and_then(|container| container.state_and_style::<State<NI>, Style>())
+        .and_then(|unique| {
+            let shared = unique.state.shared.lock().unwrap();
+            shared.widget_id_map.node_widget_ids.get(&node_id).map(|&id| id)
+        })
+}
+
+/// Returns the `widget::Id`s for the start and end nodes.
+///
+/// `Edge`s can only exist for the lifetime of a `SessionEdges`, thus we assume that there will
+/// always be a `Graph` for the edge's `graph_id` and that there will always be a `widget::Id`
+/// for the start and end nodes.
+///
+/// **Panic!**s if the given `Ui` is not the same one used to create the edge's parent Graph
+/// widget.
+pub fn edge_node_widget_ids<NI>(edge: &Edge<NI>, ui: &Ui) -> (widget::Id, widget::Id)
+where
+    NI: NodeId,
+{
+    ui.widget_graph()
+        .widget(edge.graph_id)
+        .and_then(|container| container.state_and_style::<State<NI>, Style>())
+        .map(|unique| {
+            let shared = unique.state.shared.lock().unwrap();
+            let a = shared.widget_id_map.node_widget_ids.get(&edge.start.id).map(|&id| id);
+            let b = shared.widget_id_map.node_widget_ids.get(&edge.end.id).map(|&id| id);
+            (a.expect("no `widget::Id` for start node"), b.expect("no `widget::Id` for end node"))
+        })
+        .expect("no graph associated with edge's `graph_id` was found")
+}
+
+impl<'a, NI, W> EdgeWidget<'a, NI, W>
+where
+    NI: NodeId,
+    W: 'static + Widget,
+{
+    /// Retrieve the `widget::Id` that will be used to instantiate this edge's widget.
+    pub fn widget_id(&self, ui: &mut UiCell) -> widget::Id {
+        match self.widget_id.get() {
+            Some(id) => id,
+            None => {
+                // Request a `widget::Id` from the `WidgetIdMap`.
+                let mut shared = self.edge.shared.lock().unwrap();
+                let id = shared.widget_id_map.next_id_for_edge::<W>(&mut ui.widget_id_generator());
+                self.widget_id.set(Some(id));
+                id
+            },
+        }
+    }
+
+    /// Apply the given function to the inner widget.
+    pub fn map<M>(self, map: M) -> Self
+    where
+        M: FnOnce(W) -> W,
+    {
+        let EdgeWidget { edge, mut widget, widget_id } = self;
+        widget = map(widget);
+        EdgeWidget { edge, widget, widget_id }
+    }
+
+    /// Set the given widget for the edge.
+    pub fn set(self, ui: &mut UiCell) -> W::Event {
+        let widget_id = self.widget_id(ui);
+        let EdgeWidget { edge, widget, .. } = self;
+        widget
+            .parent(edge.graph_id)
+            .set(widget_id, ui)
+    }
+}
+
+impl<'a, N, E> Graph<'a, N, E>
+where
+    N: Iterator,
+    N::Item: NodeId,
+    E: Iterator<Item=(NodeSocket<N::Item>, NodeSocket<N::Item>)>,
+{
+    /// Begin building a new **Graph** widget.
+    pub fn new<NI, EI>(nodes: NI, edges: EI, layout: &'a Layout<NI::Item>) -> Self
+    where
+        NI: IntoIterator<IntoIter=N, Item=N::Item>,
+        EI: IntoIterator<IntoIter=E, Item=(NodeSocket<N::Item>, NodeSocket<N::Item>)>,
+    {
+        Graph {
+            common: widget::CommonBuilder::default(),
+            style: Style::default(),
+            nodes: nodes.into_iter(),
+            edges: edges.into_iter(),
+            layout: layout,
+        }
+    }
+
+    /// Color the **Graph**'s rectangular area with the given color.
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.style.background_color = Some(color);
+        self
+    }
+}
+
+impl<'a, N, E> Widget for Graph<'a, N, E>
+where
+    N: Iterator,
+    N::Item: NodeId,
+    E: Iterator<Item=(NodeSocket<N::Item>, NodeSocket<N::Item>)>,
+{
+    type State = State<N::Item>;
+    type Style = Style;
+    type Event = SessionEvents<N::Item>;
+
+    fn init_state(&self, id_gen: widget::id::Generator) -> Self::State {
+        let events = VecDeque::new();
+        let nodes = HashMap::new();
+        let node_ids = Vec::new();
+        let edges = Vec::new();
+        let type_widget_ids = HashMap::new();
+        let node_widget_ids = HashMap::new();
+        let widget_id_map = WidgetIdMap { type_widget_ids, node_widget_ids };
+        let shared = Shared { events, nodes, node_ids, edges, widget_id_map };
+        State {
+            ids: Ids::new(id_gen),
+            shared: Arc::new(Mutex::new(shared)),
+        }
+    }
+
+    fn style(&self) -> Self::Style {
+        self.style.clone()
+    }
+
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
+        let widget::UpdateArgs { id, state, style, rect, ui, .. } = args;
+        let Graph { nodes, edges, layout, .. } = self;
+        let mut shared = state.shared.lock().unwrap();
+
+        // Reset the WidgetIdMap indices.
+        shared.widget_id_map.reset_indices();
+
+        // Compare the existing node indices with the new iterator.
+        match iter_diff(&shared.node_ids, nodes) {
+            Some(diff) => match diff {
+                IterDiff::FirstMismatch(i, mismatch) => {
+                    shared.node_ids.truncate(i);
+                    shared.node_ids.extend(mismatch);
+                },
+                IterDiff::Longer(remaining) => {
+                    shared.node_ids.extend(remaining);
+                },
+                IterDiff::Shorter(total) => {
+                    shared.node_ids.truncate(total);
+                },
+            },
+            None => (),
+        }
+
+        // Compare the existing edges with the new iterator.
+        match iter_diff(&shared.edges, edges) {
+            Some(diff) => match diff {
+                IterDiff::FirstMismatch(i, mismatch) => {
+                    shared.edges.truncate(i);
+                    shared.edges.extend(mismatch);
+                },
+                IterDiff::Longer(remaining) => {
+                    shared.edges.extend(remaining);
+                },
+                IterDiff::Shorter(total) => {
+                    shared.edges.truncate(total);
+                },
+            },
+            None => (),
+        }
+
+        // Use `shared.node_ids` and `shared.edges` to fill `shared.nodes`.
+        shared.nodes.clear();
+        for i in 0..shared.node_ids.len() {
+            // Retrieve the node ID.
+            let node_id = shared.node_ids[i];
+
+            // Get the node position, falling back to 0.0, 0.0 if none was given.
+            let point = layout.map.get(&node_id).map(|&p| p).unwrap_or([0.0; 2]);
+
+            // Check to see if this widget has been dragged since the last update.
+            let point = match shared.widget_id_map.node_widget_ids.get(&node_id).map(|&w| w) {
+                None => point,
+                Some(widget_id) => {
+                    let (dragged_x, dragged_y) = ui.widget_input(widget_id)
+                        .drags()
+                        .left()
+                        .fold((0.0, 0.0), |(x, y), d| (x + d.delta_xy[0], y + d.delta_xy[1]));
+
+                    // If dragging would not move the widget, we're done.
+                    if dragged_x == 0.0 && dragged_y == 0.0 {
+                        point
+                    } else {
+                        let to = [point[0] + dragged_x, point[1] + dragged_y];
+                        let node_event = NodeEvent::Dragged { node_id, from: point, to };
+                        let event = Event::Node(node_event);
+                        shared.events.push_back(event);
+                        to
+                    }
+                },
+            };
+
+            let node = NodeInner { point };
+            shared.nodes.insert(node_id, node);
+        }
+
+        let background_color = style.background_color(&ui.theme);
+        widget::Rectangle::fill(rect.dim())
+            .xy(rect.xy())
+            .color(background_color)
+            .parent(id)
+            .graphics_for(id)
+            .set(state.ids.background, ui);
+
+        // Clear the old node->widget mappings ready for node instantiation.
+        shared.widget_id_map.clear_node_mappings();
+
+        let graph_id = id;
+        let shared = Arc::downgrade(&state.shared);
+        let session = Session { graph_id, shared };
+        SessionEvents { session }
+    }
+}

--- a/src/widget/graph/node.rs
+++ b/src/widget/graph/node.rs
@@ -1,0 +1,601 @@
+//! A default container widget to use for nodes that exist within a `Graph` widget.
+
+use {widget, color, Color, Point, Positionable, Scalar, Sizeable, Widget, Ui};
+use graph;
+use position::{Axis, Direction, Range, Rect};
+use std::iter::once;
+use std::ops::{Deref, DerefMut};
+
+/// A widget that acts as a convenience container for some `Node`'s unique widgets.
+#[derive(Clone, Debug, WidgetCommon_)]
+pub struct Node<W> {
+    /// Data necessary and common for all widget builder types.
+    #[conrod(common_builder)]
+    pub common: widget::CommonBuilder,
+    /// Unique styling for the **Node**.
+    pub style: Style,
+    /// The widget wrapped by this node container.
+    pub widget: W,
+    /// The number of input sockets on the node.
+    pub inputs: usize,
+    /// The number of output sockets on the node.
+    pub outputs: usize,
+}
+
+#[allow(missing_docs)]
+pub const DEFAULT_BORDER_THICKNESS: Scalar = 6.0;
+#[allow(missing_docs)]
+pub const DEFAULT_SOCKET_LENGTH: Scalar = DEFAULT_BORDER_THICKNESS;
+
+/// Unique styling for the **BorderedRectangle** widget.
+#[derive(Copy, Clone, Debug, Default, PartialEq, WidgetStyle_)]
+pub struct Style {
+    /// Shape color for the inner rectangle.
+    #[conrod(default = "color::TRANSPARENT")]
+    pub color: Option<Color>,
+    /// The length of each rectangle along its `SocketSide`.
+    #[conrod(default = "6.0")]
+    pub socket_length: Option<Scalar>,
+    /// The widget of the border around the widget.
+    ///
+    /// this should always be a positive value in order for sockets to remain visible.
+    #[conrod(default = "6.0")]
+    pub border: Option<Scalar>,
+    /// The radius of the rounded corners of the border.
+    ///
+    /// This value will be clamped to the `border` thickness.
+    ///
+    /// A value of `0.0` gives square corners.
+    #[conrod(default = "6.0")]
+    pub border_radius: Option<Scalar>,
+    /// Color of the border.
+    #[conrod(default = "color::DARK_CHARCOAL")]
+    pub border_color: Option<Color>,
+    /// Color of the sockets.
+    #[conrod(default = "color::DARK_GREY")]
+    pub socket_color: Option<Color>,
+    /// Default layout for input sockets.
+    #[conrod(default = "SocketLayout { side: SocketSide::Left, direction: Direction::Backwards }")]
+    pub input_socket_layout: Option<SocketLayout>,
+    /// Default layout for node output sockets.
+    #[conrod(default = "SocketLayout { side: SocketSide::Right, direction: Direction::Backwards }")]
+    pub output_socket_layout: Option<SocketLayout>,
+}
+
+/// Describes the layout of either input or output sockets.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SocketLayout {
+    /// Represents the side of a node widget's bounding rectangle.
+    pub side: SocketSide,
+    /// The direction in which sockets will be laid out over the side.
+    pub direction: Direction,
+}
+
+/// Represents the side of a node widget's bounding rectangle.
+///
+/// This is used to describe default node socket layout.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+pub enum SocketSide {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
+widget_ids! {
+    struct Ids {
+        // Use triangles to describe graphics for the entire widget.
+        //
+        // The `Node` widget will be used a lot, so the less `widget::Id`s required the better.
+        //
+        // Triangulation order is as follows:
+        //
+        // 1. Inner rectangle surface (two triangles).
+        // 2. Border (eight triangles).
+        // 3. Sockets (two triangles per socket).
+        triangles,
+        // The unique identifier for the wrapped widget.
+        widget,
+    }
+}
+
+/// Unique state for the `Node`.
+pub struct State {
+    ids: Ids,
+    // Tracks whether or not a socket is currently captured under the mouse.
+    capturing_socket: Option<(SocketType, usize)>,
+    // The number of input sockets.
+    inputs: usize,
+    // The number of output sockets.
+    outputs: usize,
+}
+
+/// Describes whether a socket is associated with a node's inputs or outputs.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+pub enum SocketType { Input, Output }
+
+/// The event produced by the `Node` widget.
+#[derive(Clone, Debug)]
+pub struct Event<W> {
+    /// The event produced by the inner widget `W`.
+    pub widget_event: W,
+}
+
+impl<W> Node<W> {
+    /// Begin building a new `Node` widget.
+    pub fn new(widget: W) -> Self {
+        Node {
+            common: widget::CommonBuilder::default(),
+            style: Style::default(),
+            widget,
+            inputs: 0,
+            outputs: 0,
+        }
+    }
+
+    /// Specify the number of input sockets for the node.
+    pub fn inputs(mut self, inputs: usize) -> Self {
+        self.inputs = inputs;
+        self
+    }
+
+    /// Specify the number of output sockets for the node.
+    pub fn outputs(mut self, outputs: usize) -> Self {
+        self.outputs = outputs;
+        self
+    }
+
+    /// Specify the color for the node's inner rectangle.
+    pub fn color(mut self, color: Color) -> Self {
+        self.style.color = Some(color);
+        self
+    }
+
+    /// The thickness of the border around the inner widget.
+    ///
+    /// This must always be a positive value in order for sockets to remain visible.
+    pub fn border_thickness(mut self, thickness: Scalar) -> Self {
+        assert!(thickness > 0.0);
+        self.style.border = Some(thickness);
+        self
+    }
+
+    /// Specify the color for the node's border.
+    pub fn border_color(mut self, color: Color) -> Self {
+        self.style.border_color = Some(color);
+        self
+    }
+
+    /// Specify the radius for the node's border.
+    pub fn border_radius(mut self, radius: Scalar) -> Self {
+        self.style.border_radius = Some(radius);
+        self
+    }
+
+    /// Specify the color for the node's sockets.
+    pub fn socket_color(mut self, color: Color) -> Self {
+        self.style.socket_color = Some(color);
+        self
+    }
+
+    /// Specify the layout of the input sockets.
+    pub fn input_socket_layout(mut self, layout: SocketLayout) -> Self {
+        self.style.input_socket_layout = Some(layout);
+        self
+    }
+
+    /// Specify the layout of the input sockets.
+    pub fn output_socket_layout(mut self, layout: SocketLayout) -> Self {
+        self.style.output_socket_layout = Some(layout);
+        self
+    }
+}
+
+impl<W> Deref for Event<W> {
+    type Target = W;
+    fn deref(&self) -> &Self::Target {
+        &self.widget_event
+    }
+}
+
+impl<W> DerefMut for Event<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.widget_event
+    }
+}
+
+
+// A multiplier for the scalar direction.
+fn direction_scalar(direction: Direction) -> Scalar {
+    match direction {
+        Direction::Forwards => 1.0,
+        Direction::Backwards => -1.0,
+    }
+}
+
+// Axis from a given side and the scalar offset from the centre of the rect.
+fn side_axis_and_scalar(rect: Rect, side: SocketSide, border: Scalar) -> (Axis, Scalar) {
+    match side {
+        SocketSide::Left => (Axis::Y, rect.left() + border / 2.0),
+        SocketSide::Right => (Axis::Y, rect.right() - border / 2.0),
+        SocketSide::Bottom => (Axis::X, rect.bottom() + border / 2.0),
+        SocketSide::Top => (Axis::X, rect.top() - border / 2.0),
+    }
+}
+
+// The position of the socket at the given index.
+fn socket_position(index: usize, start_pos: Point, step: [Scalar; 2]) -> Point {
+    let x = start_pos[0] + step[0] * index as Scalar;
+    let y = start_pos[1] + step[1] * index as Scalar;
+    [x, y]
+}
+
+// Dimensions for a socket rectangle given some axis.
+fn socket_rect_dim(axis: Axis, border: Scalar, socket_length: Scalar) -> [Scalar; 2] {
+    match axis {
+        Axis::Y => [border, socket_length],
+        Axis::X => [socket_length, border],
+    }
+}
+
+// Returns the range along the rect for the given axis.
+fn rect_range(axis: Axis, rect: Rect) -> Range {
+    match axis {
+        Axis::X => rect.x,
+        Axis::Y => rect.y,
+    }
+}
+
+// The gap between each socket and the position of the first socket.
+fn socket_step_and_start(
+    n_sockets: usize,
+    axis: Axis,
+    direction: Direction,
+    inner_rect: Rect,
+    socket_length: Scalar,
+    side_scalar: Scalar,
+) -> ([Scalar; 2], Point)
+{
+    let direction_scalar = direction_scalar(direction);
+    let socket_range = rect_range(axis, inner_rect);
+    let socket_position_range = socket_range.pad(socket_length / 2.0);
+    let socket_start_scalar = match direction {
+        Direction::Forwards => socket_position_range.start,
+        Direction::Backwards => socket_position_range.end,
+    };
+    let step = if n_sockets > 1 {
+        socket_position_range.len() * direction_scalar / (n_sockets - 1) as Scalar
+    } else {
+        0.0
+    };
+    let (step, socket_start_position) = match axis {
+        Axis::X => {
+            let step = [step, 0.0];
+            let x = socket_start_scalar;
+            let y = side_scalar;
+            (step, [x, y])
+        },
+        Axis::Y => {
+            let step = [0.0, step];
+            let x = side_scalar;
+            let y = socket_start_scalar;
+            (step, [x, y])
+        },
+    };
+    (step, socket_start_position)
+}
+
+// Produce the `Rect` for a socket from the raw params required.
+fn socket_rectangle(
+    index: usize,
+    n_sockets: usize,
+    node_rect: Rect,
+    border: Scalar,
+    layout: SocketLayout,
+    socket_length: Scalar,
+) -> Rect {
+    let SocketLayout { side, direction } = layout;
+    let (axis, side_scalar) = side_axis_and_scalar(node_rect, side, border);
+    let inner_rect = node_rect.pad(border);
+    let (step, start_pos) = socket_step_and_start(n_sockets, axis, direction, inner_rect,
+                                                  socket_length, side_scalar);
+    let xy = socket_position(index, start_pos, step);
+    let socket_dim = socket_rect_dim(axis, border, socket_length);
+    let rect = Rect::from_xy_dim(xy, socket_dim);
+    rect
+}
+
+
+/// Retrieve the `Rect` for the given socket on the given node.
+///
+/// Returns `None` if there is no node for the given `Id` or if the `socket_index` is out of range.
+pub fn socket_rect(
+    node_id: widget::Id,
+    socket_type: SocketType,
+    socket_index: usize,
+    ui: &Ui,
+) -> Option<Rect> {
+    ui.widget_graph()
+        .widget(node_id)
+        .and_then(|container| {
+            let unique = container.state_and_style::<State, Style>();
+            let &graph::UniqueWidgetState { ref state, ref style } = match unique {
+                None => return None,
+                Some(unique) => unique,
+            };
+            let rect = container.rect;
+            let border = style.border(&ui.theme);
+            let socket_length = style.socket_length(&ui.theme);
+
+            let (n_sockets, layout) = match socket_type {
+                SocketType::Input => (state.inputs, style.input_socket_layout(&ui.theme)),
+                SocketType::Output => (state.outputs, style.output_socket_layout(&ui.theme)),
+            };
+
+            let rect = socket_rectangle(socket_index, n_sockets, rect, border, layout,
+                                        socket_length);
+            Some(rect)
+        })
+}
+
+/// Returns a `Rect` for an edge's start and end nodes.
+pub fn edge_socket_rects<NI>(edge: &super::Edge<NI>, ui: &Ui) -> (Rect, Rect)
+where
+    NI: super::NodeId,
+{
+    let (start_id, end_id) = super::edge_node_widget_ids(edge, ui);
+    let start = edge.start();
+    let end = edge.end();
+    let start_rect = socket_rect(start_id, SocketType::Output, start.socket_index, ui)
+        .expect("no node widget found for the edge's `start_id`");
+    let end_rect = socket_rect(end_id, SocketType::Input, end.socket_index, ui)
+        .expect("no node widget found for the edge's `end_id`");
+    (start_rect, end_rect)
+}
+
+/// Produces an iterator yielding a `Rect` for each socket for both inputs and outputs
+/// respectively.
+///
+/// Returns `None` if no node is found for the given `widget::Id`.
+pub fn socket_rects(node_id: widget::Id, ui: &Ui) -> Option<(SocketRects, SocketRects)> {
+    ui.widget_graph()
+        .widget(node_id)
+        .and_then(|container| {
+            let unique = container.state_and_style::<State, Style>();
+            let &graph::UniqueWidgetState { ref state, ref style } = match unique {
+                None => return None,
+                Some(unique) => unique,
+            };
+            let rect = container.rect;
+            let border = style.border(&ui.theme);
+            let socket_length = style.socket_length(&ui.theme);
+            let input_socket_rects = SocketRects {
+                index: 0,
+                n_sockets: state.inputs,
+                node_rect: rect,
+                border,
+                layout: style.input_socket_layout(&ui.theme),
+                socket_length,
+            };
+            let output_socket_rects = SocketRects {
+                index: 0,
+                n_sockets: state.outputs,
+                node_rect: rect,
+                border,
+                layout: style.output_socket_layout(&ui.theme),
+                socket_length,
+            };
+            Some((input_socket_rects, output_socket_rects))
+        })
+}
+
+/// The rectangle for each socket (either inputs or outputs only).
+#[derive(Clone)]
+#[allow(missing_copy_implementations)]
+pub struct SocketRects {
+    // Current socket index.
+    index: usize,
+    // Total number of sockets.
+    n_sockets: usize,
+    node_rect: Rect,
+    border: Scalar,
+    layout: SocketLayout,
+    // The length of the socket rectangle along the axis along which it is placed.
+    socket_length: Scalar,
+}
+
+impl Iterator for SocketRects {
+    type Item = Rect;
+    fn next(&mut self) -> Option<Self::Item> {
+        let SocketRects {
+            ref mut index,
+            n_sockets,
+            node_rect,
+            border,
+            layout,
+            socket_length,
+        } = *self;
+
+        // If the index is equal to or greater than the number of sockets, we're done.
+        if *index >= n_sockets {
+            return None;
+        }
+
+        let rect = socket_rectangle(*index, n_sockets, node_rect, border, layout, socket_length);
+        *index += 1;
+        Some(rect)
+    }
+}
+
+impl<W> Widget for Node<W>
+where
+    W: Widget,
+{
+    type State = State;
+    type Style = Style;
+    type Event = Event<W::Event>;
+
+    fn init_state(&self, id_gen: widget::id::Generator) -> Self::State {
+        State {
+            ids: Ids::new(id_gen),
+            capturing_socket: None,
+            inputs: self.inputs,
+            outputs: self.outputs,
+        }
+    }
+
+    fn style(&self) -> Self::Style {
+        self.style.clone()
+    }
+
+    fn update(self, args: widget::UpdateArgs<Self>) -> Self::Event {
+        let widget::UpdateArgs { id, state, style, rect, ui, .. } = args;
+        let Node { widget, inputs, outputs, .. } = self;
+        let socket_length = style.socket_length(&ui.theme);
+        let border = style.border(&ui.theme);
+
+        if state.inputs != inputs {
+            state.update(|state| state.inputs = inputs);
+        }
+
+        if state.outputs != outputs {
+            state.update(|state| state.outputs = outputs);
+        }
+
+        let input_socket_layout = style.input_socket_layout(&ui.theme);
+        let output_socket_layout = style.output_socket_layout(&ui.theme);
+
+        // A function for producing the rectangles of sockets along some axis.
+        let socket_rectangles = |n_sockets, layout| {
+            SocketRects {
+                index: 0,
+                n_sockets,
+                layout,
+                node_rect: rect,
+                border,
+                socket_length,
+            }
+        };
+
+        // Whether or not the given point is over a socket.
+        let over_socket = |abs_point: Point| -> Option<(SocketType, usize)> {
+            for (i, rect) in socket_rectangles(inputs, input_socket_layout).enumerate() {
+                if rect.is_over(abs_point) {
+                    return Some((SocketType::Input, i));
+                }
+            }
+            for (i, rect) in socket_rectangles(outputs, output_socket_layout).enumerate() {
+                if rect.is_over(abs_point) {
+                    return Some((SocketType::Output, i));
+                }
+            }
+            None
+        };
+
+        #[derive(Copy, Clone)]
+        enum Interaction { Hover, Press }
+        let maybe_socket_interaction = ui.widget_input(id)
+            .mouse()
+            .and_then(|m| match m.buttons.left().is_down() {
+                // If the mouse isn't down, we must be hovering over the widget.
+                false => over_socket(m.abs_xy()).map(|(ty, ix)| (ty, ix, Interaction::Hover)),
+                // Otherwise we're currently pressing some part of the widget.
+                true => {
+                    // If the left mouse button was just pressed, check to see if over a socket.
+                    if ui.widget_input(id).presses().mouse().left().next().is_some() {
+                        let maybe_socket = over_socket(m.abs_xy());
+                        if maybe_socket.is_some() {
+                            state.update(|state| state.capturing_socket = maybe_socket);
+                        }
+                    }
+                    // If some socket is captured by the mouse, it's pressed.
+                    state.capturing_socket.map(|(ty, ix)| (ty, ix, Interaction::Press))
+                },
+            });
+
+        // The triangles for the inner rectangle surface first.
+        let inner_rect = rect.pad(border);
+        let (inner_tri_a, inner_tri_b) = widget::primitive::shape::rectangle::triangles(inner_rect);
+        let inner_color = style.color(&ui.theme).into();
+        let inner_triangles = once(inner_tri_a)
+            .chain(once(inner_tri_b))
+            .map(|tri| tri.color_all(inner_color));
+
+        // Triangles for the border.
+        //
+        // Color the border based on interaction.
+        let border_color = style.border_color(&ui.theme);
+        let border_color = match maybe_socket_interaction.is_some() {
+            true => border_color,
+            false => {
+                ui.widget_input(id)
+                    .mouse()
+                    .map(|m| match inner_rect.is_over(m.abs_xy()) {
+                        true => border_color,
+                        false => match m.buttons.left().is_down() {
+                            true => border_color.clicked(),
+                            false => border_color.highlighted(),
+                        },
+                    })
+                    .unwrap_or(border_color)
+            },
+        };
+
+        let border_radius = style.border_radius(&ui.theme).min(border);
+        let border_triangles = widget::bordered_rectangle::rounded_border_triangles(
+            rect,
+            border,
+            border_radius,
+            widget::oval::DEFAULT_RESOLUTION,
+        );
+        let border_rgba = border_color.into();
+        let border_triangles = border_triangles.map(|tri| tri.color_all(border_rgba));
+
+        // A function for producing the triangles for sockets along some axis.
+        let socket_color = style.socket_color(&ui.theme);
+        let socket_triangles = |socket_type, n_sockets, layout| {
+            socket_rectangles(n_sockets, layout)
+                .enumerate()
+                .flat_map(move |(i, rect)| {
+                    let (tri_a, tri_b) = widget::primitive::shape::rectangle::triangles(rect);
+                    let color = match maybe_socket_interaction {
+                        Some((ty, ix, action)) if ty == socket_type && ix == i => match action {
+                            Interaction::Hover => socket_color.highlighted(),
+                            Interaction::Press => socket_color.clicked(),
+                        },
+                        _ => socket_color,
+                    };
+                    let rgba = color.into();
+                    let a = tri_a.color_all(rgba);
+                    let b = tri_b.color_all(rgba);
+                    once(a).chain(once(b))
+                })
+        };
+
+        // Triangles for sockets.
+        let input_socket_triangles = socket_triangles(SocketType::Input, inputs, input_socket_layout);
+        let output_socket_triangles = socket_triangles(SocketType::Output, outputs, output_socket_layout);
+
+        // Submit the triangles for the graphical elements of the widget.
+        let triangles = inner_triangles
+            .chain(border_triangles)
+            .chain(input_socket_triangles)
+            .chain(output_socket_triangles);
+        widget::Triangles::multi_color(triangles)
+            .with_bounding_rect(rect)
+            .graphics_for(id)
+            .parent(id)
+            .set(state.ids.triangles, ui);
+
+        // Instantiate the widget.
+        let widget_event = widget
+            .wh(inner_rect.dim())
+            .xy(inner_rect.xy())
+            .parent(id)
+            .set(state.ids.widget, ui);
+
+        Event { widget_event }
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -3,7 +3,7 @@
 //! This module contains items related to the implementation of the `Widget` trait. It also
 //! re-exports all widgets (and their modules) that are provided by conrod.
 
-use graph;
+use graph::{Container, UniqueWidgetState};
 use position::{Align, Depth, Dimension, Dimensions, Padding, Position, Point,
                Positionable, Rect, Relative, Sizeable};
 use std;
@@ -29,12 +29,13 @@ pub use self::button::Button;
 pub use self::canvas::Canvas;
 pub use self::collapsible_area::CollapsibleArea;
 pub use self::drop_down_list::DropDownList;
-pub use self::list_select::ListSelect;
 pub use self::envelope_editor::EnvelopeEditor;
 pub use self::file_navigator::FileNavigator;
 pub use self::grid::Grid;
 pub use self::list::List;
+pub use self::list_select::ListSelect;
 pub use self::matrix::Matrix;
+pub use self::graph::Graph;
 pub use self::number_dialer::NumberDialer;
 pub use self::plot_path::PlotPath;
 pub use self::range_slider::RangeSlider;
@@ -72,6 +73,7 @@ pub mod grid;
 pub mod list;
 pub mod list_select;
 pub mod matrix;
+pub mod graph;
 pub mod number_dialer;
 pub mod plot_path;
 pub mod range_slider;
@@ -370,10 +372,10 @@ impl From<Id> for IsOver {
 }
 
 /// A function type used to determine whether or not a given point is over a widget.
-pub type IsOverFn = fn(&graph::Container, Point, &Theme) -> IsOver;
+pub type IsOverFn = fn(&Container, Point, &Theme) -> IsOver;
 
 /// The default `IsOverFn` used if the `Widget::is_over` method is not overridden.
-pub fn is_over_rect(container: &graph::Container, point: Point, _: &Theme) -> IsOver {
+pub fn is_over_rect(container: &Container, point: Point, _: &Theme) -> IsOver {
     container.rect.is_over(point).into()
 }
 
@@ -901,7 +903,7 @@ fn set_widget<'a, 'b, W>(widget: W, id: Id, ui: &'a mut UiCell<'b>) -> W::Event
                 }
 
                 // Destructure the cached state.
-                let graph::Container {
+                let Container {
                     ref mut maybe_state,
                     rect,
                     depth,
@@ -914,8 +916,8 @@ fn set_widget<'a, 'b, W>(widget: W, id: Id, ui: &'a mut UiCell<'b>) -> W::Event
 
                 let (state, style) = match maybe_state.take().and_then(|a| a.downcast().ok()) {
                     Some(boxed) => {
-                        let unique: graph::UniqueWidgetState<W::State, W::Style> = *boxed;
-                        let graph::UniqueWidgetState { state, style } = unique;
+                        let unique: UniqueWidgetState<W::State, W::Style> = *boxed;
+                        let UniqueWidgetState { state, style } = unique;
                         (state, style)
                     },
                     None => return None,


### PR DESCRIPTION
See #1098 for details.

TODO:

- Add edge add/remove events (see `enum EdgeEvent`).
- Add bezier curve widgets and use them as nicer edges.
- Improve drag behaviour (see #1088).
- Add ability to passthrough "drag-ability".
- Improve example to demonstrate different widgets for each node.
- Add click-and-drag camera movement.

Closes #1098.

A pic of the example in its current state:

![screenshot from 2017-12-09 14-10-07](https://user-images.githubusercontent.com/4587373/33792302-a7025ac8-dcef-11e7-8d7e-4cfe2db1f822.png)
