### PR TITLE
Update to glium 0.19, winit 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ rusttype = "0.2.0"
 # - Converting piston `GenericEvent` types to `conrod::event::Raw`s.
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston` module.
-glium = { version = "0.18.0", optional = true }
-winit = { version = "0.8.3", optional = true }
+glium = { version = "0.19", optional = true }
+winit = { version = "0.9", optional = true }
 piston2d-graphics = { version = "0.23.0", optional = true }
 gfx = { version = "0.16.1", optional = true }
 gfx_core = { version = "0.7.0", optional = true }
@@ -60,7 +60,7 @@ find_folder = "0.3.0"
 image = "0.17.0"
 rand = "0.3.13"
 # glutin_gfx.rs example dependencies
-gfx_window_glutin = "0.18.0"
-glutin = "0.10.0"
+gfx_window_glutin = "0.19.0"
+glutin = "0.11.0"
 # piston_window.rs example dependencies
 piston_window = "0.73.0"

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -124,7 +124,7 @@ pub fn convert_window_event<W>(e: winit::WindowEvent, window: &W) -> Option<Inpu
             Some(Input::Touch(touch).into())
         }
 
-        winit::WindowEvent::MouseMoved { position: (x, y), .. } => {
+        winit::WindowEvent::CursorMoved { position: (x, y), .. } => {
             let x = tx(x as Scalar);
             let y = ty(y as Scalar);
             let motion = input::Motion::MouseCursor { x: x, y: y };


### PR DESCRIPTION
This fixes the `Graph` widget PR #1104 which has some issues with the
nightly compiler in release mode. Also picks up a bunch of new winit
updates (see their changelog).