### PR TITLE
Update to rusttype 0.3. Publish version 0.57.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.56.0"
+version = "0.57.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -24,7 +24,7 @@ daggy = "0.5.0"
 fnv = "1.0"
 num = "0.1.30"
 pistoncore-input = "0.20.0"
-rusttype = "0.2.0"
+rusttype = "0.3.0"
 
 # Optional dependencies and features
 # ----------------------------------

--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -39,7 +39,7 @@ enum PreparedCommand {
 
 /// A rusttype `GlyphCache` along with a `glium::texture::Texture2d` for caching text on the `GPU`.
 pub struct GlyphCache {
-    cache: text::GlyphCache,
+    cache: text::GlyphCache<'static>,
     texture: glium::texture::Texture2d,
 }
 


### PR DESCRIPTION
Breaking changes include:

- Update to rusttype 0.3.
- Update to glium 0.19, winit 0.9 #1107.
- Add new `Widget::is_over` method for more precise picking #1101.

Other changes include:

- Add `Graph` widget (WIP) #1104.
- Add `Oval` subsections and more point/triangle iterators #1100.