### PR TITLE
add lifetime to GlyphCache / Renderer

### DIFF
--- a/src/backend/gfx.rs
+++ b/src/backend/gfx.rs
@@ -146,9 +146,9 @@ impl Vertex {
     }
 }
 
-pub struct Renderer<R: Resources>{
+pub struct Renderer<'font, R: Resources>{
     pipeline: PipelineState<R, pipe::Meta>,
-    glyph_cache: GlyphCache,
+    glyph_cache: GlyphCache<'font>,
     cache_tex: gfx::handle::Texture<R, SurfaceFormat>,
     cache_tex_view: gfx::handle::ShaderResourceView<R, [f32; 4]>,
     blank_texture: gfx::handle::ShaderResourceView<R, [f32; 4]>,
@@ -158,7 +158,7 @@ pub struct Renderer<R: Resources>{
     vertices: Vec<Vertex>,
 }
 
-impl<R: Resources> Renderer<R>{
+impl<'font, R: Resources> Renderer<'font, R>{
     pub fn new<F: Factory<R>>(factory: &mut F, rtv: &RenderTargetView<R, ColorFormat>, dpi_factor: f64) -> Result<Self,RendererCreationError>
     {
         let sampler_info = texture::SamplerInfo::new(


### PR DESCRIPTION
While trying to get `glium` fixed in, it was [noted](https://github.com/PistonDevelopers/conrod/pull/1123#issuecomment-359444069) that the gfx backend was broken. The gfx backend is /additionally/ broken by changes to `rusttype`, which have apparently been missed by CI.

This is the minimal change to get the code to compile. It doesn't seem harmful. I didn't think it through at all.