### PR TITLE
Build documentation with features enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
     - cargo test --features "piston" --verbose
     - cargo test --features "gfx_rs" --verbose
     - cargo test --all-features --verbose
-    - cargo doc --verbose
+    - cargo doc --all-features --verbose
 
 after_success:
     - curl http://docs.piston.rs/travis-doc-upload.sh | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ homepage = "https://github.com/pistondevelopers/conrod"
 documentation = "http://docs.piston.rs/conrod/conrod/"
 categories = ["gui"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 name = "conrod"
 path = "./src/lib.rs"


### PR DESCRIPTION
This updates both docs.rs and docs.piston.rs metadata to build documentation with backend features enabled.

I believe this is an all-around win, since it allows people to easily see documentation on conrod's backend types without having to build documentation locally.