### PR TITLE
Update for rusttype breaking change (missing `gpu_cache` module error)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ daggy = "0.5.0"
 fnv = "1.0"
 num = "0.1.30"
 pistoncore-input = "0.20.0"
-rusttype = "0.3.0"
+rusttype = { version = "0.3.1", features = ["gpu_cache"] }
 
 # Optional dependencies and features
 # ----------------------------------


### PR DESCRIPTION
Don't merge yet, currently waiting on the verdict at for redox-os/rusttype#81.