### PR TITLE
Update to latest rusttype. Publish 0.58 for recent dependency updates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.57.0"
+version = "0.58.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -27,7 +27,7 @@ daggy = "0.5.0"
 fnv = "1.0"
 num = "0.1.30"
 pistoncore-input = "0.20.0"
-rusttype = "0.3.0"
+rusttype = { version = "0.4.0", features = ["gpu_cache"] }
 
 # Optional dependencies and features
 # ----------------------------------


### PR DESCRIPTION
Other than some dependency updates, this also includes some doc fixes.