### PR TITLE
[WIP] Return events from TextEdit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ fnv = "1.0"
 num = "0.1.30"
 pistoncore-input = "0.20.0"
 rusttype = { version = "0.4.0", features = ["gpu_cache"] }
+smallstring = "0.1"
+void = "1"
 
 # Optional dependencies and features
 # ----------------------------------

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -124,7 +124,7 @@ mod feature {
             .restrict_to_height(false) // Let the height grow infinitely and scroll.
             .set(ids.text_edit, ui)
         {
-            *demo_text = edit;
+            edit.apply(demo_text);
         }
 
         widget::Scrollbar::y_axis(ids.canvas).auto_hide(true).set(ids.scrollbar, ui);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ extern crate fnv;
 extern crate num;
 extern crate input as piston_input;
 extern crate rusttype;
+extern crate smallstring;
+extern crate void;
 
 #[cfg(feature="glium")] #[macro_use] pub extern crate glium;
 #[cfg(feature="gfx_rs")] #[macro_use] pub extern crate gfx;


### PR DESCRIPTION
This is still largely incomplete, inefficient, will break when used with certain configurable event transformers and has bugs with line_infos.

Still, it runs! The code demonstrates at least part of the design, and does compile.

Progress so far: I have added TextEvent, changed TextEdit to give Vec<TextEvent>, and modified things enough to compile.

Things left to do:
- [ ] handle possible insertions during the deletion path, and deletions during the insertion path. `event_transform` can turn any event into any other event, so this will be necessary
  - we'll likely just want an "apply_event" function or closure to do this
- [ ] In general, rework code which could be made cleaner under the event design
- [ ] migrate TextBox to return events as well. It currently functions, though, so this could be done in a future PR
- [ ] add support for "side-extending" text boxes. I've got no current idea how to do this, but I'd like to be able to support username/password input boxes which allow the user to type a lot of text, and just scroll to the side when they do this. Might be a future PR.

Besides pure programming, there are a few things I'm not sure what to decide on:
- [ ] decide on whether to use `smallstring::SmallString`, `String`, or `char` for events. We're usually just typing one character at a time, but we might type more. I chose `SmallString` initially as a compromise, but we might want to do something different.
- [ ] decide on if support for "passing through events" from event transformers is a good idea
- [ ] decide on if event transformers themselves are a reasonable idea.
  
  I chose to add them because I wanted to uphold "multiple keypress/typing/clicking events should function the same whether they're in the same conrod 'frame' or not". If a TextEdit wrapper was choosing to disallow numbers, the "event transform" allows TextEdit to know the wrapper has done this when it's processing the next bit of input.