### PR TITLE
Publish 0.59.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.58.0"
+version = "0.59.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"


### PR DESCRIPTION
Changes include:

- ListSelect now supports tap events from touch devices. #1160.
- Fixes multiple bugs in range_slider. #1162 #1156
- The glium backend glyph cache size can now be configured. #1157.

Breaking changes include:

- winit version 0.12 update
- glium version 0.21 update
- rusttype 0.5 update