### PR TITLE
Remove unnecessary `mut` from `self` binding in `Ui::draw_if_changed`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.59.0"
+version = "0.59.1"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1132,7 +1132,7 @@ impl Ui {
     /// This ensures that conrod is drawn to each buffer in the case that there is buffer swapping
     /// happening. Let us know if you need finer control over this and we'll expose a way for you
     /// to set the redraw count manually.
-    pub fn draw_if_changed(&mut self) -> Option<render::Primitives> {
+    pub fn draw_if_changed(&self) -> Option<render::Primitives> {
         if self.redraw_count.load(atomic::Ordering::Relaxed) > 0 {
             return Some(self.draw())
         }


### PR DESCRIPTION
This `mut` is left over from the past when the `redraw_count` field
lacked inner mutability.

This new API is strictly more flexible as the user no longer requires a
mutable reference to the `Ui` in order to call `draw_if_changed`.

This change will be published as 0.59.1.