### PR TITLE
Bump `syn` to 0.14, `quote` to 0.6

### DIFF
--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -12,5 +12,6 @@ homepage = "https://github.com/pistondevelopers/conrod"
 proc-macro = true
 
 [dependencies]
-quote = "0.5"
-syn = { version = "0.13", features = ["extra-traits", "full"] }
+proc-macro2 = "0.4.2"
+quote = "0.6"
+syn = { version = "0.14", features = ["extra-traits", "full"] }

--- a/conrod_derive/src/lib.rs
+++ b/conrod_derive/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate proc_macro;
-extern crate syn;
+
+extern crate proc_macro2;
 #[macro_use] extern crate quote;
+extern crate syn;
 
 mod common;
 mod style;
@@ -41,7 +43,7 @@ pub fn widget_style_(input: TokenStream) -> TokenStream {
 // Use the given function to generate a TokenStream for the derive implementation.
 fn impl_derive(
     input: TokenStream,
-    generate_derive: fn(&syn::DeriveInput) -> quote::Tokens,
+    generate_derive: fn(&syn::DeriveInput) -> proc_macro2::TokenStream,
 ) -> TokenStream
 {
     // Parse the input TokenStream representation.

--- a/conrod_derive/src/style.rs
+++ b/conrod_derive/src/style.rs
@@ -1,13 +1,13 @@
-use quote;
 use std;
+
+use proc_macro2;
 use syn;
 use utils;
-use syn::Expr;
 // The implementation for `WidgetStyle`.
 //
 // This generates an accessor method for every field in the struct
-pub fn impl_widget_style(ast: &syn::DeriveInput) -> quote::Tokens {
-    let crate_tokens = Some(syn::Ident::from("_conrod"));
+pub fn impl_widget_style(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    let crate_tokens = Some(syn::Ident::new("_conrod", proc_macro2::Span::call_site()));
     let params = params(ast).unwrap();
     let impl_tokens = impl_tokens(&params, crate_tokens);
     let dummy_const = &params.dummy_const;
@@ -23,7 +23,7 @@ pub fn impl_widget_style(ast: &syn::DeriveInput) -> quote::Tokens {
 // The implementation for `WidgetStyle_`.
 //
 // The same as `WidgetStyle` but only for use within the conrod crate itself.
-pub fn impl_widget_style_(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn impl_widget_style_(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
    // let crate_tokens = syn::Ident::from(syn::token::CapSelf::default());
     let crate_tokens= None;
     let params = params(ast).unwrap();
@@ -37,7 +37,7 @@ pub fn impl_widget_style_(ast: &syn::DeriveInput) -> quote::Tokens {
     }
 }
 
-fn impl_tokens(params: &Params, crate_tokens: Option<syn::Ident>) -> quote::Tokens {
+fn impl_tokens(params: &Params, crate_tokens: Option<syn::Ident>) -> proc_macro2::TokenStream {
     let Params {
         ref impl_generics,
         ref ty_generics,
@@ -79,19 +79,19 @@ fn impl_tokens(params: &Params, crate_tokens: Option<syn::Ident>) -> quote::Toke
 
 #[derive(Debug)]
 struct Params {
-    impl_generics: quote::Tokens,
-    ty_generics: quote::Tokens,
-    where_clause: quote::Tokens,
-    ident: quote::Tokens,
+    impl_generics: proc_macro2::TokenStream,
+    ty_generics: proc_macro2::TokenStream,
+    where_clause: proc_macro2::TokenStream,
+    ident: proc_macro2::TokenStream,
     fields: Vec<FieldParams>,
-    dummy_const: quote::Tokens,
+    dummy_const: proc_macro2::TokenStream,
 }
 
 #[derive(Debug)]
 struct FieldParams {
-    default: quote::Tokens,
-    ty: quote::Tokens,
-    ident: quote::Tokens,
+    default: proc_macro2::TokenStream,
+    ty: proc_macro2::TokenStream,
+    ident: proc_macro2::TokenStream,
 }
 
 fn params(ast: &syn::DeriveInput) -> Result<Params, Error> {
@@ -138,7 +138,7 @@ fn params(ast: &syn::DeriveInput) -> Result<Params, Error> {
                 ref item => return Some(Err(Error::UnexpectedMetaItem(item.clone()))),
             };
 
-            let default:Expr = match *literal {
+            let default: syn::Expr = match *literal {
                 syn::Lit::Str(ref litstr) => litstr.clone().parse().unwrap(),
                 ref literal => return Some(Err(Error::UnexpectedLiteral(literal.clone()))),
             };
@@ -186,7 +186,7 @@ fn params(ast: &syn::DeriveInput) -> Result<Params, Error> {
         })
         .collect::<Result<_, _>>()?;
 
-    let dummy_const = syn::Ident::from(format!("_IMPL_WIDGET_STYLE_FOR_{}", ast.ident));
+    let dummy_const = syn::Ident::new(&format!("_IMPL_WIDGET_STYLE_FOR_{}", ast.ident), proc_macro2::Span::call_site());
     let ident = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 

--- a/conrod_derive/src/utils.rs
+++ b/conrod_derive/src/utils.rs
@@ -19,7 +19,7 @@ impl<'a, I> Iterator for ConrodAttrs<I>
         while let Some(attr) = self.attrs.next() {
             if let Some(_meta) = attr.interpret_meta() {
                 if let &syn::Meta::List(ref _metalist) = &_meta{
-                    if _metalist.ident == syn::Ident::from("conrod"){
+                    if _metalist.ident == "conrod" {
                         let j = _metalist.nested.clone().into_pairs().map(|pair|pair.into_value()).collect::<Vec<syn::NestedMeta>>();
                         return Some(j);
                     }


### PR DESCRIPTION
Also adds `proc-macro2` dependency because `quote::Tokens` has been replaced by `proc-macro2::TokenStream`. The `^0.4.2` version requirement is because this library uses the `Ident` == `AsRef<str>` implementation.