### PR TITLE
Update deps: winit 0.16, glutin 0.17, glium 0.22. Publish 0.61.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod"
-version = "0.60.0"
+version = "0.61.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -48,8 +48,8 @@ rusttype = { version = "0.5.0", features = ["gpu_cache"] }
 # - Converting piston `GenericEvent` types to `conrod::event::Raw`s.
 # - Rendering the `conrod::render::Primitives` yielded by `Ui::draw`.
 # Enables the `conrod::backend::piston` module.
-winit = { version = "0.12", optional = true }
-glium = { version = "0.21", optional = true }
+winit = { version = "0.16", optional = true }
+glium = { version = "0.22", optional = true }
 piston2d-graphics = { version = "0.26", optional = true }
 gfx = { version = "0.17", optional = true }
 gfx_core = { version = "0.8", optional = true }
@@ -64,7 +64,7 @@ image = "0.19"
 petgraph = "0.4"
 rand = "0.5"
 # glutin_gfx.rs example dependencies
-gfx_window_glutin = "0.22"
-glutin = "0.14"
+gfx_window_glutin = "0.25"
+glutin = "0.17"
 # piston_window.rs example dependencies
 piston_window = "0.80"

--- a/examples/all_winit_gfx.rs
+++ b/examples/all_winit_gfx.rs
@@ -48,7 +48,7 @@ mod feature {
         // Builder for window
         let builder = glutin::WindowBuilder::new()
             .with_title("Conrod with GFX and Glutin")
-            .with_dimensions(WIN_W, WIN_H);
+            .with_dimensions((WIN_W, WIN_H).into());
 
         let context = glutin::ContextBuilder::new()
             .with_multisampling(4);
@@ -60,7 +60,7 @@ mod feature {
             gfx_window_glutin::init::<conrod::backend::gfx::ColorFormat, DepthFormat>(builder, context, &events_loop );
         let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 
-        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, window.hidpi_factor() as f64).unwrap();
+        let mut renderer = conrod::backend::gfx::Renderer::new(&mut factory, &rtv, window.get_hidpi_factor() as f64).unwrap();
 
         // Create Ui and Ids of widgets to instantiate
         let mut ui = conrod::UiBuilder::new([WIN_W as f64, WIN_H as f64]).theme(support::theme()).build();
@@ -116,12 +116,12 @@ mod feature {
         'main: loop {
             // If the window is closed, this will be None for one tick, so to avoid panicking with
             // unwrap, instead break the loop
-            let (win_w, win_h) = match window.get_inner_size() {
-                Some(s) => s,
+            let (win_w, win_h): (u32, u32) = match window.get_inner_size() {
+                Some(s) => s.into(),
                 None => break 'main,
             };
 
-            let dpi_factor = window.hidpi_factor();
+            let dpi_factor = window.get_hidpi_factor() as f32;
 
             if let Some(primitives) = ui.draw_if_changed() {
                 let dims = (win_w as f32 * dpi_factor, win_h as f32 * dpi_factor);
@@ -151,7 +151,7 @@ mod feature {
                 // Close window if the escape key or the exit button is pressed
                 match event {
                     winit::Event::WindowEvent{event: winit::WindowEvent::KeyboardInput{input: winit::KeyboardInput{virtual_keycode: Some(winit::VirtualKeyCode::Escape),..}, ..}, .. } |
-                    winit::Event::WindowEvent{event: winit::WindowEvent::Closed, ..} =>
+                    winit::Event::WindowEvent{event: winit::WindowEvent::CloseRequested, ..} =>
                         should_quit = true,
                     _ => {},
                 }

--- a/examples/all_winit_glium.rs
+++ b/examples/all_winit_glium.rs
@@ -29,7 +29,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Conrod with glium!")
-            .with_dimensions(WIN_W, WIN_H);
+            .with_dimensions((WIN_W, WIN_H).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -95,7 +95,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/all_winit_glium_threaded.rs
+++ b/examples/all_winit_glium_threaded.rs
@@ -28,7 +28,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Conrod with glium!")
-            .with_dimensions(WIN_W, WIN_H);
+            .with_dimensions((WIN_W, WIN_H).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -166,7 +166,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -23,7 +23,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Canvas")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -63,7 +63,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -22,7 +22,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Click me!")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -65,7 +65,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -249,7 +249,7 @@ fn main() {
     let mut events_loop = glium::glutin::EventsLoop::new();
     let window = glium::glutin::WindowBuilder::new()
         .with_title("Control Panel")
-        .with_dimensions(WIDTH, HEIGHT);
+        .with_dimensions((WIDTH, HEIGHT).into());
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
@@ -297,7 +297,7 @@ fn main() {
             match event {
                 glium::glutin::Event::WindowEvent { event, .. } => match event {
                     // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::Closed |
+                    glium::glutin::WindowEvent::CloseRequested |
                     glium::glutin::WindowEvent::KeyboardInput {
                         input: glium::glutin::KeyboardInput {
                             virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/file_navigator.rs
+++ b/examples/file_navigator.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut events_loop = glium::glutin::EventsLoop::new();
     let window = glium::glutin::WindowBuilder::new()
         .with_title("Conrod with glium!")
-        .with_dimensions(WIDTH, HEIGHT);
+        .with_dimensions((WIDTH, HEIGHT).into());
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
@@ -58,7 +58,7 @@ fn main() {
             match event {
                 glium::glutin::Event::WindowEvent { event, .. } => match event {
                     // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::Closed |
+                    glium::glutin::WindowEvent::CloseRequested |
                     glium::glutin::WindowEvent::KeyboardInput {
                         input: glium::glutin::KeyboardInput {
                             virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/graph.rs
+++ b/examples/graph.rs
@@ -57,7 +57,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Conrod Graph Widget")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_multisampling(4)
             .with_vsync(true);
@@ -97,7 +97,7 @@ mod feature {
                 match event.clone() {
                     glium::glutin::Event::WindowEvent { event, .. } => {
                         match event {
-                            glium::glutin::WindowEvent::Closed |
+                            glium::glutin::WindowEvent::CloseRequested |
                             glium::glutin::WindowEvent::KeyboardInput {
                                 input: glium::glutin::KeyboardInput {
                                     virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -20,7 +20,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Hello Conrod!")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -68,7 +68,7 @@ mod feature {
                 match event.clone() {
                     glium::glutin::Event::WindowEvent { event, .. } => {
                         match event {
-                            glium::glutin::WindowEvent::Closed |
+                            glium::glutin::WindowEvent::CloseRequested |
                             glium::glutin::WindowEvent::KeyboardInput {
                                 input: glium::glutin::KeyboardInput {
                                     virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -27,7 +27,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Image Widget Demonstration")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -66,7 +66,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -33,7 +33,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Image Button Demonstration")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -94,7 +94,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -27,7 +27,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("List Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -69,7 +69,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/list_select.rs
+++ b/examples/list_select.rs
@@ -26,7 +26,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("ListSelect Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -89,7 +89,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/old_demo.rs
+++ b/examples/old_demo.rs
@@ -109,7 +109,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Widget Demonstration")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -152,7 +152,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/plot_path.rs
+++ b/examples/plot_path.rs
@@ -26,7 +26,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("PlotPath Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -60,7 +60,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -36,7 +36,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Primitive Widgets Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -71,7 +71,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/range_slider.rs
+++ b/examples/range_slider.rs
@@ -27,7 +27,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("RangeSlider Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -69,7 +69,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -27,7 +27,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Text Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -77,7 +77,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -25,7 +25,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("TextEdit Demo")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -74,7 +74,7 @@ mod feature {
                 match event {
                     glium::glutin::Event::WindowEvent { event, .. } => match event {
                         // Break from the loop upon `Escape`.
-                        glium::glutin::WindowEvent::Closed |
+                        glium::glutin::WindowEvent::CloseRequested |
                         glium::glutin::WindowEvent::KeyboardInput {
                             input: glium::glutin::KeyboardInput {
                                 virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/examples/triangles.rs
+++ b/examples/triangles.rs
@@ -20,7 +20,7 @@ mod feature {
         let mut events_loop = glium::glutin::EventsLoop::new();
         let window = glium::glutin::WindowBuilder::new()
             .with_title("Triangles!")
-            .with_dimensions(WIDTH, HEIGHT);
+            .with_dimensions((WIDTH, HEIGHT).into());
         let context = glium::glutin::ContextBuilder::new()
             .with_vsync(true)
             .with_multisampling(4);
@@ -51,7 +51,7 @@ mod feature {
                 glium::glutin::Event::WindowEvent { event, .. } => match event {
 
                     // Break from the loop upon `Escape` or closed window.
-                    glium::glutin::WindowEvent::Closed |
+                    glium::glutin::WindowEvent::CloseRequested |
                     glium::glutin::WindowEvent::KeyboardInput {
                         input: glium::glutin::KeyboardInput {
                             virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),

--- a/src/backend/glium.rs
+++ b/src/backend/glium.rs
@@ -509,7 +509,7 @@ impl Renderer {
         let (win_w, win_h) = (screen_w as Scalar, screen_h as Scalar);
         let half_win_w = win_w / 2.0;
         let half_win_h = win_h / 2.0;
-        let dpi_factor = display.gl_window().hidpi_factor() as Scalar;
+        let dpi_factor = display.gl_window().get_hidpi_factor() as Scalar;
 
         // Functions for converting for conrod scalar coords to GL vertex coords (-1.0 to 1.0).
         let vx = |x: Scalar| (x * dpi_factor / half_win_w) as f32;


### PR DESCRIPTION
This is quite a big leap in versions with a few breaking changes to take
note of, particularly if you're using the `winit` backend.

- Almost all window positioning and sizing is now handled in logical
  pixels.
- DPI handling is now type-safe in general - read [these docs][1] for
  deets.
- The `Closed` event is now `CloseRequested`
- `hidpi_factor()` is now `get_hidpi_factor()`

Please see the [winit CHANGELOG][2] for more details.

[1]: https://docs.rs/winit/0.16.2/winit/dpi/index.html
[2]: https://github.com/tomaka/winit/blob/master/CHANGELOG.md