### PR TITLE
Satisfy warning for unnecessary parens

### DIFF
--- a/src/backend/piston/draw.rs
+++ b/src/backend/piston/draw.rs
@@ -262,8 +262,8 @@ fn crop_context(context: Context, rect: Rect) -> Context {
     let y_neg = if y < 0 { y } else { 0 };
     let mut x = ::std::cmp::max(0, x) as u32;
     let mut y = ::std::cmp::max(0, y) as u32;
-    let mut w = ::std::cmp::max(0, (w as i32 + x_neg)) as u32;
-    let mut h = ::std::cmp::max(0, (h as i32 + y_neg)) as u32;
+    let mut w = ::std::cmp::max(0, w as i32 + x_neg) as u32;
+    let mut h = ::std::cmp::max(0, h as i32 + y_neg) as u32;
 
     // If there was already some scissor set, we must check for the intersection.
     if let Some(rect) = draw_state.scissor {


### PR DESCRIPTION
I got this warning when building the piston backend. There didn't seem to be any other warnings on the piston backend code, so I figured it was worth a quick jaunt to get rid of these two.

I ran the `all_piston_window` example and the unit tests and they seem to work, but unsure if they exercised this block of code.

Thanks for the great project! Really excited to see it coming together.