### PR TITLE
Add no-line-wrap to TextEdit as option, to TextBox

### DIFF
--- a/src/widget/text_box.rs
+++ b/src/widget/text_box.rs
@@ -161,7 +161,7 @@ impl<'a> Widget for TextBox<'a> {
 
         let text_color = style.text_color(ui.theme());
         let font_id = style.font_id(&ui.theme).or(ui.fonts.ids().next());
-        if let Some(new_string) = widget::TextEdit::new(text)
+        if let Some(new_string) = widget::TextEdit::new(text).no_line_wrap()
             .and_then(font_id, widget::TextEdit::font_id)
             .wh(text_rect.dim())
             .xy(text_rect.xy())


### PR DESCRIPTION
Aside from the added option to TextEdit, one can now write text beyond the bounding box of a TextBox, which is standard behavior on text boxes in general (file dialogs, address bars, search bars allow text to extend beyond the bar, but are cropped within a size). As such, with this change, TextBox can now be cropped with crop_kids without wrapped lines showing within the stencil under the main line of text.