### PR TITLE
 Add `conrod_vulkano` backend crate along with `all_winit_vulkano` demo.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "conrod_derive",
     "backends/conrod_example_shared",
     "backends/conrod_winit",
-    "backends/conrod_glium",
     "backends/conrod_gfx",
+    "backends/conrod_glium",
     "backends/conrod_piston",
+    "backends/conrod_vulkano",
 ]

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "conrod_gfx"
 version = "0.62.0"
-authors = [
-    "Mitchell Nordine <mitchell.nordine@gmail.com>",
-    "Sven Nilsen <bvssvni@gmail.com>"
-]
+authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
 license = "MIT OR Apache-2.0"

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "conrod_glium"
 version = "0.62.0"
-authors = [
-    "Mitchell Nordine <mitchell.nordine@gmail.com>",
-    "Sven Nilsen <bvssvni@gmail.com>"
-]
+authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
 license = "MIT OR Apache-2.0"

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "conrod_vulkano"
 version = "0.1.0"
-authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
+authors = [
+    "mitchmindtree <mitchell.nordine@gmail.com>",
+    "Kurble",
+    "Abendstolz",
+]
 edition = "2018"
 
 [dependencies]

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "conrod_vulkano"
+version = "0.1.0"
+authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+conrod_core = { path = "../../conrod_core", version = "0.62" }
+vulkano = "0.11"
+vulkano-shaders = "0.11"

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -8,3 +8,11 @@ edition = "2018"
 conrod_core = { path = "../../conrod_core", version = "0.62" }
 vulkano = "0.11"
 vulkano-shaders = "0.11"
+
+[dev-dependencies]
+conrod_example_shared = { path = "../conrod_example_shared" }
+conrod_winit = { path = "../conrod_winit", version = "0.62" }
+find_folder = "0.3"
+image = "0.20"
+vulkano-win = "0.11"
+winit = "0.18"

--- a/backends/conrod_vulkano/examples/all_winit_vulkano.rs
+++ b/backends/conrod_vulkano/examples/all_winit_vulkano.rs
@@ -1,0 +1,339 @@
+//! A demonstration of using `winit` to provide events and GFX to draw the UI.
+//!
+//! `winit` is used via the `glutin` crate which also provides an OpenGL context for drawing
+//! `conrod_core::render::Primitives` to the screen.
+
+#![allow(unused_variables)]
+
+extern crate conrod_core;
+extern crate conrod_example_shared;
+extern crate conrod_vulkano;
+extern crate conrod_winit;
+extern crate find_folder;
+extern crate image;
+#[macro_use]
+extern crate vulkano;
+extern crate vulkano_win;
+extern crate winit;
+
+mod support;
+
+use conrod_example_shared::{WIN_H, WIN_W};
+use std::{mem, sync::Arc};
+use vulkano::{
+    command_buffer::AutoCommandBufferBuilder,
+    format,
+    format::D16Unorm,
+    framebuffer::{Framebuffer, RenderPassAbstract},
+    image::{AttachmentImage, SwapchainImage},
+    swapchain,
+    swapchain::AcquireError,
+    sync::{now, FlushError, GpuFuture},
+};
+
+use conrod_vulkano::{Image as VulkanoGuiImage, Renderer};
+
+fn main() {
+    const CLEAR_COLOR: [f32; 4] = [0.2, 0.2, 0.2, 1.0];
+
+    let mut window = support::Window::new(WIN_W, WIN_H, "Conrod with vulkano");
+
+    let subpass = vulkano::framebuffer::Subpass::from(window.render_pass.clone(), 0)
+        .expect("Couldn't create subpass for gui!");
+    let queue = window.queue.clone();
+    let mut renderer = Renderer::new(
+        window.device.clone(),
+        subpass,
+        queue.family(),
+        WIN_W,
+        WIN_H,
+        window.surface.window().get_hidpi_factor() as f64,
+    );
+
+    let mut render_helper = RenderHelper::new(&window);
+
+    // Create Ui and Ids of widgets to instantiate
+    let mut ui = conrod_core::UiBuilder::new([WIN_W as f64, WIN_H as f64])
+        .theme(conrod_example_shared::theme())
+        .build();
+    let ids = conrod_example_shared::Ids::new(ui.widget_id_generator());
+
+    // Load font from file
+    let assets = find_folder::Search::KidsThenParents(3, 5)
+        .for_folder("assets")
+        .unwrap();
+    let font_path = assets.join("fonts/NotoSans/NotoSans-Regular.ttf");
+    ui.fonts.insert_from_file(font_path).unwrap();
+
+    // Load the Rust logo from our assets folder to use as an example image.
+    let logo_path = assets.join("images/rust.png");
+    let rgba_logo_image = image::open(logo_path)
+        .expect("Couldn't load logo")
+        .to_rgba();
+    let logo_dimensions = rgba_logo_image.dimensions();
+
+    let (logo_texture, logo_texture_future) = vulkano::image::immutable::ImmutableImage::from_iter(
+        rgba_logo_image.into_raw().clone().iter().cloned(),
+        vulkano::image::Dimensions::Dim2d {
+            width: logo_dimensions.0,
+            height: logo_dimensions.1,
+        },
+        vulkano::format::R8G8B8A8Unorm,
+        window.queue.clone(),
+    )
+    .expect("Couldn't create vulkan texture for logo");
+
+    let logo = VulkanoGuiImage {
+        image_access: logo_texture,
+        width: logo_dimensions.0,
+        height: logo_dimensions.1,
+    };
+    let mut image_map = conrod_core::image::Map::new();
+    let rust_logo = image_map.insert(logo);
+
+    // Demonstration app state that we'll control with our conrod GUI.
+    let mut app = conrod_example_shared::DemoApp::new(rust_logo);
+
+    let mut previous_frame_end = Box::new(logo_texture_future) as Box<GpuFuture>;
+
+    'main: loop {
+        // If the window is closed, this will be None for one tick, so to avoid panicking with
+        // unwrap, instead break the loop
+        let (win_w, win_h) = match window.get_dimensions() {
+            Some(s) => s,
+            None => break 'main,
+        };
+
+        if let Some(primitives) = ui.draw_if_changed() {
+            let (image_num, acquire_future) =
+                match swapchain::acquire_next_image(window.swapchain.clone(), None) {
+                    Ok(r) => r,
+                    Err(AcquireError::OutOfDate) => {
+                        render_helper.handle_resize(&mut window);
+                        continue;
+                    }
+                    Err(err) => panic!("{:?}", err),
+                };
+
+            // We are tidy little fellows and cleanup our leftovers
+            previous_frame_end.cleanup_finished();
+
+            let mut command_buffer_builder = AutoCommandBufferBuilder::primary_one_time_submit(
+                window.device.clone(),
+                window.queue.family(),
+            )
+            .expect("Failed to create AutoCommandBufferBuilder");
+
+            let viewport = [0.0, 0.0, win_w as f32, win_h as f32];
+            let mut cmds = renderer.fill(&image_map, viewport, primitives);
+            for cmd in cmds.commands.drain(..) {
+                let buffer = cmds.glyph_cpu_buffer_pool.chunk(cmd.data.iter().cloned()).unwrap();
+                command_buffer_builder = command_buffer_builder
+                    .copy_buffer_to_image_dimensions(
+                        buffer,
+                        cmds.glyph_cache_texture.clone(),
+                        [cmd.offset[0], cmd.offset[1], 0],
+                        [cmd.size[0], cmd.size[1], 1],
+                        0,
+                        1,
+                        0
+                    )
+                    .expect("failed to submit command for caching glyph");
+
+            }
+
+            let mut command_buffer_builder = command_buffer_builder
+                .begin_render_pass(
+                    render_helper.frame_buffers[image_num].clone(),
+                    false,
+                    vec![CLEAR_COLOR.into(), 1f32.into()],
+                ) // Info: We need to clear background AND depth buffer here!
+                .expect("Failed to begin render pass!");
+
+            let draw_cmds = renderer.draw(
+                window.device.clone(),
+                &image_map,
+                [0.0, 0.0, win_w as f32, win_h as f32],
+            );
+            for cmd in draw_cmds {
+                let conrod_vulkano::DrawCommand {
+                    graphics_pipeline,
+                    dynamic_state,
+                    vertex_buffer,
+                    descriptor_set,
+                } = cmd;
+                command_buffer_builder = command_buffer_builder
+                    .draw(
+                        graphics_pipeline,
+                        &dynamic_state,
+                        vec![vertex_buffer],
+                        descriptor_set,
+                        (),
+                    )
+                    .expect("failed to submit draw command");
+            }
+
+            let command_buffer = command_buffer_builder
+                .end_render_pass()
+                .unwrap()
+                .build()
+                .unwrap();
+
+            let future = previous_frame_end
+                .join(acquire_future)
+                .then_execute(window.queue.clone(), command_buffer)
+                .expect("Failed to join previous frame with new one")
+                .then_swapchain_present(window.queue.clone(), window.swapchain.clone(), image_num)
+                .then_signal_fence_and_flush();
+
+            match future {
+                Ok(future) => previous_frame_end = Box::new(future) as Box<_>,
+                Err(FlushError::OutOfDate) => {
+                    previous_frame_end = Box::new(now(window.device.clone())) as Box<_>
+                }
+                Err(e) => {
+                    previous_frame_end = Box::new(now(window.device.clone())) as Box<_>;
+                }
+            }
+        }
+
+        let mut should_quit = false;
+
+        let winit_window_handle = window.surface.window();
+
+        window.events_loop.poll_events(|event| {
+            let (w, h) = (win_w as conrod_core::Scalar, win_h as conrod_core::Scalar);
+            //let dpi_factor = dpi_factor as conrod_core::Scalar;
+
+            // Convert winit event to conrod event, requires conrod to be built with the `winit`
+            // feature
+            if let Some(event) = conrod_winit::convert_event(event.clone(), winit_window_handle) {
+                ui.handle_event(event);
+            }
+
+            // Close window if the escape key or the exit button is pressed
+            match event {
+                winit::Event::WindowEvent {
+                    event:
+                        winit::WindowEvent::KeyboardInput {
+                            input:
+                                winit::KeyboardInput {
+                                    virtual_keycode: Some(winit::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        },
+                    ..
+                }
+                | winit::Event::WindowEvent {
+                    event: winit::WindowEvent::CloseRequested,
+                    ..
+                } => should_quit = true,
+                _ => {}
+            }
+        });
+        if should_quit {
+            break 'main;
+        }
+
+        // Update widgets if any event has happened
+        if ui.global_input().events().next().is_some() {
+            let mut ui = ui.set_widgets();
+            conrod_example_shared::gui(&mut ui, &ids, &mut app);
+        }
+    }
+}
+
+pub struct RenderHelper {
+    depth_buffer: Arc<AttachmentImage<D16Unorm>>,
+    frame_buffers: Vec<
+        Arc<
+            Framebuffer<
+                Arc<RenderPassAbstract + Send + Sync>,
+                (
+                    ((), Arc<SwapchainImage<winit::Window>>),
+                    Arc<AttachmentImage<D16Unorm>>,
+                ),
+            >,
+        >,
+    >,
+    //previous_frame_end: Box<GpuFuture>,
+    width: u32,
+    height: u32,
+}
+
+impl RenderHelper {
+    pub fn new(window: &support::Window) -> Self {
+        let (width, height) = window
+            .get_dimensions()
+            .expect("Couldn't get window dimensions");
+        let depth_buffer =
+            AttachmentImage::transient(window.device.clone(), [width, height], format::D16Unorm)
+                .unwrap();
+        let frame_buffers: Vec<
+            Arc<
+                Framebuffer<
+                    Arc<RenderPassAbstract + Send + Sync>,
+                    (
+                        ((), Arc<SwapchainImage<winit::Window>>),
+                        Arc<AttachmentImage<D16Unorm>>,
+                    ),
+                >,
+            >,
+        > = window
+            .images
+            .iter()
+            .map(|image| {
+                Arc::new(
+                    Framebuffer::start(window.render_pass.clone())
+                        .add(image.clone())
+                        .unwrap()
+                        .add(depth_buffer.clone())
+                        .unwrap()
+                        .build()
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        RenderHelper {
+            depth_buffer,
+            frame_buffers,
+            width,
+            height,
+        }
+    }
+
+    pub fn handle_resize(&mut self, window: &mut support::Window) -> () {
+        window.handle_resize();
+
+        let (width, height) = window
+            .get_dimensions()
+            .expect("Couldn't get window dimensions");
+        if self.width != width || self.height != height {
+            self.depth_buffer = AttachmentImage::transient(
+                window.device.clone(),
+                [width, height],
+                format::D16Unorm,
+            )
+            .unwrap();
+        }
+
+        let new_framebuffers = window
+            .images
+            .iter()
+            .map(|image| {
+                Arc::new(
+                    Framebuffer::start(window.render_pass.clone())
+                        .add(image.clone())
+                        .unwrap()
+                        .add(self.depth_buffer.clone())
+                        .unwrap()
+                        .build()
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        mem::replace(&mut self.frame_buffers, new_framebuffers);
+    }
+}

--- a/backends/conrod_vulkano/examples/support/mod.rs
+++ b/backends/conrod_vulkano/examples/support/mod.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use vulkano::{
     self,
     device::{Device, Queue},
-    framebuffer::RenderPassAbstract,
     image::SwapchainImage,
     instance::{Instance, PhysicalDevice},
     swapchain::{PresentMode, Surface, SurfaceTransform, Swapchain, SwapchainCreationError},
@@ -18,7 +17,6 @@ pub struct Window {
     pub events_loop: EventsLoop,
     pub device: Arc<Device>,
     pub images: Vec<Arc<SwapchainImage<winit::Window>>>,
-    pub render_pass: Arc<RenderPassAbstract + Send + Sync>,
 }
 
 impl Window {
@@ -97,30 +95,6 @@ impl Window {
             )
         };
 
-        let render_pass = Arc::new(
-            single_pass_renderpass!(device.clone(),
-                attachments: {
-                    color: {
-                        load: Clear,
-                        store: Store,
-                        format: swapchain.format(),
-                        samples: 1,
-                    },
-                    depth: {
-                        load: Clear,
-                        store: DontCare,
-                        format: vulkano::format::Format::D16Unorm,
-                        samples: 1,
-                    }
-                },
-                pass: {
-                    color: [color],
-                    depth_stencil: {depth}
-                }
-            )
-            .unwrap(),
-        );
-
         Self {
             surface,
             swapchain,
@@ -128,7 +102,6 @@ impl Window {
             events_loop,
             device,
             images,
-            render_pass,
         }
     }
 

--- a/backends/conrod_vulkano/examples/support/mod.rs
+++ b/backends/conrod_vulkano/examples/support/mod.rs
@@ -1,0 +1,166 @@
+use std::sync::Arc;
+use vulkano::{
+    self,
+    device::{Device, Queue},
+    framebuffer::RenderPassAbstract,
+    image::SwapchainImage,
+    instance::{Instance, PhysicalDevice},
+    swapchain::{PresentMode, Surface, SurfaceTransform, Swapchain, SwapchainCreationError},
+};
+
+use vulkano_win::{self, VkSurfaceBuild};
+use winit::{self, EventsLoop};
+
+pub struct Window {
+    pub surface: Arc<Surface<winit::Window>>,
+    pub swapchain: Arc<Swapchain<winit::Window>>,
+    pub queue: Arc<Queue>,
+    pub events_loop: EventsLoop,
+    pub device: Arc<Device>,
+    pub images: Vec<Arc<SwapchainImage<winit::Window>>>,
+    pub render_pass: Arc<RenderPassAbstract + Send + Sync>,
+}
+
+impl Window {
+    pub fn new(width: u32, height: u32, title: &str) -> Self {
+        let size = winit::dpi::LogicalSize::new(width as f64, height as f64);
+        let (width, height): (u32, u32) = size.into();
+
+        let instance: Arc<Instance> = {
+            let extensions = vulkano_win::required_extensions();
+            Instance::new(None, &extensions, None).expect("failed to create Vulkan instance")
+        };
+
+        let cloned_instance = instance.clone();
+
+        let physical: PhysicalDevice =
+            vulkano::instance::PhysicalDevice::enumerate(&cloned_instance)
+                .next()
+                .expect("no device available");
+
+        let events_loop = winit::EventsLoop::new();
+        let surface = winit::WindowBuilder::new()
+            .with_dimensions(size)
+            .with_resizable(false)
+            .with_title(title)
+            .build_vk_surface(&events_loop, instance.clone())
+            .unwrap();
+
+        let queue = physical
+            .queue_families()
+            .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+            .expect("couldn't find a graphical queue family");
+
+        let (device, mut queues) = {
+            let device_ext = vulkano::device::DeviceExtensions {
+                khr_swapchain: true,
+                ..vulkano::device::DeviceExtensions::none()
+            };
+
+            Device::new(
+                physical,
+                physical.supported_features(),
+                &device_ext,
+                [(queue, 0.5)].iter().cloned(),
+            )
+            .expect("failed to create device")
+        };
+
+        let queue = queues.next().unwrap();
+        let ((swapchain, images), _surface_dimensions) = {
+            let caps = surface
+                .capabilities(physical)
+                .expect("failed to get surface capabilities");
+
+            let surface_dimensions = caps.current_extent.unwrap_or([width, height]);
+            let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+            let format = caps.supported_formats[0].0;
+
+            (
+                Swapchain::new(
+                    device.clone(),
+                    surface.clone(),
+                    caps.min_image_count,
+                    format,
+                    surface_dimensions,
+                    1,
+                    caps.supported_usage_flags,
+                    &queue,
+                    SurfaceTransform::Identity,
+                    alpha,
+                    PresentMode::Fifo,
+                    true,
+                    None,
+                )
+                .expect("failed to create swapchain"),
+                surface_dimensions,
+            )
+        };
+
+        let render_pass = Arc::new(
+            single_pass_renderpass!(device.clone(),
+                attachments: {
+                    color: {
+                        load: Clear,
+                        store: Store,
+                        format: swapchain.format(),
+                        samples: 1,
+                    },
+                    depth: {
+                        load: Clear,
+                        store: DontCare,
+                        format: vulkano::format::Format::D16Unorm,
+                        samples: 1,
+                    }
+                },
+                pass: {
+                    color: [color],
+                    depth_stencil: {depth}
+                }
+            )
+            .unwrap(),
+        );
+
+        Self {
+            surface,
+            swapchain,
+            queue,
+            events_loop,
+            device,
+            images,
+            render_pass,
+        }
+    }
+
+    pub fn get_dimensions(&self) -> Option<(u32, u32)> {
+        let inner_size = self
+            .surface
+            .window()
+            .get_inner_size()
+            .unwrap()
+            .to_physical(self.surface.window().get_hidpi_factor());
+        Some(inner_size.into())
+    }
+
+    pub fn handle_resize(&mut self) -> () {
+        // Get the new dimensions for the viewport/framebuffers.
+        let new_dimensions = self
+            .surface
+            .capabilities(self.device.physical_device())
+            .expect("failed to get surface capabilities")
+            .current_extent
+            .unwrap();
+
+        let (new_swapchain, new_images) =
+            match self.swapchain.recreate_with_dimension(new_dimensions) {
+                Ok(r) => r,
+                // This error tends to happen when the user is manually resizing the window.
+                // Simply restarting the loop is the easiest way to fix this issue.
+                Err(SwapchainCreationError::UnsupportedDimensions) => return self.handle_resize(),
+                Err(err) => panic!("Window couldn't be resized! {:?}", err),
+            };
+
+        self.swapchain = new_swapchain;
+        self.images = new_images;
+    }
+}

--- a/backends/conrod_vulkano/src/lib.rs
+++ b/backends/conrod_vulkano/src/lib.rs
@@ -1,0 +1,760 @@
+extern crate conrod_core;
+#[macro_use]
+extern crate vulkano;
+extern crate vulkano_shaders;
+
+use std::sync::Arc;
+
+use conrod_core::{render, color, image, Rect, Scalar};
+use conrod_core::text::{rt,GlyphCache};
+
+use vulkano::command_buffer::AutoCommandBufferBuilder;
+use vulkano::pipeline::viewport::Scissor;
+use vulkano::instance::QueueFamily;
+use vulkano::device::*;
+use vulkano::pipeline::*;
+use vulkano::descriptor::descriptor_set::FixedSizeDescriptorSetsPool;
+use vulkano::buffer::cpu_pool::CpuBufferPool;
+use vulkano::buffer::BufferUsage;
+use vulkano::buffer::CpuAccessibleBuffer;
+use vulkano::framebuffer::*;
+use vulkano::image::*;
+use vulkano::format::*;
+use vulkano::sampler::*;
+use vulkano::pipeline::viewport::Viewport;
+use vulkano::command_buffer::DynamicState;
+
+/// A `Command` describing a step in the drawing process.
+#[derive(Clone, Debug)]
+pub enum Command<'a> {
+    /// Draw to the target.
+    Draw(Draw<'a>),
+    /// Update the scizzor within the pipeline.
+    Scizzor(Scissor),
+}
+
+/// An iterator yielding `Command`s, produced by the `Renderer::commands` method.
+pub struct Commands<'a> {
+    commands: std::slice::Iter<'a, PreparedCommand>,
+    vertices: &'a [Vertex],
+}
+
+/// A `Command` for drawing to the target.
+///
+/// Each variant describes how to draw the contents of the vertex buffer.
+#[derive(Clone, Debug)]
+pub enum Draw<'a> {
+    /// A range of vertices representing triangles textured with the image in the
+    /// image_map at the given `widget::Id`.
+    Image(image::Id, &'a [Vertex]),
+    /// A range of vertices representing plain triangles.
+    Plain(&'a [Vertex]),
+}
+
+enum PreparedCommand {
+    Image(image::Id, std::ops::Range<usize>),
+    Plain(std::ops::Range<usize>),
+    Scizzor(Scissor),
+}
+
+/// A loaded vulkan texture and it's width/height
+pub struct Image {
+    /// The actual image.
+    pub image_access: Arc<ImmutableImage<R8G8B8A8Unorm>>,
+    /// The width of the image.
+    pub width: u32,
+    /// The height of the image.
+    pub height: u32,
+}
+
+/// Draw text from the text cache texture `tex` in the fragment shader.
+pub const MODE_TEXT: u32 = 0;
+/// Draw an image from the texture at `tex` in the fragment shader.
+pub const MODE_IMAGE: u32 = 1;
+/// Ignore `tex` and draw simple, colored 2D geometry.
+pub const MODE_GEOMETRY: u32 = 2;
+
+mod vs {
+    vulkano_shaders::shader! {
+        ty: "vertex",
+        src: "
+#version 450
+
+layout(location = 0) in vec2 pos;
+layout(location = 1) in vec2 uv;
+layout(location = 2) in vec4 color;
+layout(location = 3) in uint mode;
+
+layout(location = 0) out vec2 v_Uv;
+layout(location = 1) out vec4 v_Color;
+layout(location = 2) flat out uint v_Mode;
+
+void main() {
+    v_Uv = uv;
+    v_Color = color;
+    gl_Position = vec4(pos, 0.0, 1.0);
+    v_Mode = mode;
+}
+"
+    }
+}
+
+mod fs {
+    vulkano_shaders::shader! {
+        ty: "fragment",
+        src: "
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler2D t_Color;
+
+layout(location = 0) in vec2 v_Uv;
+layout(location = 1) in vec4 v_Color;
+layout(location = 2) flat in uint v_Mode;
+
+layout(location = 0) out vec4 Target0;
+
+void main() {
+    // Text
+    if (v_Mode == uint(0)) {
+        Target0 = v_Color * vec4(1.0, 1.0, 1.0, texture(t_Color, v_Uv).a);
+
+    // Image
+    } else if (v_Mode == uint(1)) {
+        Target0 = texture(t_Color, v_Uv);
+
+    // 2D Geometry
+    } else if (v_Mode == uint(2)) {
+        Target0 = v_Color;
+    }
+}
+"
+    }
+}
+
+/// The `Vertex` type passed to the vertex shader.
+#[derive(Debug, Clone, Copy)]
+pub  struct Vertex { 
+    /// The position of the vertex within vector space.
+    ///
+    /// [-1.0, -1.0] is the leftmost, bottom position of the display.
+    /// [1.0, 1.0] is the rightmost, top position of the display.
+    pub pos:   [f32; 2],
+    /// The coordinates of the texture used by this `Vertex`.
+    ///
+    /// [0.0, 0.0] is the leftmost, top position of the texture.
+    /// [1.0, 1.0] is the rightmost, bottom position of the texture.
+    pub uv:    [f32; 2],
+    /// A color associated with the `Vertex`.
+    ///
+    /// The way that the color is used depends on the `mode`.
+    pub color: [f32; 4],
+    /// The mode with which the `Vertex` will be drawn within the fragment shader.
+    ///
+    /// `0` for rendering text.
+    /// `1` for rendering an image.
+    /// `2` for rendering non-textured 2D geometry.
+    ///
+    /// If any other value is given, the fragment shader will not output any color.
+    pub mode:  u32, 
+}
+
+impl_vertex!(Vertex, pos, uv, color, mode);
+
+/// A type used for translating `render::Primitives` into `Command`s that indicate how to draw the
+/// conrod GUI using `vulkano`.
+pub struct Renderer {
+    pipeline: Box<Arc<GraphicsPipelineAbstract+Send+Sync>>,
+    glyph_cache: GlyphCache<'static>,
+    glyph_uploads: CpuBufferPool<[u8; 4]>,
+    glyph_cache_tex: Arc<StorageImage<R8G8B8A8Unorm>>,
+    sampler: Arc<Sampler>,
+    dpi_factor: f64,
+    commands: Vec<PreparedCommand>,
+    vertices: Vec<Vertex>,
+    tex_descs: FixedSizeDescriptorSetsPool<Arc<GraphicsPipelineAbstract+Send+Sync>>,
+}
+
+impl Renderer {
+    /// Construct a new empty `Renderer`.
+    pub fn new<
+        'a,
+        L: RenderPassDesc + RenderPassAbstract + Send + Sync + 'static
+    > (
+        device: Arc<Device>,
+        subpass: Subpass<L>,
+        graphics_queue_family: QueueFamily<'a>,
+        width: u32,
+        height: u32,
+        dpi_factor: f64
+    ) -> Self {
+        let sampler = Sampler::new(
+            device.clone(), 
+            Filter::Linear,
+            Filter::Linear, 
+            MipmapMode::Nearest,
+            SamplerAddressMode::ClampToEdge,
+            SamplerAddressMode::ClampToEdge,
+            SamplerAddressMode::ClampToEdge,
+            0.0, 1.0, 0.0, 0.0
+        ).unwrap();
+
+        let vertex_shader = vs::Shader::load(device.clone())
+            .expect("failed to create shader module");
+
+        let fragment_shader = fs::Shader::load(device.clone())
+            .expect("failed to create shader module");
+
+        let pipeline = Arc::new(GraphicsPipeline::start()
+            .vertex_input_single_buffer::<Vertex>()
+            .vertex_shader(vertex_shader.main_entry_point(), ())
+            .depth_stencil_disabled()
+            .triangle_list()
+            .front_face_clockwise()
+            //.cull_mode_back()
+            .viewports_scissors_dynamic(1)
+            .fragment_shader(fragment_shader.main_entry_point(), ())
+            .blend_alpha_blending()
+            .render_pass(subpass)
+            .build(device.clone())
+            .unwrap());
+
+        let (glyph_cache, glyph_cache_tex) = {
+
+            let width = (width as f64 * dpi_factor) as u32;
+            let height = (height as f64 * dpi_factor) as u32;
+
+            const SCALE_TOLERANCE: f32 = 0.1;
+            const POSITION_TOLERANCE: f32 = 0.1;
+
+            let glyph_cache = GlyphCache::builder()
+                .dimensions(width, height)
+                .scale_tolerance(SCALE_TOLERANCE)
+                .position_tolerance(POSITION_TOLERANCE)
+                .build();
+
+            let glyph_cache_tex = StorageImage::with_usage(
+                device.clone(), 
+                Dimensions::Dim2d{ width, height }, 
+                R8G8B8A8Unorm, 
+                ImageUsage {
+                    transfer_destination: true,
+                    sampled: true,
+                    .. ImageUsage::none()
+                }, 
+                vec![graphics_queue_family]
+            ).unwrap();
+
+            (glyph_cache, glyph_cache_tex)
+        };
+
+        let tex_descs = FixedSizeDescriptorSetsPool::new(pipeline.clone() as Arc<_>, 0);
+
+        Renderer {
+            pipeline: Box::new(pipeline),
+            glyph_cache,
+            glyph_uploads: CpuBufferPool::upload(device.clone()),
+            glyph_cache_tex,
+            sampler,
+            dpi_factor,
+            commands: Vec::new(),
+            vertices: Vec::new(),
+            tex_descs,            
+        }
+    }
+
+    /// Produce an `Iterator` yielding `Command`s.
+    pub fn commands(&self) -> Commands {
+        let Renderer { ref commands, ref vertices, .. } = *self;
+        Commands {
+            commands: commands.iter(),
+            vertices: vertices,
+        }
+    }
+
+    /// Fill the inner vertex and command buffers by translating the given `primitives`.
+    pub fn fill<
+        P: render::PrimitiveWalker
+    > (
+        &mut self,
+        mut cmd: AutoCommandBufferBuilder,
+        image_map: &image::Map<Image>,
+        viewport: [f32; 4],
+        mut primitives: P   
+    ) -> AutoCommandBufferBuilder {
+        let Renderer { 
+            ref mut commands, 
+            ref mut vertices, 
+            ref mut glyph_cache, 
+            ref     glyph_uploads,
+            ref mut glyph_cache_tex, 
+            dpi_factor, 
+            .. 
+        } = *self;
+
+        commands.clear();
+        vertices.clear();
+
+        enum State {
+            Image { image_id: image::Id, start: usize },
+            Plain { start: usize },
+        }
+
+        let mut current_state = State::Plain { start: 0 };
+
+        // Switches to the `Plain` state and completes the previous `Command` if not already in the
+        // `Plain` state.
+        macro_rules! switch_to_plain_state {
+            () => {
+                match current_state {
+                    State::Plain { .. } => (),
+                    State::Image { image_id, start } => {
+                        commands.push(PreparedCommand::Image(image_id, start..vertices.len()));
+                        current_state = State::Plain { start: vertices.len() };
+                    },
+                }
+            };
+        }
+
+        // Framebuffer dimensions and the "dots per inch" factor.
+        let (screen_w, screen_h) = (viewport[2]-viewport[0], viewport[3]-viewport[1]);
+        let (win_w, win_h) = (screen_w as Scalar, screen_h as Scalar);
+        let half_win_w = win_w / 2.0;
+        let half_win_h = win_h / 2.0;
+
+        // Functions for converting for conrod scalar coords to GL vertex coords (-1.0 to 1.0).
+        let vx = |x: Scalar| (x * dpi_factor / half_win_w) as f32;
+        let vy = |y: Scalar| -1.0 * (y * dpi_factor / half_win_h) as f32;
+
+        let mut current_scizzor = Scissor {
+            origin: [0, 0],
+            dimensions: [screen_w as u32, screen_h as u32],
+        };
+
+        let rect_to_scissor = |rect: Rect| {
+            let (w, h) = rect.w_h();
+            let left = (rect.left() * dpi_factor + half_win_w) as i32;
+            let bottom = (rect.bottom() * dpi_factor + half_win_h) as i32;
+            let width = (w * dpi_factor) as u32;
+            let height = (h * dpi_factor) as u32;
+            Scissor {
+                origin: [left.max(0), bottom.max(0)],
+                dimensions: [width.min(screen_w as u32), height.min(screen_h as u32)],
+            }
+        };
+
+        // Draw each primitive in order of depth.
+        while let Some(primitive) = primitives.next_primitive() {
+            let render::Primitive { kind, scizzor, rect, .. } = primitive;
+
+            // Check for a `Scizzor` command.
+            let new_scizzor = rect_to_scissor(scizzor);
+            if new_scizzor != current_scizzor {
+                // Finish the current command.
+                match current_state {
+                    State::Plain { start } =>
+                        commands.push(PreparedCommand::Plain(start..vertices.len())),
+                    State::Image { image_id, start } =>
+                        commands.push(PreparedCommand::Image(image_id, start..vertices.len())),
+                }
+
+                // Update the scizzor and produce a command.
+                current_scizzor = new_scizzor;
+                commands.push(PreparedCommand::Scizzor(new_scizzor));
+
+                // Set the state back to plain drawing.
+                current_state = State::Plain { start: vertices.len() };
+            }
+
+            match kind {
+
+                render::PrimitiveKind::Rectangle { color } => {
+                    switch_to_plain_state!();
+
+                    let color = gamma_srgb_to_linear(color.to_fsa());
+                    let (l, r, b, t) = rect.l_r_b_t();
+
+                    let v = |x, y| {
+                        // Convert from conrod Scalar range to GL range -1.0 to 1.0.
+                        Vertex {
+                            pos: [vx(x), vy(y)],
+                            uv: [0.0, 0.0],
+                            color: color,
+                            mode: MODE_GEOMETRY,
+                        }
+                    };
+
+                    let mut push_v = |x, y| vertices.push(v(x, y));
+
+                    // Bottom left triangle.
+                    push_v(l, t);
+                    push_v(r, b);
+                    push_v(l, b);
+
+                    // Top right triangle.
+                    push_v(l, t);
+                    push_v(r, b);
+                    push_v(r, t);
+                },
+
+                render::PrimitiveKind::TrianglesSingleColor { color, triangles } => {
+                    if triangles.is_empty() {
+                        continue;
+                    }
+
+                    switch_to_plain_state!();
+
+                    let color = gamma_srgb_to_linear(color.into());
+
+                    let v = |p: [Scalar; 2]| {
+                        Vertex {
+                            pos: [vx(p[0]), vy(p[1])],
+                            uv: [0.0, 0.0],
+                            color: color,
+                            mode: MODE_GEOMETRY,
+                        }
+                    };
+
+                    for triangle in triangles {
+                        vertices.push(v(triangle[0]));
+                        vertices.push(v(triangle[1]));
+                        vertices.push(v(triangle[2]));
+                    }
+                },
+
+                render::PrimitiveKind::TrianglesMultiColor { triangles } => {
+                    if triangles.is_empty() {
+                        continue;
+                    }
+
+                    switch_to_plain_state!();
+
+                    let v = |(p, c): ([Scalar; 2], color::Rgba)| {
+                        Vertex {
+                            pos: [vx(p[0]), vy(p[1])],
+                            uv: [0.0, 0.0],
+                            color: gamma_srgb_to_linear(c.into()),
+                            mode: MODE_GEOMETRY,
+                        }
+                    };
+
+                    for triangle in triangles {
+                        vertices.push(v(triangle[0]));
+                        vertices.push(v(triangle[1]));
+                        vertices.push(v(triangle[2]));
+                    }
+                },
+
+                render::PrimitiveKind::Text { color, text, font_id } => {
+                    switch_to_plain_state!();
+
+                    let positioned_glyphs = text.positioned_glyphs(dpi_factor as f32);
+
+                    // Queue the glyphs to be cached
+                    for glyph in positioned_glyphs {
+                        glyph_cache.queue_glyph(font_id.index(), glyph.clone());
+                    }
+
+                    let mut capture_cmd = Some(cmd);
+
+                    glyph_cache.cache_queued(|rect, data| {
+                        let offset = [rect.min.x as u32, rect.min.y as u32];
+                        let size = [rect.width() as u32, rect.height() as u32];
+
+                        let new_data = data.iter()
+                            .map(|x| [255, 255, 255, *x])
+                            .collect::<Vec<[u8; 4]>>();
+
+                        capture_cmd = Some(update_texture(
+                            capture_cmd.take().unwrap(), 
+                            glyph_uploads, 
+                            glyph_cache_tex.clone(), 
+                            offset, 
+                            size, 
+                            new_data
+                        ));
+                    }).unwrap();
+
+                    cmd = capture_cmd.take().unwrap();
+
+                    let color = gamma_srgb_to_linear(color.to_fsa());
+                    let cache_id = font_id.index();
+                    let origin = rt::point(0.0, 0.0);
+
+                    // A closure to convert RustType rects to GL rects
+                    let to_vk_rect = |screen_rect: rt::Rect<i32>| rt::Rect {
+                        min: origin
+                            + (rt::vector(screen_rect.min.x as f32 / screen_w - 0.5,
+                                          screen_rect.min.y as f32 / screen_h - 0.5)) * 2.0,
+                        max: origin
+                            + (rt::vector(screen_rect.max.x as f32 / screen_w - 0.5,
+                                          screen_rect.max.y as f32 / screen_h - 0.5)) * 2.0,
+                    };
+
+                    for g in positioned_glyphs {
+                        if let Ok(Some((uv_rect, screen_rect))) = 
+                            glyph_cache.rect_for(cache_id, g) {
+
+                            let vk_rect = to_vk_rect(screen_rect);
+                            let v = |p, t| Vertex {
+                                pos: p,
+                                uv: t,
+                                color: color,
+                                mode: MODE_TEXT,
+                            };
+                            let mut push_v = |p, t| vertices.push(v(p, t));
+                            push_v([vk_rect.min.x, vk_rect.max.y], [uv_rect.min.x, uv_rect.max.y]);
+                            push_v([vk_rect.min.x, vk_rect.min.y], [uv_rect.min.x, uv_rect.min.y]);
+                            push_v([vk_rect.max.x, vk_rect.min.y], [uv_rect.max.x, uv_rect.min.y]);
+                            push_v([vk_rect.max.x, vk_rect.min.y], [uv_rect.max.x, uv_rect.min.y]);
+                            push_v([vk_rect.max.x, vk_rect.max.y], [uv_rect.max.x, uv_rect.max.y]);
+                            push_v([vk_rect.min.x, vk_rect.max.y], [uv_rect.min.x, uv_rect.max.y]);
+                        }
+                    }
+                },
+
+                render::PrimitiveKind::Image { image_id, color, source_rect } => {
+
+                    // Switch to the `Image` state for this image if we're not in it already.
+                    let new_image_id = image_id;
+                    match current_state {
+
+                        // If we're already in the drawing mode for this image, we're done.
+                        State::Image { image_id, .. } if image_id == new_image_id => (),
+
+                        // If we were in the `Plain` drawing state, switch to Image drawing state.
+                        State::Plain { start } => {
+                            commands.push(PreparedCommand::Plain(start..vertices.len()));
+                            current_state = State::Image {
+                                image_id: new_image_id,
+                                start: vertices.len(),
+                            };
+                        },
+
+                        // If we were drawing a different image, switch state to draw *this* image.
+                        State::Image { image_id, start } => {
+                            commands.push(PreparedCommand::Image(image_id, start..vertices.len()));
+                            current_state = State::Image {
+                                image_id: new_image_id,
+                                start: vertices.len(),
+                            };
+                        },
+                    }
+
+                    let color = color.unwrap_or(color::WHITE).to_fsa();
+
+                    let image_ref = image_map.get(&image_id).unwrap();
+                    let (image_w, image_h) = (image_ref.width, image_ref.height);
+                    let (image_w, image_h) = (image_w as Scalar, image_h as Scalar);
+
+                    // Get the sides of the source rectangle as uv coordinates.
+                    //
+                    // Texture coordinates range:
+                    // - left to right: 0.0 to 1.0
+                    // - bottom to top: 0.0 to 0.1
+                    // Note bottom and top are flipped in comparison to glium so that we don't need 
+                    //  to flip images when loading
+                    let (uv_l, uv_r, uv_t, uv_b) = match source_rect {
+                        Some(src_rect) => {
+                            let (l, r, b, t) = src_rect.l_r_b_t();
+                            ((l / image_w) as f32,
+                             (r / image_w) as f32,
+                             (t / image_h) as f32,
+                             (b / image_h) as f32)
+                        },
+                        None => (0.0, 1.0, 0.0, 1.0),
+                    };
+
+                    let v = |x, y, t| {
+                        // Convert from conrod Scalar range to GL range -1.0 to 1.0.
+                        let x = (x * dpi_factor / half_win_w) as f32;
+                        let y = (y * dpi_factor / half_win_h) as f32;
+                        Vertex {
+                            pos: [x, y],
+                            uv: t,
+                            color: color,
+                            mode: MODE_IMAGE,
+                        }
+                    };
+
+                    let mut push_v = |x, y, t| vertices.push(v(x, y, t));
+
+                    let (l, r, t, b) = rect.l_r_b_t();
+
+                    // Bottom left triangle.
+                    push_v(l, t, [uv_l, uv_t]);
+                    push_v(r, b, [uv_r, uv_b]);
+                    push_v(l, b, [uv_l, uv_b]);
+
+                    // Top right triangle.
+                    push_v(l, t, [uv_l, uv_t]);
+                    push_v(r, b, [uv_r, uv_b]);
+                    push_v(r, t, [uv_r, uv_t]);
+                },
+
+                // We have no special case widgets to handle.
+                render::PrimitiveKind::Other(_) => (),
+            }
+
+        }
+
+        // Enter the final command.
+        match current_state {
+            State::Plain { start } =>
+                commands.push(PreparedCommand::Plain(start..vertices.len())),
+            State::Image { image_id, start } =>
+                commands.push(PreparedCommand::Image(image_id, start..vertices.len())),
+        }
+
+        cmd
+    }
+
+    /// Draws using the inner list of `Command`s to the given `display`.
+    ///
+    /// Note: If you require more granular control over rendering, you may want to use the `fill`
+    /// and `commands` methods separately. This method is simply a convenience wrapper around those
+    /// methods for the case that the user does not require accessing or modifying conrod's draw
+    /// parameters, uniforms or generated draw commands.
+    pub fn draw(
+        &mut self, 
+        mut cmd: AutoCommandBufferBuilder,
+        device: Arc<Device>,
+        image_map: &image::Map<Image>,
+        viewport: [f32; 4]        
+    ) -> AutoCommandBufferBuilder {
+        let current_viewport = Viewport {
+            origin: [viewport[0], viewport[1]],
+            dimensions: [viewport[2]-viewport[0], viewport[3]-viewport[1]],
+            depth_range: 0.0 .. 1.0,
+        };
+
+        let mut current_scissor = Scissor {
+            origin: [viewport[0] as i32, viewport[1] as i32],
+            dimensions: [(viewport[2]-viewport[0]) as u32, (viewport[3]-viewport[1]) as u32],
+        };
+
+        let desc_cache = Arc::new(self.tex_descs.next()
+            .add_sampled_image(self.glyph_cache_tex.clone(), self.sampler.clone()).unwrap()
+            .build().unwrap());
+
+        let tex_descs = &mut self.tex_descs;
+
+        let commands = Commands {
+            commands: self.commands.iter(),
+            vertices: &self.vertices,
+        };
+
+        let dynamic_state = |scissor| {
+            DynamicState {
+                line_width: None,
+                viewports: Some(vec![current_viewport.clone()]),
+                scissors: Some(vec![scissor]),
+            }
+        };
+
+        for command in commands {
+            match command {
+
+                // Update the `scizzor` before continuing to draw.
+                Command::Scizzor(scizzor) => current_scissor = scizzor,
+
+                // Draw to the target with the given `draw` command.
+                Command::Draw(draw) => match draw {
+
+                    // Draw text and plain 2D geometry.
+                    Draw::Plain(verts) => {
+                        if verts.len() > 0 {
+                            let vbuf = CpuAccessibleBuffer::<[Vertex]>::from_iter(
+                                device.clone(), 
+                                BufferUsage::vertex_buffer(), 
+                                verts.iter().cloned()
+                            ).unwrap();
+
+                            cmd = cmd
+                                .draw(self.pipeline.clone(),
+                                    &dynamic_state(current_scissor.clone()),
+                                    vec![vbuf],
+                                    desc_cache.clone(), 
+                                    ())
+                                .unwrap();
+                        }
+                    },
+
+                    // Draw an image whose texture data lies within the `image_map` at the
+                    // given `id`.
+                    Draw::Image(image_id, verts) => {
+                        if verts.len() > 0 {
+                            let image = image_map.get(&image_id).unwrap().image_access.clone();
+
+                            let desc_image = Arc::new(tex_descs.next()
+                                .add_sampled_image(image, self.sampler.clone()).unwrap()
+                                .build().unwrap());
+
+                            let vbuf = CpuAccessibleBuffer::from_iter(
+                                device.clone(), 
+                                BufferUsage::vertex_buffer(), 
+                                verts.iter().cloned()
+                            ).unwrap();
+
+                            cmd = cmd
+                                .draw(self.pipeline.clone(),
+                                    &dynamic_state(current_scissor.clone()),
+                                    vec![vbuf],
+                                    desc_image, 
+                                    ())
+                                .unwrap();
+                        }
+                    },
+                }
+            }
+        }
+
+        cmd
+    }
+}
+
+fn update_texture(
+    cmd: AutoCommandBufferBuilder,
+    pool: &CpuBufferPool<[u8;4]>,
+    texture: Arc<StorageImage<R8G8B8A8Unorm>>,
+    offset: [u32;2],
+    size: [u32;2],
+    data: Vec<[u8;4]>
+) -> AutoCommandBufferBuilder {
+    let buffer = pool.chunk(data.iter().cloned()).unwrap();
+
+    cmd.copy_buffer_to_image_dimensions(
+        buffer, 
+        texture, 
+        [offset[0], offset[1], 0], 
+        [size[0], size[1], 1], 
+        0, 
+        1, 
+        0
+    ).unwrap()
+}
+
+fn gamma_srgb_to_linear(c: [f32; 4]) -> [f32; 4] {
+    fn component(f: f32) -> f32 {
+        // Taken from https://github.com/PistonDevelopers/graphics/src/color.rs#L42
+        if f <= 0.04045 {
+            f / 12.92
+        } else {
+            ((f + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    [component(c[0]), component(c[1]), component(c[2]), c[3]]
+}
+
+impl<'a> Iterator for Commands<'a> {
+    type Item = Command<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Commands { ref mut commands, ref vertices } = *self;
+        commands.next().map(|command| match *command {
+            PreparedCommand::Scizzor(scizzor) => Command::Scizzor(scizzor),
+            PreparedCommand::Plain(ref range) =>
+                Command::Draw(Draw::Plain(&vertices[range.clone()])),
+            PreparedCommand::Image(id, ref range) =>
+                Command::Draw(Draw::Image(id, &vertices[range.clone()])),
+        })
+    }
+}

--- a/conrod_core/src/text.rs
+++ b/conrod_core/src/text.rs
@@ -9,7 +9,7 @@ pub use rusttype::gpu_cache::Cache as GlyphCache;
 
 /// Re-exported RustType geometrical types.
 pub mod rt {
-    pub use rusttype::{Point, Rect, Vector, point, vector};
+    pub use rusttype::{Point, Rect, Vector, gpu_cache, point, vector};
 }
 
 


### PR DESCRIPTION
This rebases work by @Kurble and @Abendstolz onto #1223, ready to land a
working conrod vulkano backend once the crate split lands. I have made
some small tweaks to deduplicate some code and make the `conrod_vulkano`
crate a little more modular so that it does not require consuming the
`AutoCommandBufferBuilder`.

Merging blocked on #1223.

Closes #1052.