### PR TITLE
Trigger a redraw on focus

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -899,6 +899,7 @@ impl Ui {
 
             },
 
+            Input::Focus(focused) if focused == true => self.needs_redraw(),
             Input::Focus(_focused) => (),
 
             Input::Redraw => self.needs_redraw(),


### PR DESCRIPTION
I'm assuming this applies to window managers without compositing (I'm using i3wm), but this fixes a bug where tabbing into a different application and then back causes conrod's window to get "overwritten" by the previous application and become unusable until a redraw is triggered.

[video of what i mean](https://gfycat.com/SillyApprehensiveBarasinga)