### PR TITLE
Re-export `conrod_derive` macros.

### DIFF
--- a/conrod_core/src/lib.rs
+++ b/conrod_core/src/lib.rs
@@ -15,11 +15,8 @@ extern crate num;
 extern crate input as piston_input;
 extern crate rusttype;
 
-//#[cfg(feature="glium")] #[macro_use] pub extern crate glium;
-//#[cfg(feature="gfx_rs")] #[macro_use] pub extern crate gfx;
-//#[cfg(feature="gfx_rs")] pub extern crate gfx_core;
-
 pub use color::{Color, Colorable};
+pub use conrod_derive::*;
 pub use border::{Bordering, Borderable};
 pub use label::{FontSize, Labelable};
 pub use position::{Dimensions, Point, Position, Positionable, Range, Rect, Scalar, Sizeable};


### PR DESCRIPTION
This should remove the need to import `conrod_derive` into projects
where one is designing custom widgets.

This follows the convention set by `serde` and `serde_derive`.