### PR TITLE
Fix color space and GPU sync issues in `all_winit_vulkano.rs` example

### DIFF
--- a/backends/conrod_vulkano/examples/support/mod.rs
+++ b/backends/conrod_vulkano/examples/support/mod.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 use vulkano::{
     self,
     device::{Device, Queue},
+    format::Format,
     image::SwapchainImage,
     instance::{Instance, PhysicalDevice},
-    swapchain::{PresentMode, Surface, SurfaceTransform, Swapchain, SwapchainCreationError},
+    swapchain::{ColorSpace, PresentMode, Surface, SurfaceTransform, Swapchain, SwapchainCreationError},
 };
 
 use vulkano_win::{self, VkSurfaceBuild};
@@ -72,7 +73,12 @@ impl Window {
 
             let surface_dimensions = caps.current_extent.unwrap_or([width, height]);
             let alpha = caps.supported_composite_alpha.iter().next().unwrap();
-            let format = caps.supported_formats[0].0;
+            let format = caps.supported_formats
+                .iter()
+                .filter(|&&(fmt, cs)| format_is_srgb(fmt) && cs ==  ColorSpace::SrgbNonLinear)
+                .map(|&(fmt, _)| fmt)
+                .next()
+                .expect("failed to find sRGB format");
 
             (
                 Swapchain::new(
@@ -135,5 +141,41 @@ impl Window {
 
         self.swapchain = new_swapchain;
         self.images = new_images;
+    }
+}
+
+pub fn format_is_srgb(format: Format) -> bool {
+    use vulkano::format::Format::*;
+    match format {
+        R8Srgb |
+        R8G8Srgb |
+        R8G8B8Srgb |
+        B8G8R8Srgb |
+        R8G8B8A8Srgb |
+        B8G8R8A8Srgb |
+        A8B8G8R8SrgbPack32 |
+        BC1_RGBSrgbBlock |
+        BC1_RGBASrgbBlock |
+        BC2SrgbBlock |
+        BC3SrgbBlock |
+        BC7SrgbBlock |
+        ETC2_R8G8B8SrgbBlock |
+        ETC2_R8G8B8A1SrgbBlock |
+        ETC2_R8G8B8A8SrgbBlock |
+        ASTC_4x4SrgbBlock |
+        ASTC_5x4SrgbBlock |
+        ASTC_5x5SrgbBlock |
+        ASTC_6x5SrgbBlock |
+        ASTC_6x6SrgbBlock |
+        ASTC_8x5SrgbBlock |
+        ASTC_8x6SrgbBlock |
+        ASTC_8x8SrgbBlock |
+        ASTC_10x5SrgbBlock |
+        ASTC_10x6SrgbBlock |
+        ASTC_10x8SrgbBlock |
+        ASTC_10x10SrgbBlock |
+        ASTC_12x10SrgbBlock |
+        ASTC_12x12SrgbBlock => true,
+        _ => false,
     }
 }


### PR DESCRIPTION
This fixes an issue where the example would not always pick an sRGB
format and color space, even though this is what conrod requires.

Also fixes a bug on Mac where the CPU would out-pace the GPU by ensuring
that we wait for the previous frame presentation to complete before
presenting the next one.