### PR TITLE
Make Position::Relative(Relative::Place, None) work with an explicit parent

### DIFF
--- a/conrod_core/src/ui.rs
+++ b/conrod_core/src/ui.rs
@@ -940,6 +940,7 @@ impl Ui {
     /// should target a **Widget**'s `kid_area`, or simply the **Widget**'s total area.
     pub fn calc_xy(&self,
                    maybe_id: Option<widget::Id>,
+                   maybe_parent_id: Option<widget::Id>,
                    x_position: Position,
                    y_position: Position,
                    dim: Dimensions,
@@ -952,6 +953,7 @@ impl Ui {
         // The axis used is specified by the given range_from_rect function which, given some
         // **Rect**, returns the relevant **Range**.
         fn abs_from_position<R, P>(ui: &Ui,
+                                   maybe_parent_id: Option<widget::Id>,
                                    position: Position,
                                    dim: Scalar,
                                    place_on_kid_area: bool,
@@ -1003,6 +1005,7 @@ impl Ui {
 
                 position::Relative::Place(place) => {
                     let parent_id = maybe_id
+                        .or(maybe_parent_id)
                         .or(ui.maybe_current_parent_id)
                         .unwrap_or(ui.window.into());
                     let maybe_area = match place_on_kid_area {
@@ -1034,8 +1037,8 @@ impl Ui {
         fn y_range(rect: Rect) -> Range { rect.y }
         fn x_pad(pad: Padding) -> Range { pad.x }
         fn y_pad(pad: Padding) -> Range { pad.y }
-        let x = abs_from_position(self, x_position, dim[0], place_on_kid_area, x_range, x_pad);
-        let y = abs_from_position(self, y_position, dim[1], place_on_kid_area, y_range, y_pad);
+        let x = abs_from_position(self, maybe_parent_id, x_position, dim[0], place_on_kid_area, x_range, x_pad);
+        let y = abs_from_position(self, maybe_parent_id, y_position, dim[1], place_on_kid_area, y_range, y_pad);
         let xy = [x, y];
 
         // Add the widget's parents' total combined scroll offset to the given xy.

--- a/conrod_core/src/widget/mod.rs
+++ b/conrod_core/src/widget/mod.rs
@@ -980,7 +980,7 @@ fn set_widget<'a, 'b, W>(widget: W, id: Id, ui: &'a mut UiCell<'b>) -> W::Event
         // If there is no previous state to compare for dragging, return an initial state.
         //
         // A function for generating the xy coords from the given alignment and Position.
-        .unwrap_or_else(|| ui.calc_xy(Some(id), x_pos, y_pos, dim, place_on_kid_area));
+        .unwrap_or_else(|| ui.calc_xy(Some(id), maybe_parent_id, x_pos, y_pos, dim, place_on_kid_area));
 
     // Construct the rectangle describing our Widget's area.
     let rect = Rect::from_xy_dim(xy, dim);


### PR DESCRIPTION
When creating a new widget with a `Position::Relative(Relative::Place, None)` the widget should be placed on its parent. However, if the parent is specified with `Widget::parent()` this does not work because within `Widget::set_widget()` the position is calculated before `ui.maybe_current_parent_id` is updated. Instead, the previous widget's parent ends up being used to calculate the position. For example, this won't work:
```rust
Image::new(image_id)
    .w_h(w, h)
    .parent(parent_id)
    .mid_bottom()
    .set(id, ui_cell);
```
This changes `calc_xy()` to take the `maybe_parent_id` of the widget as an input and use it to properly determine the parent of the widget.

An alternative fix would be to add a function that allows updating `ui.maybe_current_parent_id`.