### PR TITLE
Changing the way dragging is handled

### DIFF
--- a/conrod_core/src/graph/mod.rs
+++ b/conrod_core/src/graph/mod.rs
@@ -4,7 +4,7 @@
 //! The primary type of interest in this module is the [**Graph**](./struct.Graph) type.
 
 use daggy;
-use position::{Axis, Depth, Rect};
+use position::{Axis, Depth, Point, Rect};
 use std;
 use std::any::Any;
 use std::ops::{Index, IndexMut};
@@ -79,6 +79,8 @@ pub struct Container {
     pub depth: Depth,
     /// The area in which child widgets are placed.
     pub kid_area: widget::KidArea,
+    /// If widget is draggable and is being dragged, this is where it started
+    pub maybe_dragged_from: Option<Point>,
     /// Whether or not the widget is a "Floating" widget.
     ///
     /// See the `Widget::float` docs for an explanation of what this means.
@@ -624,7 +626,7 @@ impl Graph {
     {
         let widget::PreUpdateCache {
             type_id, id, maybe_parent_id, maybe_x_positioned_relatively_id,
-            maybe_y_positioned_relatively_id, rect, depth, kid_area, maybe_floating,
+            maybe_y_positioned_relatively_id, rect, depth, kid_area, maybe_dragged_from, maybe_floating,
             crop_kids, maybe_x_scroll_state, maybe_y_scroll_state, maybe_graphics_for, is_over,
         } = widget;
 
@@ -637,6 +639,7 @@ impl Graph {
             rect: rect,
             depth: depth,
             kid_area: kid_area,
+            maybe_dragged_from: maybe_dragged_from,
             maybe_floating: maybe_floating,
             crop_kids: crop_kids,
             maybe_x_scroll_state: maybe_x_scroll_state,
@@ -689,6 +692,7 @@ impl Graph {
                 container.rect = rect;
                 container.depth = depth;
                 container.kid_area = kid_area;
+                container.maybe_dragged_from = maybe_dragged_from;
                 container.maybe_floating = maybe_floating;
                 container.crop_kids = crop_kids;
                 container.maybe_x_scroll_state = maybe_x_scroll_state;

--- a/conrod_core/src/widget/mod.rs
+++ b/conrod_core/src/widget/mod.rs
@@ -963,6 +963,9 @@ fn set_widget<'a, 'b, W>(widget: W, id: Id, ui: &'a mut UiCell<'b>) -> W::Event
     let (xy, maybe_dragged_from) = maybe_prev_common
         .as_ref()
         .and_then(|prev| {
+            if widget.common().maybe_graphics_for.is_some() {
+                return None;
+            }
             let maybe_drag_area = widget.drag_area(dim, &new_style, &ui.theme);
             maybe_drag_area.map(|drag_area| {
                 let mut current_dragged_from = prev.maybe_dragged_from;


### PR DESCRIPTION
Hi!

When trying to use Conrod for an experimental project, I started out with the "canvas" example. I noticed that dragging the floating canvases was a bit wrong. If I held one for a long time, moving the mouse all around quickly, the mouse could sometimes slide relative to the floating box, and it would let go of it if it slid completely off. (The "graph" example has a similar problem, but because that doesn't check a `drag_area`, you can keep holding a node even when the mouse cursor moves far away from it.)

I'm not sure where the difference comes in, but adding together the many `delta`s is less reliable than just taking the difference between the `origin` and `to` of the `drag`. But to use that I need to know where the widget started from, so I needed to add a new field to CommonState to help with that.

This version worked well for me, even when I slowed the test down to 1 FPS it did what I expected.