### PR TITLE
Fix a panic when using conrod targetting WASM

### DIFF
--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -17,6 +17,10 @@ categories = ["gui"]
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+stdweb = [ "instant/stdweb" ]
+wasm-bindgen = [ "instant/wasm-bindgen" ]
+
 [dependencies]
 conrod_derive = { path = "../conrod_derive", version = "0.63" }
 daggy = "0.5"
@@ -24,3 +28,4 @@ fnv = "1.0"
 num = "0.2"
 pistoncore-input = "0.24"
 rusttype = { version = "0.7", features = ["gpu_cache"] }
+instant = "0.1"

--- a/conrod_core/src/input/global.rs
+++ b/conrod_core/src/input/global.rs
@@ -20,7 +20,7 @@ pub struct Global {
     events: Vec<event::Event>,
     /// Tracks the last click that occurred and the time at which it occurred in order to create
     /// double-click events.
-    pub last_click: Option<(std::time::Instant, event::Click)>,
+    pub last_click: Option<(instant::Instant, event::Click)>,
 }
 
 /// Iterator over all global `event::Event`s that have occurred since the last time

--- a/conrod_core/src/input/state.rs
+++ b/conrod_core/src/input/state.rs
@@ -73,7 +73,7 @@ pub mod touch {
     #[derive(Copy, Clone, Debug, PartialEq)]
     pub struct Start {
         /// The time at which the `Touch` began.
-        pub time: std::time::Instant,
+        pub time: instant::Instant,
         /// The position at which the touch began.
         pub xy: Point,
         /// The widget under the beginning of the touch if there was one.

--- a/conrod_core/src/ui.rs
+++ b/conrod_core/src/ui.rs
@@ -515,7 +515,7 @@ impl Ui {
                         let click_event = event::Ui::Click(clicked_widget, click).into();
                         self.global_input.push_event(click_event);
 
-                        let now = std::time::Instant::now();
+                        let now = instant::Instant::now();
                         let double_click = self.global_input.last_click
                             .and_then(|(last_time, last_click)| {
 
@@ -811,7 +811,7 @@ impl Ui {
 
                     // The start of the touch interaction state to be stored.
                     let start = input::state::touch::Start {
-                        time: std::time::Instant::now(),
+                        time: instant::Instant::now(),
                         xy: touch.xy,
                         widget: widget_under_touch,
                     };

--- a/conrod_core/src/widget/mod.rs
+++ b/conrod_core/src/widget/mod.rs
@@ -189,7 +189,7 @@ impl MaybeParent {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Floating {
     /// The time the **Widget** was last clicked (used for depth sorting in the widget **Graph**).
-    pub time_last_clicked: std::time::Instant,
+    pub time_last_clicked: instant::Instant,
 }
 
 /// A struct containing builder data common to all **Widget** types.
@@ -1017,7 +1017,7 @@ fn set_widget<'a, 'b, W>(widget: W, id: Id, ui: &'a mut UiCell<'b>) -> W::Event
     let maybe_floating = if widget.common().is_floating {
 
         fn new_floating() -> Floating {
-            Floating { time_last_clicked: std::time::Instant::now() }
+            Floating { time_last_clicked: instant::Instant::now() }
         }
 
         // If it is floating, check to see if we need to update the last time it was clicked.


### PR DESCRIPTION
Hi!

I'm in the process of integrating `conrod_core` to my graphics engine [kiss3d](https://crates.io/crates/kiss3d). You can see the current result of this unfinished integration (after patching `conrod_core` with this PR) there: http://www.crozet.re/kiss3d_ui/

Currently, `conrod_core` is unusable when targeting WASM because it will cause a panic whenever the user presses a button. This is due to the call to `std::time::Instant::now()` which will panic on WASM because it requires a syscall. To fix this, I've created the [instant](https://crates.io/crates/instant) crate that provides the type `instant::Instant` which is:

- A type emulating the behavior of `std::time::Instant` using the javascript function `performance.now()` when compiling for WASM **and** when its feature `stdweb` or its feature `wasm-bindgen` is activates.
- A type alias for `std::time::Instant` otherwise.

I don't know if this is wanted here, but this PR replaces all occurrences of `std::time::Instant` by `instant::Instant` and adds the two features `stdweb` and `wasm-bindgen` to enable the corresponding features of the `instant` crate transitively. This allows the use of `conrod` without panic when targeting WASM.

Note that this is not a breaking change because for all existing users the `instant::Instant` type will just be a type alias for `std::time::Instant`.

This PR is related to #1118.