### PR TITLE
Fix incorrectly scaled text when there is a non integer dpi_factor

### DIFF
--- a/conrod_core/src/render.rs
+++ b/conrod_core/src/render.rs
@@ -271,7 +271,7 @@ impl<'a> Text<'a> {
 
         // Clear the existing glyphs and fill the buffer with glyphs for this Text.
         positioned_glyphs.clear();
-        let scale = text::pt_to_scale((font_size as f32 * dpi_factor) as FontSize);
+        let scale = text::f32_pt_to_scale(font_size as f32 * dpi_factor);
         for (line, line_rect) in lines.zip(line_rects) {
             let (x, y) = (trans_x(line_rect.left()) as f32, trans_y(line_rect.bottom()) as f32);
             let point = text::rt::Point { x: x, y: y };

--- a/conrod_core/src/text.rs
+++ b/conrod_core/src/text.rs
@@ -68,8 +68,20 @@ pub fn lines<I>(text: &str, ranges: I) -> Lines<I>
 
 
 /// Converts the given font size in "points" to its font size in pixels.
+/// This is useful for when the font size is not an integer.
+pub fn f32_pt_to_px(font_size_in_points: f32) -> f32 {
+    font_size_in_points * 4.0 / 3.0
+}
+
+/// Converts the given font size in "points" to a uniform `rusttype::Scale`.
+/// This is useful for when the font size is not an integer.
+pub fn f32_pt_to_scale(font_size_in_points: f32) -> Scale {
+    Scale::uniform(f32_pt_to_px(font_size_in_points))
+}
+
+/// Converts the given font size in "points" to its font size in pixels.
 pub fn pt_to_px(font_size_in_points: FontSize) -> f32 {
-    (font_size_in_points * 4) as f32 / 3.0
+    f32_pt_to_px(font_size_in_points as f32)
 }
 
 /// Converts the given font size in "points" to a uniform `rusttype::Scale`.


### PR DESCRIPTION
fixes #1265
If there is better/more preferred solution for this, I would be happy to implement it.