### PR TITLE
Minimal fix for list cropping problem

### DIFF
--- a/backends/conrod_piston/src/draw.rs
+++ b/backends/conrod_piston/src/draw.rs
@@ -289,8 +289,5 @@ fn crop_context(context: Context, rect: Rect) -> Context {
         }
     }
 
-    // The y coordinate is backwards, min to prevent overflow
-    let y = draw_dim[1] as u32 - (y+h).min(draw_dim[1] as u32);
-
     Context { draw_state: draw_state.scissor([x, y, w, h]), ..context }
 }


### PR DESCRIPTION
This fixes a problem where a scrollable canvas gets strangely cropped when inside another scrollable region.
This also applies to List, ListSelect and DropDownList.
To demonstrate the problem I've added a scrollable canvas and a List to the all_piston_window example on this commit:
tdaffin@b84ae50

I think that this will fix https://github.com/PistonDevelopers/conrod/issues/955
