### PR TITLE
Update `winit`, `vulkano` and `vulkano-*` dependencies for `conrod_vulkano` backend.

### DIFF
--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2018"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.64" }
-vulkano = { git = "https://github.com/vulkano-rs/vulkano", branch = "master" }
-vulkano-shaders = { git = "https://github.com/vulkano-rs/vulkano", branch = "master" }
+vulkano = "0.12"
+vulkano-shaders = "0.12"
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.64" }
 conrod_winit = { path = "../conrod_winit", version = "0.64" }
 find_folder = "0.3"
 image = "0.21"
-vulkano-win = { git = "https://github.com/vulkano-rs/vulkano", branch = "master" }
+vulkano-win = "0.12"
 winit = "0.19"

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2018"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.64" }
-vulkano = "0.11"
-vulkano-shaders = "0.11"
+vulkano = { git = "https://github.com/vulkano-rs/vulkano", branch = "master" }
+vulkano-shaders = { git = "https://github.com/vulkano-rs/vulkano", branch = "master" }
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.64" }
 conrod_winit = { path = "../conrod_winit", version = "0.64" }
 find_folder = "0.3"
 image = "0.21"
-vulkano-win = "0.11"
-winit = "0.18"
+vulkano-win = { git = "https://github.com/vulkano-rs/vulkano", branch = "master" }
+winit = "0.19"


### PR DESCRIPTION
Version `0.12.0` of vulkano has just been published, including an update to use version `0.19` of winit.

This PR updates these dependency versions in conrod's vulkano backend.