### PR TITLE
Update glium dependencies

### DIFF
--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -17,7 +17,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.65" }
-glium = { version = "0.23" }
+glium = { version = "0.24" }
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.65" }
@@ -26,4 +26,4 @@ find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"
 rand = "0.6"
-winit = "0.18"
+winit = "0.19"


### PR DESCRIPTION
Update the dependencies of the `conrod_glium` backend to fix #1281.
Since [`glium 0.24`](https://github.com/glium/glium/blob/master/CHANGELOG.md#version-0240-2019-04-08) and [`winit 0.19`](https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#version-0190-2019-03-06) have some breaking changes, this could break some other stuff.