### PR TITLE
Update conrod_vulkano to vulkano version 0.13

### DIFF
--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -18,13 +18,13 @@ edition = "2018"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.65" }
-vulkano = "0.12"
-vulkano-shaders = "0.12"
+vulkano = "0.13"
+vulkano-shaders = "0.13"
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.65" }
 conrod_winit = { path = "../conrod_winit", version = "0.65" }
 find_folder = "0.3"
 image = "0.21"
-vulkano-win = "0.12"
+vulkano-win = "0.13"
 winit = "0.19"

--- a/backends/conrod_vulkano/src/lib.rs
+++ b/backends/conrod_vulkano/src/lib.rs
@@ -138,7 +138,7 @@ void main() {
 }
 
 /// The `Vertex` type passed to the vertex shader.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Vertex {
     /// The position of the vertex within vector space.
     ///


### PR DESCRIPTION
This fixes a UB related bug. See vulkano-rs/vulkano#1212 for more
details.

Unfortunately the fix for this requires that vulkano `Vertex` types
implement `Default`, meaning this is a breaking change, albeit a slight
one.