### PR TITLE
Update shaderc dep in conrod_vulkano. Update gfx deps. Publish 0.67.

### DIFF
--- a/backends/conrod_example_shared/Cargo.toml
+++ b/backends/conrod_example_shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_example_shared"
-version = "0.66.0"
+version = "0.67.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "A small crate for sharing common code between conrod examples."
@@ -12,5 +12,5 @@ documentation = "http://docs.rs/conrod"
 categories = ["gui"]
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.66" }
+conrod_core = { path = "../../conrod_core", version = "0.67" }
 rand = "0.6"

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -17,8 +17,8 @@ path = "./src/lib.rs"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.67" }
-gfx = { version = "0.17" }
-gfx_core = { version = "0.8" }
+gfx = { version = "0.18" }
+gfx_core = { version = "0.9" }
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
@@ -27,6 +27,6 @@ find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"
 ## glutin_gfx.rs example dependencies
-gfx_window_glutin = "0.28"
-glutin = "0.19"
-winit = "0.18"
+gfx_window_glutin = "0.31"
+glutin = "0.21"
+winit = "0.19"

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_gfx"
-version = "0.66.0"
+version = "0.67.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -16,13 +16,13 @@ name = "conrod_gfx"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.66" }
+conrod_core = { path = "../../conrod_core", version = "0.67" }
 gfx = { version = "0.17" }
 gfx_core = { version = "0.8" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.66" }
-conrod_winit = { path = "../conrod_winit", version = "0.66" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
+conrod_winit = { path = "../conrod_winit", version = "0.67" }
 find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_glium"
-version = "0.66.0"
+version = "0.67.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -16,12 +16,12 @@ name = "conrod_glium"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.66" }
+conrod_core = { path = "../../conrod_core", version = "0.67" }
 glium = { version = "0.24" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.66" }
-conrod_winit = { path = "../conrod_winit", version = "0.66" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
+conrod_winit = { path = "../conrod_winit", version = "0.67" }
 find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"

--- a/backends/conrod_piston/Cargo.toml
+++ b/backends/conrod_piston/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_piston"
-version = "0.66.0"
+version = "0.67.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,12 +22,12 @@ name = "conrod_piston"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.66" }
+conrod_core = { path = "../../conrod_core", version = "0.67" }
 piston2d-graphics = { version = "0.30" }
 pistoncore-input = "0.24.0"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.66" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
 find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_vulkano"
-version = "0.66.0"
+version = "0.67.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "Kurble",
@@ -17,14 +17,14 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.66" }
-vulkano = "0.13"
-vulkano-shaders = "0.13"
+conrod_core = { path = "../../conrod_core", version = "0.67" }
+vulkano = "0.14"
+vulkano-shaders = "0.14"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.66" }
-conrod_winit = { path = "../conrod_winit", version = "0.66" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
+conrod_winit = { path = "../conrod_winit", version = "0.67" }
 find_folder = "0.3"
 image = "0.21"
-vulkano-win = "0.13"
+vulkano-win = "0.14"
 winit = "0.19"

--- a/backends/conrod_winit/Cargo.toml
+++ b/backends/conrod_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_winit"
-version = "0.66.0"
+version = "0.67.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_core"
-version = "0.66.0"
+version = "0.67.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,7 +22,7 @@ stdweb = [ "instant/stdweb" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 
 [dependencies]
-conrod_derive = { path = "../conrod_derive", version = "0.66" }
+conrod_derive = { path = "../conrod_derive", version = "0.67" }
 daggy = "0.5"
 fnv = "1.0"
 num = "0.2"

--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_derive"
-version = "0.66.0"
+version = "0.67.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A crate providing procedural macros for the conrod library"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This is kind of a late, emergency release to fix an issue where users of
some Linux distros (Arch, Void, possibly others) cannot currently build
conrod_vulkano due to a bug in the shaderc 0.5.1 build script.
google/shaderc-rs#58.

Edit: Travis was showing a build error on the nightly build of an older
dependency. The gfx deps have been updated as an attempt to fix this.