### PR TITLE
Make delta_xy of Drag events add up to total_delta_xy

### DIFF
--- a/conrod_core/src/ui.rs
+++ b/conrod_core/src/ui.rs
@@ -636,21 +636,25 @@ impl Ui {
                         let last_mouse_xy = self.global_input.current.mouse.xy;
                         let mouse_xy = [x, y];
                         let delta_xy = utils::vec2_sub(mouse_xy, last_mouse_xy);
-                        let distance = (delta_xy[0] + delta_xy[1]).abs().sqrt();
-                        if distance > self.theme.mouse_drag_threshold {
-                            // For each button that is down, trigger a drag event.
-                            let buttons = self.global_input.current.mouse.buttons.clone();
-                            for (btn, btn_xy, widget) in buttons.pressed() {
-                                let total_delta_xy = utils::vec2_sub(mouse_xy, btn_xy);
-                                let event = event::Ui::Drag(widget, event::Drag {
-                                    button: btn,
-                                    origin: btn_xy,
-                                    from: last_mouse_xy,
-                                    to: mouse_xy,
-                                    delta_xy: delta_xy,
-                                    total_delta_xy: total_delta_xy,
-                                    modifiers: self.global_input.current.modifiers,
-                                }).into();
+                        // For each button that is down, trigger a drag event.
+                        let buttons = self.global_input.current.mouse.buttons.clone();
+                        for (btn, btn_xy, widget) in buttons.pressed() {
+                            let total_delta_xy = utils::vec2_sub(mouse_xy, btn_xy);
+                            let distance = (total_delta_xy[0] + total_delta_xy[1]).abs().sqrt();
+                            if distance > self.theme.mouse_drag_threshold {
+                                let event = event::Ui::Drag(
+                                    widget,
+                                    event::Drag {
+                                        button: btn,
+                                        origin: btn_xy,
+                                        from: last_mouse_xy,
+                                        to: mouse_xy,
+                                        delta_xy: delta_xy,
+                                        total_delta_xy: total_delta_xy,
+                                        modifiers: self.global_input.current.modifiers,
+                                    },
+                                )
+                                .into();
                                 self.global_input.push_event(event);
                             }
                         }


### PR DESCRIPTION
With high frame rates, slow mouse movement or high drag thresholds,
Ui::handle_event omits any Drag events whose delta_xy would be below the
threshold. That causes the sum of all delta_xy of sequential Drag events not
to add up to total_delta_xy.

The solution implemented here is to compare total_distance_xy instead of
delta_xy against the threshold. This is admittedly not ideal. A better
solution would be to set a flag when the first movement exceeds the threshold,
then generate Drag events as long as the flag is set. Once the mouse button
is released, reset the flag to stop generating Drag events.