### PR TITLE
Double click select word

### DIFF
--- a/conrod_core/src/widget/text_edit.rs
+++ b/conrod_core/src/widget/text_edit.rs
@@ -443,14 +443,7 @@ impl<'a> Widget for TextEdit<'a> {
                         let font = ui.fonts.get(font_id).unwrap();
                         let closest = closest_cursor_index_and_xy(abs_xy, &text, infos, font);
 
-                        if let Some((closest_cursor, _)) = closest {
-                            cursor = Cursor::Idx(closest_cursor);
-
-                            let (_, cursor_idx) = match cursor {
-                                Cursor::Idx(idx) => (idx, idx),
-                                Cursor::Selection { start, end } => (start, end),
-                            };
-
+                        if let Some((cursor_idx, _)) = closest {
                             let line_infos = state.line_infos.iter().cloned();
 
                             let (start, end) = (

--- a/conrod_core/src/widget/text_edit.rs
+++ b/conrod_core/src/widget/text_edit.rs
@@ -447,8 +447,10 @@ impl<'a> Widget for TextEdit<'a> {
                             let line_infos = state.line_infos.iter().cloned();
 
                             let (start, end) = (
-                                cursor_idx.previous_word_start(&text, line_infos.clone()).unwrap(),
-                                cursor_idx.next_word_end(&text, line_infos).unwrap(),
+                                cursor_idx.previous_word_start(&text, line_infos.clone())
+                                    .unwrap_or(cursor_idx), // account for the first position of the text
+                                cursor_idx.next_word_end(&text, line_infos)
+                                    .unwrap_or(cursor_idx), // account for the last position of the text
                             );
 
                             cursor = Cursor::Selection {


### PR DESCRIPTION
Adds the ability to select a word by double clicking on it in a TextEdit widget.

Double clicking on a space between words selects the two adjoining words as defined in this ticket:

https://github.com/PistonDevelopers/conrod/issues/71#issuecomment-52115050