### PR TITLE
Initial implementation of shift+LMB click to select a text range.

### DIFF
--- a/conrod_core/src/widget/text_edit.rs
+++ b/conrod_core/src/widget/text_edit.rs
@@ -444,8 +444,22 @@ impl<'a> Widget for TextEdit<'a> {
                         let infos = &state.line_infos;
                         let font = ui.fonts.get(font_id).unwrap();
                         let closest = closest_cursor_index_and_xy(abs_xy, &text, infos, font);
+
                         if let Some((closest_cursor, _)) = closest {
-                            cursor = Cursor::Idx(closest_cursor);
+                            // We may be handling a range selection if the SHIFT key is held while left clicking
+                            if press.modifiers.contains(input::keyboard::ModifierKey::SHIFT) {
+                                let (old_selection_start, _) = match cursor {
+                                    Cursor::Idx(idx) => (idx, idx),
+                                    Cursor::Selection { start, end } => (start, end),
+                                };
+
+                                cursor = Cursor::Selection {
+                                    start: old_selection_start,
+                                    end: closest_cursor,
+                                };
+                            } else {
+                                cursor = Cursor::Idx(closest_cursor);
+                            }
                         }
 
                         // TODO: Differentiate between Selecting and MoveSelection.


### PR DESCRIPTION
This works forwards and backwards, with an initial selection or single cursor index.

Ref: https://github.com/PistonDevelopers/conrod/issues/71#issuecomment-52115050