### PR TITLE
Update documentation link in Cargo config as the current URL is a 404.

### DIFF
--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = https://docs.rs/conrod_core/latest"
+documentation = "https://docs.rs/conrod_core/latest"
 categories = ["gui"]
 
 [package.metadata.docs.rs]

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "http://docs.piston.rs/conrod/conrod/"
+documentation = "http://docs.piston.rs/conrod/conrod_core/"
 categories = ["gui"]
 
 [package.metadata.docs.rs]

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "http://docs.piston.rs/conrod/conrod_core/"
+documentation = https://docs.rs/conrod_core/latest"
 categories = ["gui"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Fixes #1306 