### PR TITLE
Remove references to the image_map! macro which no longer exists.

### DIFF
--- a/backends/conrod_glium/examples/image.rs
+++ b/backends/conrod_glium/examples/image.rs
@@ -41,7 +41,6 @@ fn main() {
     let ids = Ids::new(ui.widget_id_generator());
 
     // Create our `conrod_core::image::Map` which describes each of our widget->image mappings.
-    // In our case we only have one image, however the macro may be used to list multiple.
     let rust_logo = load_rust_logo(&display.0);
     let (w, h) = (rust_logo.get_width(), rust_logo.get_height().unwrap());
     let mut image_map = conrod_core::image::Map::new();

--- a/backends/conrod_glium/examples/image_button.rs
+++ b/backends/conrod_glium/examples/image_button.rs
@@ -52,7 +52,6 @@ fn main() {
     let ids = Ids::new(ui.widget_id_generator());
 
     // Create our `conrod_core::image::Map` which describes each of our widget->image mappings.
-    // In our case we only have one image, however the macro may be used to list multiple.
     let mut image_map = conrod_core::image::Map::new();
 
     struct ImageIds {

--- a/backends/conrod_piston/examples/all_piston_window.rs
+++ b/backends/conrod_piston/examples/all_piston_window.rs
@@ -66,7 +66,6 @@ pub fn main() {
     };
 
     // Create our `conrod_core::image::Map` which describes each of our widget->image mappings.
-    // In our case we only have one image, however the macro may be used to list multiple.
     let mut image_map = conrod_core::image::Map::new();
     let rust_logo = image_map.insert(rust_logo);
 

--- a/conrod_core/src/image.rs
+++ b/conrod_core/src/image.rs
@@ -16,15 +16,7 @@ pub struct Id(u32);
 /// A type used to map the `widget::Id` of `Image` widgets to their associated `Img` data.
 ///
 /// The `image::Map` type is usually instantiated and loaded during the "setup" stage of the
-/// application before the main loop begins. A macro is provided to simplify the construction of
-/// maps with multiple images.
-///
-/// ```ignore
-/// let image_map = image_map! {
-///     (RUST_LOGO, image::open("rust-logo.png")?),
-///     (CAT_PIC, image::open("floof.jpeg")?),
-/// };
-/// ```
+/// application before the main loop begins.
 pub struct Map<Img> {
     next_index: u32,
     map: HashMap<Img>,


### PR DESCRIPTION
Fixes #1192 