### PR TITLE
Publish version 0.68 - text features and vulkano 0.16 update

### DIFF
--- a/backends/conrod_example_shared/Cargo.toml
+++ b/backends/conrod_example_shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_example_shared"
-version = "0.67.0"
+version = "0.68.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "A small crate for sharing common code between conrod examples."
@@ -12,5 +12,5 @@ documentation = "http://docs.rs/conrod"
 categories = ["gui"]
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.67" }
+conrod_core = { path = "../../conrod_core", version = "0.68" }
 rand = "0.6"

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_gfx"
-version = "0.67.0"
+version = "0.68.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -16,13 +16,13 @@ name = "conrod_gfx"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.67" }
+conrod_core = { path = "../../conrod_core", version = "0.68" }
 gfx = { version = "0.18" }
 gfx_core = { version = "0.9" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
-conrod_winit = { path = "../conrod_winit", version = "0.67" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
+conrod_winit = { path = "../conrod_winit", version = "0.68" }
 find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_glium"
-version = "0.67.0"
+version = "0.68.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -16,12 +16,12 @@ name = "conrod_glium"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.67" }
+conrod_core = { path = "../../conrod_core", version = "0.68" }
 glium = { version = "0.24" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
-conrod_winit = { path = "../conrod_winit", version = "0.67" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
+conrod_winit = { path = "../conrod_winit", version = "0.68" }
 find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"

--- a/backends/conrod_piston/Cargo.toml
+++ b/backends/conrod_piston/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_piston"
-version = "0.67.0"
+version = "0.68.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,12 +22,12 @@ name = "conrod_piston"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.67" }
+conrod_core = { path = "../../conrod_core", version = "0.68" }
 piston2d-graphics = { version = "0.30" }
 pistoncore-input = "0.24.0"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
 find_folder = "0.3.0"
 image = "0.21"
 petgraph = "0.4"

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_vulkano"
-version = "0.67.0"
+version = "0.68.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "Kurble",
@@ -17,13 +17,13 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.67" }
+conrod_core = { path = "../../conrod_core", version = "0.68" }
 vulkano = "0.16"
 vulkano-shaders = "0.16"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.67" }
-conrod_winit = { path = "../conrod_winit", version = "0.67" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
+conrod_winit = { path = "../conrod_winit", version = "0.68" }
 find_folder = "0.3"
 image = "0.21"
 vulkano-win = "0.16"

--- a/backends/conrod_winit/Cargo.toml
+++ b/backends/conrod_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_winit"
-version = "0.67.0"
+version = "0.68.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_core"
-version = "0.67.0"
+version = "0.68.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,7 +22,7 @@ stdweb = [ "instant/stdweb" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 
 [dependencies]
-conrod_derive = { path = "../conrod_derive", version = "0.67" }
+conrod_derive = { path = "../conrod_derive", version = "0.68" }
 daggy = "0.5"
 fnv = "1.0"
 num = "0.2"

--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_derive"
-version = "0.67.0"
+version = "0.68.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A crate providing procedural macros for the conrod library"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This release mostly features the awesome work of @shanehandley!

- `TextEdit` now supports copy/paste with the system clipboard #1308
- `TextEdit` now suports double-click to select word #1309
- `TextEdit` now supports shit+LMB to select a range #1310

Also includes an update of `conrod_vulkano`'s `vulkano` dependency in
order to address an issue where some users on the latest macOS could not
build `metal` 0.13.