### PR TITLE
Publish 0.69 - rendy and wgpu backends.

### DIFF
--- a/backends/conrod_example_shared/Cargo.toml
+++ b/backends/conrod_example_shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_example_shared"
-version = "0.68.0"
+version = "0.69.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "A small crate for sharing common code between conrod examples."
@@ -12,5 +12,5 @@ documentation = "http://docs.rs/conrod"
 categories = ["gui"]
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 rand = "0.7"

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_gfx"
-version = "0.68.0"
+version = "0.69.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -16,13 +16,13 @@ name = "conrod_gfx"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 gfx = { version = "0.18" }
 gfx_core = { version = "0.9" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
-conrod_winit = { path = "../conrod_winit", version = "0.68" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.69" }
+conrod_winit = { path = "../conrod_winit", version = "0.69" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_glium"
-version = "0.68.0"
+version = "0.69.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -16,12 +16,12 @@ name = "conrod_glium"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 glium = "0.24"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
-conrod_winit = { path = "../conrod_winit", version = "0.68" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.69" }
+conrod_winit = { path = "../conrod_winit", version = "0.69" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_piston/Cargo.toml
+++ b/backends/conrod_piston/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_piston"
-version = "0.68.0"
+version = "0.69.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,12 +22,12 @@ name = "conrod_piston"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 piston2d-graphics = { version = "0.30" }
 pistoncore-input = "0.24.0"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.69" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["David Partouche <david@kaligs.com>"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 lazy_static = "1.4.0"
 rendy = { version = "0.5.1", default-features = false, features = ["base", "texture"] }
 
@@ -20,8 +20,8 @@ no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 profiler = ["rendy/profiler"]
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
-conrod_winit = { path = "../conrod_winit", version = "0.68" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.69" }
+conrod_winit = { path = "../conrod_winit", version = "0.69" }
 find_folder = "0.3.0"
 image = "0.22"
 

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -1,7 +1,18 @@
 [package]
 name = "conrod_rendy"
 version = "0.1.0"
-authors = ["David Partouche <david@kaligs.com>"]
+authors = [
+    "David Partouche <david@kaligs.com>",
+    "mitchmindtree <mitchell.nordine@gmail.com>",
+]
+keywords = ["ui", "widgets", "gui", "interface", "graphics"]
+description = "A rendy backend for conrod."
+license = "MIT OR Apache-2.0"
+readme = "../../README.md"
+repository = "https://github.com/pistondevelopers/conrod.git"
+homepage = "https://github.com/pistondevelopers/conrod"
+documentation = "https://docs.rs/conrod"
+categories = ["gui"]
 edition = "2018"
 
 [dependencies]

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_vulkano"
-version = "0.68.0"
+version = "0.69.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "Kurble",
@@ -17,13 +17,13 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 vulkano = "0.16"
 vulkano-shaders = "0.16"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
-conrod_winit = { path = "../conrod_winit", version = "0.68" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.69" }
+conrod_winit = { path = "../conrod_winit", version = "0.69" }
 find_folder = "0.3"
 image = "0.22"
 vulkano-win = "0.16"

--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_wgpu"
-version = "0.68.0"
+version = "0.69.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
 ]
@@ -15,12 +15,12 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.68" }
+conrod_core = { path = "../../conrod_core", version = "0.69" }
 wgpu = "0.4"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.68" }
-conrod_winit = { path = "../conrod_winit", version = "0.68" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.69" }
+conrod_winit = { path = "../conrod_winit", version = "0.69" }
 find_folder = "0.3"
 image = "0.23"
 winit = "0.21"

--- a/backends/conrod_winit/Cargo.toml
+++ b/backends/conrod_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_winit"
-version = "0.68.0"
+version = "0.69.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_core"
-version = "0.68.0"
+version = "0.69.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -22,7 +22,7 @@ stdweb = [ "instant/stdweb" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 
 [dependencies]
-conrod_derive = { path = "../conrod_derive", version = "0.68" }
+conrod_derive = { path = "../conrod_derive", version = "0.69" }
 daggy = "0.5"
 fnv = "1.0"
 num = "0.2"

--- a/conrod_core/src/graph/mod.rs
+++ b/conrod_core/src/graph/mod.rs
@@ -68,7 +68,7 @@ pub struct UniqueWidgetState<State, Style> where
 #[derive(Debug)]
 pub struct Container {
     /// Dynamically stored widget state.
-    pub maybe_state: Option<Box<Any + Send>>,
+    pub maybe_state: Option<Box<dyn Any + Send>>,
     /// The unique `TypeId` associated with the `Widget::State`.
     ///
     /// This is equal to `std::any::TypeId::of::<Widget::State>()`.

--- a/conrod_core/src/text.rs
+++ b/conrod_core/src/text.rs
@@ -251,20 +251,21 @@ pub mod font {
     }
 
     impl std::error::Error for Error {
-        fn description(&self) -> &str {
+        fn cause(&self) -> Option<&dyn std::error::Error> {
             match *self {
-                Error::IO(ref e) => std::error::Error::description(e),
-                Error::NoFont => "No `Font` found in the loaded `FontCollection`.",
+                Error::IO(ref e) => Some(e),
+                _ => None,
             }
         }
     }
 
     impl std::fmt::Display for Error {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-            match *self {
-                Error::IO(ref e) => std::fmt::Display::fmt(e, f),
-                _ => write!(f, "{}", std::error::Error::description(self))
-            }
+            let s = match *self {
+                Error::IO(ref e) => return std::fmt::Display::fmt(e, f),
+                Error::NoFont => "No `Font` found in the loaded `FontCollection`.",
+            };
+            write!(f, "{}", s)
         }
     }
 

--- a/conrod_core/src/theme.rs
+++ b/conrod_core/src/theme.rs
@@ -60,7 +60,7 @@ pub struct Theme {
 #[derive(Debug)]
 pub struct WidgetDefault {
     /// The unique style of a widget.
-    pub style: Box<Any + Send>,
+    pub style: Box<dyn Any + Send>,
     /// The attributes commonly shared between widgets.
     pub common: widget::CommonStyle,
 }
@@ -76,7 +76,7 @@ pub struct UniqueDefault<'a, T: 'a> {
 
 impl WidgetDefault {
     /// Constructor for a WidgetDefault.
-    pub fn new(style: Box<Any + Send>) -> WidgetDefault {
+    pub fn new(style: Box<dyn Any + Send>) -> WidgetDefault {
         WidgetDefault {
             style: style,
             common: widget::CommonStyle::default(),

--- a/conrod_core/src/widget/number_dialer.rs
+++ b/conrod_core/src/widget/number_dialer.rs
@@ -243,7 +243,7 @@ impl<'a, T> Widget for NumberDialer<'a, T>
         // - If a value has been `Press`ed and is being dragged.
         // - `Drag`ging of the mouse while a button is pressed.
         // - `Scroll`ing of the mouse over a value.
-        'events: for widget_event in ui.widget_input(id).events() {
+        for widget_event in ui.widget_input(id).events() {
             use event;
             use input::{self, MouseButton};
 

--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_derive"
-version = "0.68.0"
+version = "0.69.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A crate providing procedural macros for the conrod library"
 license = "MIT OR Apache-2.0"

--- a/conrod_derive/src/common.rs
+++ b/conrod_derive/src/common.rs
@@ -131,9 +131,11 @@ enum Error {
     NoCommonBuilderField,
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s = match *self {
             Error::NotStruct =>
                 "#[derive(WidgetCommon)] is only defined for structs",
             Error::TupleStruct =>
@@ -148,12 +150,7 @@ impl std::error::Error for Error {
                 "`#[derive(WidgetCommon)]` requires a struct with one field of type \
                  `conrod::widget::CommonBuilder` that has the `#[conrod(common_builder)]` \
                  attribute",
-        }
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", std::error::Error::description(self))
+        };
+        write!(f, "{}", s)
     }
 }

--- a/conrod_derive/src/style.rs
+++ b/conrod_derive/src/style.rs
@@ -211,9 +211,11 @@ enum Error {
     NonOptionFieldTy,
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s = match *self {
             Error::NotStruct =>
                 "`#[derive(WidgetStyle)]` is only defined for structs",
             Error::TupleStruct =>
@@ -228,12 +230,7 @@ impl std::error::Error for Error {
                 "Cannot use #[conrod(default = \"foo\")] attribute on unnamed fields",
             Error::NonOptionFieldTy =>
                 "Cannot use #[conrod(default = \"foo\")] attribute on non-`Option` fields"
-        }
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", std::error::Error::description(self))
+        };
+        write!(f, "{}", s)
     }
 }


### PR DESCRIPTION
This version adds two new backends!

- `conrod_rendy` providing a custom graphics pipeline for rendering UIs.
  #1323.
- `conrod_wgpu` for encoding UI rendering to a given command encoder.
  #1331.

Also includes some other changes:

- A `Display` trait has been added to `conrod_glium` to allow for
  non-`glutin` opengl context displays. #1332.
- Adds a `ui.has_changed()` method, useful for indicating whether or not
  `ui.draw_if_changed()` would return `Some` or `None`. #1324.
- Updates some dependencies across all backends #1321.

This PR also fixes some warnings introduced on recent versions of rustc
within the `conrod_derive` and `conrod_core` crates.