### PR TITLE
Make winit conversion functions generic over UserEvent

### DIFF
--- a/backends/conrod_winit/src/v020.rs
+++ b/backends/conrod_winit/src/v020.rs
@@ -335,8 +335,8 @@ macro_rules! v020_conversion_fns {
         }
 
         /// A function for converting a `winit::Event` to a `conrod_core::event::Input`.
-        pub fn convert_event(
-            event: winit::event::Event<()>,
+        pub fn convert_event<T>(
+            event: winit::event::Event<T>,
             window: &winit::window::Window,
         ) -> Option<conrod_core::event::Input> {
             $crate::v020_convert_event!(event, window)

--- a/backends/conrod_winit/src/v021.rs
+++ b/backends/conrod_winit/src/v021.rs
@@ -334,8 +334,8 @@ macro_rules! v021_conversion_fns {
         }
 
         /// A function for converting a `winit::Event` to a `conrod_core::event::Input`.
-        pub fn convert_event(
-            event: &winit::event::Event<()>,
+        pub fn convert_event<T>(
+            event: &winit::event::Event<T>,
             window: &winit::window::Window,
         ) -> Option<conrod_core::event::Input> {
             $crate::v021_convert_event!(event, window)


### PR DESCRIPTION
this makes it possible to use custom user event types with the winit
event loop.