### PR TITLE
Fix scrollbar handle snapping when clicking on track

### DIFF
--- a/conrod_core/src/widget/scrollbar.rs
+++ b/conrod_core/src/widget/scrollbar.rs
@@ -219,7 +219,7 @@ impl<A> Widget for Scrollbar<A>
                         if rect.is_over(abs_xy) && !handle_rect.is_over(abs_xy) {
                             let handle_pos_range_len = handle_pos_range_len();
                             let offset_range_len = offset_bounds.len();
-                            let mouse_scalar = A::mouse_scalar(xy);
+                            let mouse_scalar = A::mouse_scalar(abs_xy);
                             let pos_offset = mouse_scalar - handle_range.middle();
                             let offset = utils::map_range(pos_offset,
                                                           0.0, handle_pos_range_len,


### PR DESCRIPTION
Fix the behaviour of the scrollbar handle when clicking on the track for scrollbars that doesn't start from the window edge.

**Steps to verify:**

Apply the following patch and run the `all_winit_glium` example, then click on the scrollbar track.

Without this fix, the handle will snap to the wrong position.

```patch
diff --git a/backends/conrod_example_shared/src/lib.rs b/backends/conrod_example_shared/src/lib.rs
index 4e4ec77..c2c304e 100644
--- a/backends/conrod_example_shared/src/lib.rs
+++ b/backends/conrod_example_shared/src/lib.rs
@@ -116,6 +116,8 @@ pub fn gui(ui: &mut conrod_core::UiCell, ids: &Ids, app: &mut DemoApp) {
     const TITLE: &'static str = "All Widgets";
     widget::Canvas::new()
         .pad(MARGIN)
+        .align_bottom()
+        .h(300.0)
         .scroll_kids_vertically()
         .set(ids.canvas, ui);
 
```