### PR TITLE
Proof-of-concept resizeable floating window

### DIFF
--- a/backends/conrod_glium/examples/canvas.rs
+++ b/backends/conrod_glium/examples/canvas.rs
@@ -77,6 +77,10 @@ fn main() {
         // Instantiate all widgets in the GUI.
         set_widgets(ui.set_widgets(), ids);
 
+        // Get the underlying winit window and update the mouse cursor as set by conrod.
+        display.0.gl_window().window()
+            .set_cursor(support::convert_mouse_cursor(ui.mouse_cursor()));
+
         // Render the `Ui` and then display it on the screen.
         if let Some(primitives) = ui.draw_if_changed() {
             renderer.fill(&display.0, primitives, &image_map);
@@ -110,6 +114,14 @@ fn set_widgets(ref mut ui: conrod_core::UiCell, ids: &mut Ids) {
     let floating = widget::Canvas::new().floating(true).w_h(110.0, 150.0).label_color(color::WHITE);
     floating.middle_of(ids.left_column).title_bar("Blue").color(color::BLUE).set(ids.floating_a, ui);
     floating.middle_of(ids.right_column).title_bar("Orange").color(color::LIGHT_ORANGE).set(ids.floating_b, ui);
+    widget::FloatingWindow::new()
+        .floating(true)
+        .w_h(200.0, 160.0)
+        .label_color(color::BLACK)
+        .middle_of(ids.left_column)
+        .title_bar("Test")
+        .color(color::LIGHT_GREY)
+        .set(ids.floating_c, ui);
 
     // Here we make some canvas `Tabs` in the middle column.
     widget::Tabs::new(&[(ids.tab_foo, "FOO"), (ids.tab_bar, "BAR"), (ids.tab_baz, "BAZ")])
@@ -163,8 +175,11 @@ fn set_widgets(ref mut ui: conrod_core::UiCell, ids: &mut Ids) {
     for _click in button.clone().middle_of(ids.floating_a).set(ids.bing, ui) {
         println!("Bing!");
     }
-    for _click in button.middle_of(ids.floating_b).set(ids.bong, ui) {
+    for _click in button.clone().middle_of(ids.floating_b).set(ids.bong, ui) {
         println!("Bong!");
+    }
+    for _click in button.middle_of(ids.floating_c).set(ids.foobar, ui) {
+        println!("Foobar!");
     }
 }
 
@@ -186,6 +201,7 @@ widget_ids! {
         footer_scrollbar,
         floating_a,
         floating_b,
+        floating_c,
         tabs,
         tab_foo,
         tab_bar,
@@ -201,5 +217,6 @@ widget_ids! {
         button_matrix,
         bing,
         bong,
+        foobar,
     }
 }

--- a/conrod_core/src/graph/mod.rs
+++ b/conrod_core/src/graph/mod.rs
@@ -8,7 +8,7 @@ use position::{Axis, Depth, Point, Rect};
 use std;
 use std::any::Any;
 use std::ops::{Index, IndexMut};
-use widget::{self, Widget};
+use widget::{self, Widget, HitTest};
 
 pub use daggy::Walker;
 pub use self::depth_order::DepthOrder;
@@ -101,6 +101,7 @@ pub struct Container {
     ///
     /// NOTE: See `Wiget::is_over` for more details and a note on possible future plans.
     pub is_over: IsOverFn,
+    pub maybe_drag_start_hit_test_and_rect: Option<(HitTest, Rect)>,
 }
 
 /// A wrapper around a `widget::IsOverFn` to make implementing `Debug` easier for `Container`.
@@ -628,6 +629,7 @@ impl Graph {
             type_id, id, maybe_parent_id, maybe_x_positioned_relatively_id,
             maybe_y_positioned_relatively_id, rect, depth, kid_area, maybe_dragged_from, maybe_floating,
             crop_kids, maybe_x_scroll_state, maybe_y_scroll_state, maybe_graphics_for, is_over,
+            maybe_drag_start_hit_test_and_rect,
         } = widget;
 
         assert!(self.node(id).is_some(), "No node found for the given widget::Id {:?}", id);
@@ -646,6 +648,7 @@ impl Graph {
             maybe_y_scroll_state: maybe_y_scroll_state,
             instantiation_order_idx: instantiation_order_idx,
             is_over: IsOverFn(is_over),
+            maybe_drag_start_hit_test_and_rect,
         };
 
         // Retrieves the widget's parent index.
@@ -699,6 +702,7 @@ impl Graph {
                 container.maybe_y_scroll_state = maybe_y_scroll_state;
                 container.instantiation_order_idx = instantiation_order_idx;
                 container.is_over = IsOverFn(is_over);
+                container.maybe_drag_start_hit_test_and_rect = maybe_drag_start_hit_test_and_rect;
             },
 
         }

--- a/conrod_core/src/widget/floating_window.rs
+++ b/conrod_core/src/widget/floating_window.rs
@@ -1,0 +1,527 @@
+//! The `FloatingWindow` widget and related items.
+
+use {
+    Color,
+    Colorable,
+    FontSize,
+    Borderable,
+    Labelable,
+    Positionable,
+    Sizeable,
+    Theme,
+    Ui,
+    UiCell,
+    Widget,
+};
+use position::{self, Dimensions, Padding, Place, Position, Range, Rect, Scalar};
+use position::Direction::{Forwards, Backwards};
+use text;
+use widget::{self, HitTest, Id, };
+use crate::{cursor, Point};
+
+
+/// **Canvas** is designed to be a "container"-like "parent" widget that simplifies placement of
+/// "children" widgets.
+///
+/// Widgets can be placed on a **Canvas** in a variety of ways using methods from the
+/// [**Positionable**](../../position/trait.Positionable.html) trait.
+///
+/// **Canvas** provides methods for padding the kid widget area which can make using the
+/// **Place**-related **Positionable** methods a little easier.
+///
+/// A **Canvas** can also be divided into a sequence of smaller **Canvas**ses using the `.flow_*`
+/// methods. This creates a kind of **Canvas** tree, where each "split" can be sized using the
+/// `.length` or `.length_weight` methods.
+///
+/// See the `canvas.rs` example for a demonstration of the **Canvas** type.
+#[derive(Copy, Clone, Debug, WidgetCommon_)]
+pub struct FloatingWindow<'a> {
+    /// Data necessary and common for all widget builder types.
+    #[conrod(common_builder)]
+    pub common: widget::CommonBuilder,
+    /// The builder data related to the style of the Canvas.
+    pub style: Style,
+    /// The label for the **Canvas**' **TitleBar** if there is one.
+    pub maybe_title_bar_label: Option<&'a str>, 
+    // /// A list of child **Canvas**ses as splits of this **Canvas** flowing in the given direction.
+    // pub maybe_splits: Option<FlowOfSplits<'a>>,
+}
+
+/// **Canvas** state to be cached.
+pub struct State {
+    ids: Ids,
+}
+
+widget_ids! {
+    struct Ids {
+        rectangle,
+        title_bar,
+        size_grip,
+    }
+}
+
+/// Unique styling for the Canvas.
+#[derive(Copy, Clone, Debug, Default, PartialEq, WidgetStyle_)]
+pub struct Style {
+    /// The color of the Canvas' rectangle surface.
+    #[conrod(default = "theme.background_color")]
+    pub color: Option<Color>,
+    /// The width of the border surrounding the Canvas' rectangle.
+    #[conrod(default = "theme.border_width")]
+    pub border: Option<Scalar>,
+    /// The color of the Canvas' border.
+    #[conrod(default = "theme.border_color")]
+    pub border_color: Option<Color>,
+    // /// If this Canvas is a split of some parent Canvas, this is the length of the split.
+    // #[conrod(default = "Length::Weight(1.0)")]
+    // pub length: Option<Length>,
+
+    /// Padding for the left edge of the Canvas' kid area.
+    #[conrod(default = "theme.padding.x.start")]
+    pub pad_left: Option<Scalar>,
+    /// Padding for the right edge of the Canvas' kid area.
+    #[conrod(default = "theme.padding.x.end")]
+    pub pad_right: Option<Scalar>,
+    /// Padding for the bottom edge of the Canvas' kid area.
+    #[conrod(default = "theme.padding.y.start")]
+    pub pad_bottom: Option<Scalar>,
+    /// Padding for the top edge of the Canvas' kid area.
+    #[conrod(default = "theme.padding.y.end")]
+    pub pad_top: Option<Scalar>,
+
+    /// The color of the title bar. Defaults to the color of the Canvas.
+    #[conrod(default = "None")]
+    pub title_bar_color: Option<Option<Color>>,
+    /// The color of the title bar's text.
+    #[conrod(default = "theme.label_color")]
+    pub title_bar_text_color: Option<Color>,
+    /// The font size for the title bar's text.
+    #[conrod(default = "theme.font_size_medium")]
+    pub title_bar_font_size: Option<FontSize>,
+    /// The way in which the title bar's text should wrap.
+    #[conrod(default = "Some(widget::text::Wrap::Whitespace)")]
+    pub title_bar_maybe_wrap: Option<Option<widget::text::Wrap>>,
+    /// The distance between lines for multi-line title bar text.
+    #[conrod(default = "1.0")]
+    pub title_bar_line_spacing: Option<Scalar>,
+    /// The label's typographic alignment over the *x* axis.
+    #[conrod(default = "text::Justify::Center")]
+    pub title_bar_justify: Option<text::Justify>,
+}
+
+// /// A series of **Canvas** splits along with their unique identifiers.
+// pub type ListOfSplits<'a> = &'a [(widget::Id, FloatingWindow<'a>)];
+
+// /// A series of **Canvas** splits flowing in the specified direction.
+// pub type FlowOfSplits<'a> = (Direction, ListOfSplits<'a>);
+
+// /// The length of a `Split` given as a weight.
+// ///
+// /// The length is determined by determining what percentage each `Split`'s weight contributes to
+// /// the total weight of all `Split`s in a flow list.
+// pub type Weight = Scalar;
+
+// /// Used to describe the desired length for a `Split`.
+// #[derive(Copy, Clone, Debug, PartialEq)]
+// pub enum Length {
+//     /// The length as an absolute scalar.
+//     Absolute(Scalar),
+//     /// The length as a weight of the non-absolute length of the parent **Canvas**.
+//     Weight(Weight),
+// }
+
+/// The direction in which a sequence of canvas splits will be laid out.
+#[derive(Copy, Clone, Debug)]
+pub enum Direction {
+    /// Lay splits along the *x* axis.
+    X(position::Direction),
+    /// Lay splits along the *y* axis.
+    Y(position::Direction),
+}
+
+
+impl<'a> FloatingWindow<'a> {
+
+    /// Construct a new Canvas builder.
+    pub fn new() -> Self {
+        FloatingWindow {
+            common: widget::CommonBuilder::default(),
+            style: Style::default(),
+            maybe_title_bar_label: None,
+            // maybe_splits: None,
+        }
+    }
+
+    builder_methods!{
+        pub title_bar { maybe_title_bar_label = Some(&'a str) }
+        pub pad_left { style.pad_left = Some(Scalar) }
+        pub pad_right { style.pad_right = Some(Scalar) }
+        pub pad_bottom { style.pad_bottom = Some(Scalar) }
+        pub pad_top { style.pad_top = Some(Scalar) }
+        pub with_style { style = Style }
+    }
+
+    // /// Set the length of the Split as an absolute scalar.
+    // pub fn length(mut self, length: Scalar) -> Self {
+    //     self.style.length = Some(Length::Absolute(length));
+    //     self
+    // }
+
+    // /// Set the length of the Split as a weight.
+    // ///
+    // /// The default length weight for each widget is `1.0`.
+    // pub fn length_weight(mut self, weight: Weight) -> Self {
+    //     self.style.length = Some(Length::Weight(weight));
+    //     self
+    // }
+
+    // /// Set the child Canvas Splits of the current Canvas flowing in a given direction.
+    // fn flow(mut self, direction: Direction, splits: ListOfSplits<'a>) -> Self {
+    //     self.maybe_splits = Some((direction, splits));
+    //     self
+    // }
+
+    // /// Set the child Canvasses flowing to the right.
+    // pub fn flow_right(self, splits: ListOfSplits<'a>) -> Self {
+    //     self.flow(Direction::X(Forwards), splits)
+    // }
+
+    // /// Set the child Canvasses flowing to the left.
+    // pub fn flow_left(self, splits: ListOfSplits<'a>) -> Self {
+    //     self.flow(Direction::X(Backwards), splits)
+    // }
+
+    // /// Set the child Canvasses flowing upwards.
+    // pub fn flow_up(self, splits: ListOfSplits<'a>) -> Self {
+    //     self.flow(Direction::Y(Forwards), splits)
+    // }
+
+    // /// Set the child Canvasses flowing downwards.
+    // pub fn flow_down(self, splits: ListOfSplits<'a>) -> Self {
+    //     self.flow(Direction::Y(Backwards), splits)
+    // }
+
+    /// Set the padding for all edges of the area where child widgets will be placed.
+    #[inline]
+    pub fn pad(self, pad: Scalar) -> Self {
+        self.pad_left(pad).pad_right(pad).pad_bottom(pad).pad_top(pad)
+    }
+
+    /// Set the padding of the area where child widgets will be placed.
+    #[inline]
+    pub fn padding(self, pad: Padding) -> Self {
+        self.pad_left(pad.x.start)
+            .pad_right(pad.x.end)
+            .pad_bottom(pad.y.start)
+            .pad_top(pad.y.end)
+    }
+
+    /// Set the color of the `Canvas`' `TitleBar` if it is visible.
+    pub fn title_bar_color(mut self, color: Color) -> Self {
+        self.style.title_bar_color = Some(Some(color));
+        self
+    }
+
+}
+
+// TODO: Remove this constant.
+const GRIP_SIZE: Scalar = 8.0;
+
+impl<'a> Widget for FloatingWindow<'a> {
+    type State = State;
+    type Style = Style;
+    type Event = ();
+
+    fn init_state(&self, id_gen: widget::id::Generator) -> Self::State {
+        State {
+            ids: Ids::new(id_gen),
+            // maybe_window_rect: None,
+        }
+    }
+
+    fn style(&self) -> Self::Style {
+        self.style.clone()
+    }
+
+    fn default_x_position(&self, _ui: &Ui) -> Position {
+        Position::Relative(position::Relative::Place(Place::Middle), None)
+    }
+
+    fn default_y_position(&self, _ui: &Ui) -> Position {
+        Position::Relative(position::Relative::Place(Place::Middle), None)
+    }
+
+    // /// The title bar area at which the Canvas can be clicked and dragged.
+    // ///
+    // /// Note: the position of the returned **Rect** should be relative to the center of the widget.
+    // fn drag_area(&self, dim: Dimensions, style: &Style, theme: &Theme) -> Option<Rect> {
+    //     self.maybe_title_bar_label.map(|_| {
+    //         let font_size = style.title_bar_font_size(theme);
+    //         let (h, rel_y) = title_bar_h_rel_y(dim[1], font_size);
+    //         let rel_xy = [0.0, rel_y];
+    //         let dim = [dim[0], h];
+    //         Rect::from_xy_dim(rel_xy, dim)
+    //     })
+    // }
+
+    fn hit_test_supported(&self) -> bool {
+        true
+    }
+
+    fn hit_test(&self, dim: Dimensions, style: &Self::Style, theme: &Theme, point: Point) -> HitTest {
+        let title_bar_rect = {
+            // let (xy, dim) = rect.xy_dim();
+            let font_size = style.title_bar_font_size(theme);
+            let (h, rel_y) = title_bar_h_rel_y(dim[1], font_size);
+            let rel_xy = [0.0, rel_y];
+            let dim = [dim[0], h];
+            // let title_bar_rect = Rect::from_xy_dim([rel_xy[0] + xy[0], rel_xy[1] + xy[1]], dim);
+            Rect::from_xy_dim(rel_xy, dim)
+        };
+        if title_bar_rect.is_over(point) {
+            HitTest::TitleBar
+        } else {
+            let bottom_right_grip = {
+                let [w, h] = dim;
+                let grip_size = GRIP_SIZE;
+                Rect::from_xy_dim([w / 2.0 - grip_size / 2.0, -h / 2.0 + grip_size / 2.0], [grip_size, grip_size])
+            };
+            if bottom_right_grip.is_over(point) {
+                HitTest::BottomRightCorner
+            } else {
+                HitTest::Content
+            }
+        }
+    }
+
+    /// The area of the widget below the title bar, upon which child widgets will be placed.
+    fn kid_area(&self, args: widget::KidAreaArgs<Self>) -> widget::KidArea {
+        let widget::KidAreaArgs { rect, style, theme, .. } = args;
+        if true || self.maybe_title_bar_label.is_some() {
+            let font_size = style.title_bar_font_size(theme);
+            let title_bar = title_bar(rect, font_size);
+            widget::KidArea {
+                rect: rect.pad_top(title_bar.h()),
+                pad: style.padding(theme),
+            }
+        } else {
+            widget::KidArea {
+                rect: rect,
+                pad: style.padding(theme),
+            }
+        }
+    }
+
+    /// Update the state of the Canvas.
+    fn update(self, args: widget::UpdateArgs<Self>) {
+        let widget::UpdateArgs { id, state, rect, mut ui, .. } = args;
+        let FloatingWindow { style, maybe_title_bar_label, /*maybe_splits,*/ .. } = self;
+
+        // BorderedRectangle widget as the rectangle backdrop.
+        let dim = rect.dim();
+        let color = style.color(ui.theme());
+        let border = style.border(ui.theme());
+        let border_color = style.border_color(ui.theme());
+        widget::BorderedRectangle::new(dim)
+            .color(color)
+            .border(border)
+            .border_color(border_color)
+            .middle_of(id)
+            .graphics_for(id)
+            .place_on_kid_area(false)
+            .set(state.ids.rectangle, &mut ui);
+
+        // BorderedRectangle widget for the bottom-right size grip.
+        {
+            let dim = [GRIP_SIZE, GRIP_SIZE];
+            let color = Color::Rgba(1.0, 0.0, 0.0, 1.0);
+            let border = 1.0;
+            let border_color = Color::Rgba(0.0, 1.0, 0.0, 1.0);
+            widget::BorderedRectangle::new(dim)
+                .color(color)
+                .border(border)
+                .border_color(border_color)
+                .bottom_right_of(id)
+                .graphics_for(id)
+                .place_on_kid_area(false)
+                .set(state.ids.size_grip, &mut ui);
+        }
+
+        // TitleBar widget if we were given some label.
+        if let Some(label) = maybe_title_bar_label {
+            let color = style.title_bar_color(&ui.theme).unwrap_or(color);
+            let font_size = style.title_bar_font_size(&ui.theme);
+            let label_color = style.title_bar_text_color(&ui.theme);
+            let justify = style.title_bar_justify(&ui.theme);
+            let line_spacing = style.title_bar_line_spacing(&ui.theme);
+            let maybe_wrap = style.title_bar_maybe_wrap(&ui.theme);
+            widget::TitleBar::new(label, state.ids.rectangle)
+                .and_mut(|title_bar| {
+                    title_bar.style.maybe_wrap = Some(maybe_wrap);
+                    title_bar.style.justify = Some(justify);
+                })
+                .color(color)
+                .border(border)
+                .border_color(border_color)
+                .label_font_size(font_size)
+                .label_color(label_color)
+                .line_spacing(line_spacing)
+                .graphics_for(id)
+                .place_on_kid_area(false)
+                .set(state.ids.title_bar, &mut ui);
+        }
+
+        if let Some(m) = ui.widget_input(id).mouse() {
+            let ht = self.hit_test(dim, &style, &ui.theme, m.rel_xy());
+            match ht {
+                HitTest::Content => {}
+                HitTest::TitleBar => {
+                    ui.set_mouse_cursor(cursor::MouseCursor::Grab);
+                }
+                HitTest::TopBorder => {}
+                HitTest::LeftBorder => {}
+                HitTest::RightBorder => {}
+                HitTest::BottomBorder => {}
+                HitTest::TopLeftCorner => {}
+                HitTest::TopRightCorner => {}
+                HitTest::BorromLeftCorner => {}
+                HitTest::BottomRightCorner => {
+                    ui.set_mouse_cursor(cursor::MouseCursor::ResizeTopLeftBottomRight);
+                }
+            }
+            
+        }
+
+        // If we were given some child canvas splits, we should instantiate them.
+        // if let Some((direction, splits)) = maybe_splits {
+
+        //     let (total_abs, total_weight) =
+        //         splits.iter().fold((0.0, 0.0), |(abs, weight), &(_, split)| {
+        //             match split.style.length(ui.theme()) {
+        //                 Length::Absolute(a) => (abs + a, weight),
+        //                 Length::Weight(w) => (abs, weight + w),
+        //             }
+        //         });
+
+        //     // No need to calculate kid_area again, we'll just get it from the graph.
+        //     let kid_area = ui.kid_area_of(id).expect("No KidArea found");
+        //     let kid_area_range = match direction {
+        //         Direction::X(_) => kid_area.x,
+        //         Direction::Y(_) => kid_area.y,
+        //     };
+
+        //     let total_length = kid_area_range.len();
+        //     let non_abs_length = (total_length - total_abs).max(0.0);
+        //     let weight_normaliser = 1.0 / total_weight;
+
+        //     let length = |split: &Self, ui: &UiCell| -> Scalar {
+        //         match split.style.length(ui.theme()) {
+        //             Length::Absolute(length) => length,
+        //             Length::Weight(weight) => weight * weight_normaliser * non_abs_length,
+        //         }
+        //     };
+
+        //     let set_split = |split_id: widget::Id, split: FloatingWindow<'a>, ui: &mut UiCell| {
+        //         split.parent(id).set(split_id, ui);
+        //     };
+
+        //     // Instantiate each of the splits, matching on the direction first for efficiency.
+        //     match direction {
+
+        //         Direction::X(direction) => match direction {
+        //             Forwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
+        //                 let w = length(&split, &ui);
+        //                 let split = match i {
+        //                     0 => split.h(kid_area.h()).mid_left_of(id),
+        //                     _ => split.right(0.0),
+        //                 }.w(w);
+        //                 set_split(split_id, split, &mut ui);
+        //             },
+        //             Backwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
+        //                 let w = length(&split, &ui);
+        //                 let split = match i {
+        //                     0 => split.h(kid_area.h()).mid_right_of(id),
+        //                     _ => split.left(0.0),
+        //                 }.w(w);
+        //                 set_split(split_id, split, &mut ui);
+        //             },
+        //         },
+
+        //         Direction::Y(direction) => match direction {
+        //             Forwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
+        //                 let h = length(&split, &ui);
+        //                 let split = match i {
+        //                     0 => split.w(kid_area.w()).mid_bottom_of(id),
+        //                     _ => split.up(0.0),
+        //                 }.h(h);
+        //                 set_split(split_id, split, &mut ui);
+        //             },
+        //             Backwards => for (i, &(split_id, split)) in splits.iter().enumerate() {
+        //                 let h = length(&split, &ui);
+        //                 let split = match i {
+        //                     0 => split.w(kid_area.w()).mid_top_of(id),
+        //                     _ => split.down(0.0),
+        //                 }.h(h);
+        //                 set_split(split_id, split, &mut ui);
+        //             },
+        //         },
+        //     }
+        // }
+    }
+
+    // fn set<'r, 's>(self, id: Id, ui_cell: &'r mut UiCell<'s>) -> Self::Event {
+    //     let rect = ui_cell.rect_of(id);
+    //     dbg!(&rect);
+    //     Widget::set(self, id, ui_cell)
+    // }
+}
+
+
+/// The height and relative y coordinate of a Canvas' title bar given some canvas height and font
+/// size for the title bar.
+fn title_bar_h_rel_y(canvas_h: Scalar, font_size: FontSize) -> (Scalar, Scalar) {
+    let h = widget::title_bar::calc_height(font_size);
+    let rel_y = canvas_h / 2.0 - h / 2.0;
+    (h, rel_y)
+}
+
+/// The Rect for the Canvas' title bar.
+fn title_bar(canvas: Rect, font_size: FontSize) -> Rect {
+    let (c_w, c_h) = canvas.w_h();
+    let (h, rel_y) = title_bar_h_rel_y(c_h, font_size);
+    let xy = [0.0, rel_y];
+    let dim = [c_w, h];
+    Rect::from_xy_dim(xy, dim)
+}
+
+impl Style {
+    /// Get the Padding for the Canvas' kid area.
+    pub fn padding(&self, theme: &Theme) -> position::Padding {
+        position::Padding {
+            x: Range::new(self.pad_left(theme), self.pad_right(theme)),
+            y: Range::new(self.pad_bottom(theme), self.pad_top(theme)),
+        }
+    }
+}
+
+impl<'a> ::color::Colorable for FloatingWindow<'a> {
+    builder_method!(color { style.color = Some(Color) });
+}
+
+impl<'a> ::border::Borderable for FloatingWindow<'a> {
+    builder_methods!{
+        border { style.border = Some(Scalar) }
+        border_color { style.border_color = Some(Color) }
+    }
+}
+
+impl<'a> ::label::Labelable<'a> for FloatingWindow<'a> {
+    fn label(self, text: &'a str) -> Self {
+        self.title_bar(text)
+    }
+    builder_methods!{
+        label_color { style.title_bar_text_color = Some(Color) }
+        label_font_size { style.title_bar_font_size = Some(FontSize) }
+    }
+}
+


### PR DESCRIPTION
Here is a POC of a resizeable floating window. I copied the `Canvas` widget, removed the split functionality, then implemented some of the logic to make resizing possible.

- I added a method `Widget::hit_test` returning a `HitTest` enum for widgets to indicate what element is at specific points. This can potentially replace `Widget::drag_area` (or that the default implementation of `hit_test` may use `drag_area` to provide the equivalent function).
- I added a field `maybe_drag_start_hit_test_and_rect: Option<(HitTest, Rect)>` to the widget states. Functionally, it overlaps with`maybe_dragged_from`.
- Inside `set_widget` I implemented a move and resize logic which is somewhat similar to the existing `drag_area` handling. This new code can technically replace the existing code.
- In this POC I have only implemented moving by title bar and resizing by the bottom-right corner, but resizing with the other corners and borders can easily be implemented.
- The functionality can technically be combined with `Canvas`. The reason I made a new widget is that I feel that the `Canvas` widget might have too many functions. I want a floating window widget that only does needed needed for a floating window. My idea of the `Canvas` is that it helps group widgets in some way so the idea of adding a title bar to it already seems weird to me.
- How should the resizeable border and grip sizes be determined?
- I also want to make the window collapsible and closable with buttons on the title bar, but it seems a bit tricky.

To test, run `cargo run --example canvas`.

(#1362)