### PR TITLE
Fix scrollbar behaviour with padded canvas

### DIFF
--- a/conrod_core/src/widget/scroll.rs
+++ b/conrod_core/src/widget/scroll.rs
@@ -210,7 +210,11 @@ impl<A> State<A>
             let new_offset = maybe_prev_scroll_state.as_ref()
                 .map(|prev| prev.offset_bounds.clamp_value(new_offset_unbounded))
                 .unwrap_or(new_offset_unbounded);
-            offset_bounds.clamp_value(new_offset)
+            if new_offset.is_nan() {
+                offset_bounds.start
+            } else {
+                offset_bounds.clamp_value(new_offset)
+            }
         };
 
         State {

--- a/conrod_core/src/widget/scrollbar.rs
+++ b/conrod_core/src/widget/scrollbar.rs
@@ -181,7 +181,7 @@ impl<A> Widget for Scrollbar<A>
             let len = if scrollable_range_len == 0.0 {
                 track_len
             } else {
-                utils::clamp(track_len * (track_len / scrollable_range_len), 0.0, track_len)
+                utils::clamp(track_len * (1.0 - offset_bounds.len() / scrollable_range_len), 0.0, track_len)
             };
             let handle_range = Range::from_pos_and_len(0.0, len);
             let pos = {
@@ -248,7 +248,7 @@ impl<A> Widget for Scrollbar<A>
         }
 
         // Scroll the given widget by the accumulated additional offset.
-        if additional_offset != 0.0 {
+        if additional_offset != 0.0 && !additional_offset.is_nan() {
             ui.scroll_widget(widget, A::to_2d(additional_offset));
         }
 


### PR DESCRIPTION
This fixes the behaviour of scrollbars on canvas, when the scrollable content excluding padding fits the kids area but overflows when padding is included. Without this fix, the scrollbar shows a full-range handle, while still scrollable, will cause the scrollable content to disappear after flicking the scrollbar handle a few times, due to the scroll offset turning into NaN.

I have also added some checks to prevent the scroll offset from becoming NaN.