### PR TITLE
Fix rgb to hsl saturation

### DIFF
--- a/conrod_core/src/color.rs
+++ b/conrod_core/src/color.rs
@@ -329,7 +329,8 @@ pub fn f32_to_byte(c: f32) -> u8 { (c * 255.0) as u8 }
 
 
 /// Pure function for converting rgb to hsl.
-/// Inputs expected to be between `0.0` and `1.0`.
+/// * Inputs expected to be between `0.0` and `1.0`.
+/// * Outputs `[0.0, 2*PI)` for `h`, `[0.0, 1.0]` for both `s` and `l`
 pub fn rgb_to_hsl(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
     let c_max = r.max(g).max(b);
     let c_min = r.min(g).min(b);

--- a/conrod_core/src/color.rs
+++ b/conrod_core/src/color.rs
@@ -19,7 +19,7 @@ use utils::{degrees, fmod, turns};
 pub enum Color {
     /// Red, Green, Blue, Alpha - All values' scales represented between 0.0 and 1.0.
     Rgba(f32, f32, f32, f32),
-    /// Hue, Saturation, Lightness, Alpha - all valuess scales represented between 0.0 and 1.0.
+    /// Hue, Saturation, Lightness, Alpha - all values scales represented between 0.0 and 1.0.
     Hsla(f32, f32, f32, f32),
 }
 

--- a/conrod_core/src/color.rs
+++ b/conrod_core/src/color.rs
@@ -329,6 +329,7 @@ pub fn f32_to_byte(c: f32) -> u8 { (c * 255.0) as u8 }
 
 
 /// Pure function for converting rgb to hsl.
+/// Inputs expected to be between `0.0` and `1.0`.
 pub fn rgb_to_hsl(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
     let c_max = r.max(g).max(b);
     let c_min = r.min(g).min(b);
@@ -344,7 +345,7 @@ pub fn rgb_to_hsl(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
     };
 
     let lightness = (c_max + c_min) / 2.0;
-    let saturation = if lightness == 0.0 { 0.0 }
+    let saturation = if lightness == 0.0 || lightness == 1.0 { 0.0 }
                      else { c / (1.0 - (2.0 * lightness - 1.0).abs()) };
     (hue, saturation, lightness)
 }

--- a/conrod_core/src/tests/color.rs
+++ b/conrod_core/src/tests/color.rs
@@ -1,0 +1,60 @@
+use color::{rgb_to_hsl, hsl_to_rgb};
+use std::cmp::Ordering::Equal;
+
+///// Test assist code.
+
+fn convert_rgb_to_hsl_to_rgb(expected_r: f32, expected_g: f32, expected_b: f32) -> (f32, f32, f32) {
+    let (h, s, l) = rgb_to_hsl(expected_r, expected_g, expected_b);
+    hsl_to_rgb(h, s, l)
+}
+
+fn compare_rgb_pairs(expected: (f32, f32, f32), actual: (f32, f32, f32)) -> bool{
+    let (expected_r, expected_g, expected_b) = expected;
+    let (actual_r, actual_g, actual_b) = actual;
+    let r_comp = expected_r.partial_cmp(&actual_r).unwrap();
+    let g_comp = expected_g.partial_cmp(&actual_g).unwrap();
+    let b_comp = expected_b.partial_cmp(&actual_b).unwrap();
+    r_comp == Equal && g_comp == Equal && b_comp == Equal
+}
+
+///// Actual tests.
+
+#[test]
+fn rgb_to_hsl_black() {
+    // black (0,0,0) should convert to hsl (0.0, 0.0, 0.0)
+    let (r, g, b) = (0.0, 0.0, 0.0);
+    let actual = convert_rgb_to_hsl_to_rgb(r, g, b);
+    assert!(compare_rgb_pairs((r, g, b), actual))
+}
+
+#[test]
+fn rgb_to_hsl_white() {
+    // white (255,255,255) should convert to hsl (0.0, 0.0, 1.0)
+    let (r, g, b) = (1.0, 1.0, 1.0);
+    let actual = convert_rgb_to_hsl_to_rgb(r, g, b);
+    assert!(compare_rgb_pairs((r, g, b), actual))
+}
+
+#[test]
+fn rgb_to_hsl_gray() {
+    // gray rgb (128,128,128) should convert to hsl (0.0, 0.0, 0.5)
+    let (r, g, b) = (0.5, 0.5, 0.5);
+    let actual = convert_rgb_to_hsl_to_rgb(r, g, b);
+    assert!(compare_rgb_pairs((r, g, b), actual));
+}
+
+#[test]
+fn rgb_to_hsl_purple() {
+    // purple rgb (128,0,128) should convert to hsl (5.0, 1.0, 0.25)
+    let (r, g, b) = (0.5, 0.0, 0.5);
+    let actual = convert_rgb_to_hsl_to_rgb(r, g, b);
+    assert!(compare_rgb_pairs((r, g, b), actual));
+}
+
+#[test]
+fn rgb_to_hsl_silver() {
+    // silver rgb (191,191,191) should convert to hsl (0.0, 0.0, 0.75)
+    let (r, g, b) = (0.75, 0.75, 0.75);
+    let actual = convert_rgb_to_hsl_to_rgb(r, g, b);
+    assert!(compare_rgb_pairs((r, g, b), actual));
+}

--- a/conrod_core/src/tests/color.rs
+++ b/conrod_core/src/tests/color.rs
@@ -45,7 +45,7 @@ fn rgb_to_hsl_gray() {
 
 #[test]
 fn rgb_to_hsl_purple() {
-    // purple rgb (128,0,128) should convert to hsl (5.0, 1.0, 0.25)
+    // purple rgb (128,0,128) should convert to hsl (5.23598766, 1.0, 0.25)
     let (r, g, b) = (0.5, 0.0, 0.5);
     let actual = convert_rgb_to_hsl_to_rgb(r, g, b);
     assert!(compare_rgb_pairs((r, g, b), actual));

--- a/conrod_core/src/tests/mod.rs
+++ b/conrod_core/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod color;
 mod global_input;
 mod widget_input;
 mod ui;


### PR DESCRIPTION
Closes #1370 

Addresses the NaN problem mentioned in #1370 . It seems like the hue range is expected to be between 0 and 2PI for other parts of the library, so I'm assuming that is correct and left it as is.

Also expanded the doc for the function indicating the expected input and output ranges.