### PR TITLE
Change to round scissor rect before truncating

### DIFF
--- a/backends/conrod_gfx/src/lib.rs
+++ b/backends/conrod_gfx/src/lib.rs
@@ -290,10 +290,10 @@ impl<'a, R: Resources> Renderer<'a, R> {
 
         let rect_to_gfx_rect = |rect: Rect| {
             let (w, h) = rect.w_h();
-            let left = (rect.left() * dpi_factor + half_win_w) as u16;
-            let bottom = (rect.bottom() * dpi_factor + half_win_h) as u16;
-            let width = (w * dpi_factor) as u16;
-            let height = (h * dpi_factor) as u16;
+            let left = (rect.left() * dpi_factor + half_win_w).round() as u16;
+            let bottom = (rect.bottom() * dpi_factor + half_win_h).round() as u16;
+            let width = (w * dpi_factor).round() as u16;
+            let height = (h * dpi_factor).round() as u16;
             gfx::Rect {
                 x: std::cmp::max(left, 0),
                 w: std::cmp::min(width, screen_w as u16),

--- a/backends/conrod_glium/src/lib.rs
+++ b/backends/conrod_glium/src/lib.rs
@@ -549,10 +549,10 @@ impl Renderer {
 
         let rect_to_glium_rect = |rect: Rect| {
             let (w, h) = rect.w_h();
-            let left = (rect.left() * dpi_factor + half_win_w) as u32;
-            let bottom = (rect.bottom() * dpi_factor + half_win_h) as u32;
-            let width = (w * dpi_factor) as u32;
-            let height = (h * dpi_factor) as u32;
+            let left = (rect.left() * dpi_factor + half_win_w).round() as u32;
+            let bottom = (rect.bottom() * dpi_factor + half_win_h).round() as u32;
+            let width = (w * dpi_factor).round() as u32;
+            let height = (h * dpi_factor).round() as u32;
             glium::Rect {
                 left: std::cmp::max(left, 0),
                 bottom: std::cmp::max(bottom, 0),

--- a/conrod_core/src/mesh.rs
+++ b/conrod_core/src/mesh.rs
@@ -200,10 +200,10 @@ impl Mesh {
 
         let rect_to_scizzor = |rect: Rect| {
             let (w, h) = rect.w_h();
-            let left = (rect.left() * dpi_factor + half_viewport_w) as i32;
-            let top = (rect.top() * dpi_factor - half_viewport_h).abs() as i32;
-            let width = (w * dpi_factor) as u32;
-            let height = (h * dpi_factor) as u32;
+            let left = (rect.left() * dpi_factor + half_viewport_w).round() as i32;
+            let top = (rect.top() * dpi_factor - half_viewport_h).round().abs() as i32;
+            let width = (w * dpi_factor).round() as u32;
+            let height = (h * dpi_factor).round() as u32;
             Scizzor {
                 top_left: [left.max(0), top.max(0)],
                 dimensions: [width.min(viewport_w as u32), height.min(viewport_h as u32)],


### PR DESCRIPTION
This change rounds the scissor rect before truncating to an integer type.

**Rationale:**

When a fractional hidpi scaling is in use, the code may want to align widgets or graphical elements to the physical device pixel grid. This can be done by `aligned = (coord * hidpi_factor).round() / hidpi_factor` for example, where `coord` is a coordinate relative to the corner (not centre) of the viewport. This is done so that when the coordinate is converted back to the device coordinate by `aligned * hidpi_factor`, the result is an integer or close to an integer.

Unfortunately, due to the nature of floating point maths, the end result is often not an exact integer. Therefore when the scissor code truncates the coordinates, an off-by-one error may occur. Rounding the value before truncation fixes the issue.

**Potential issues:**

This may result in a different behaviour for widgets that does not explicitly align themselves to the pixel grid, even when there is no dpi scaling.

**Other notes:**

This PR changes all included backends except for the Piston backend. (The calculation in the Piston backend is quite different from the others so I'm unsure how to properly change it.)