### PR TITLE
Update glium backend to glium 0.28 with winit 0.23

### DIFF
--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -16,7 +16,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.70" }
-glium = "0.24"
+glium = "0.27"
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.70" }
@@ -25,4 +25,4 @@ find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"
 rand = "0.7"
-winit = "0.19"
+winit = "0.22"

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -16,7 +16,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.70" }
-glium = "0.27"
+glium = "0.28"
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.70" }
@@ -25,4 +25,4 @@ find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"
 rand = "0.7"
-winit = "0.22"
+winit = "0.23"

--- a/backends/conrod_glium/examples/all_winit_glium_threaded.rs
+++ b/backends/conrod_glium/examples/all_winit_glium_threaded.rs
@@ -18,15 +18,14 @@ use glium::Surface;
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Conrod with glium!")
-        .with_dimensions((WIN_W, WIN_H).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIN_W, WIN_H));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
@@ -37,7 +36,7 @@ fn main() {
     // - a `Vec` for collecting `backend::glium::Vertex`s generated when translating the
     // `conrod_core::render::Primitive`s.
     // - a `Vec` of commands that describe how to draw the vertices.
-    let mut renderer = Renderer::new(&display.0).unwrap();
+    let mut renderer = Renderer::new(&display).unwrap();
 
     // Load the Rust logo from our assets folder to use as an example image.
     fn load_rust_logo(display: &glium::Display) -> glium::texture::Texture2d {
@@ -51,20 +50,20 @@ fn main() {
     }
 
     let mut image_map = conrod_core::image::Map::new();
-    let rust_logo = image_map.insert(load_rust_logo(&display.0));
+    let rust_logo = image_map.insert(load_rust_logo(&display));
 
     // A channel to send events from the main `winit` thread to the conrod thread.
     let (event_tx, event_rx) = std::sync::mpsc::channel();
     // A channel to send `render::Primitive`s from the conrod thread to the `winit thread.
     let (render_tx, render_rx) = std::sync::mpsc::channel();
     // Clone the handle to the events loop so that we can interrupt it when ready to draw.
-    let events_loop_proxy = events_loop.create_proxy();
+    let events_loop_proxy = event_loop.create_proxy();
 
     // A function that runs the conrod loop.
     fn run_conrod(rust_logo: conrod_core::image::Id,
                   event_rx: std::sync::mpsc::Receiver<conrod_core::event::Input>,
                   render_tx: std::sync::mpsc::Sender<conrod_core::render::OwnedPrimitives>,
-                  events_loop_proxy: glium::glutin::EventsLoopProxy)
+                  events_loop_proxy: glium::glutin::event_loop::EventLoopProxy<()>)
     {
         // Construct our `Ui`.
         let mut ui = conrod_core::UiBuilder::new([WIN_W as f64, WIN_H as f64])
@@ -94,7 +93,7 @@ fn main() {
             }
 
             // If there are no events pending, wait for them.
-            if events.is_empty() || !needs_update {
+            if events.is_empty() && !needs_update {
                 match event_rx.recv() {
                     Ok(event) => events.push(event),
                     Err(_) => break 'conrod,
@@ -115,8 +114,9 @@ fn main() {
             // Render the `Ui` to a list of primitives that we can send to the main thread for
             // display. Wakeup `winit` for rendering.
             if let Some(primitives) = ui.draw_if_changed() {
+                needs_update = true;
                 if render_tx.send(primitives.owned()).is_err()
-                || events_loop_proxy.wakeup().is_err() {
+                || events_loop_proxy.send_event(()).is_err() {
                     break 'conrod;
                 }
             }
@@ -140,60 +140,66 @@ fn main() {
     std::thread::spawn(move || run_conrod(rust_logo, event_rx, render_tx, events_loop_proxy));
 
     // Run the `winit` loop.
-    let mut last_update = std::time::Instant::now();
-    let mut closed = false;
-    while !closed {
+    let mut is_waken = false;
+    let mut latest_primitives = None;
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    event_tx.send(event).unwrap();
+                }
 
-        // We don't want to loop any faster than 60 FPS, so wait until it has been at least
-        // 16ms since the last yield.
-        let sixteen_ms = std::time::Duration::from_millis(16);
-        let now = std::time::Instant::now();
-        let duration_since_last_update = now.duration_since(last_update);
-        if duration_since_last_update < sixteen_ms {
-            std::thread::sleep(sixteen_ms - duration_since_last_update);
-        }
-
-        events_loop.run_forever(|event| {
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                event_tx.send(event).unwrap();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => {
-                        closed = true;
-                        return glium::glutin::ControlFlow::Break;
-                    },
-                    // We must re-draw on `Resized`, as the event loops become blocked during
-                    // resize on macOS.
-                    glium::glutin::WindowEvent::Resized(..) => {
-                        if let Some(primitives) = render_rx.iter().next() {
-                            draw(&display.0, &mut renderer, &image_map, &primitives);
+                        } => *should_exit = true,
+                        // We must re-draw on `Resized`, as the event loops become blocked during
+                        // resize on macOS.
+                        glium::glutin::event::WindowEvent::Resized(..) => {
+                            if let Some(primitives) = render_rx.try_iter().last() {
+                                latest_primitives = Some(primitives);
+                            }
+                            if let Some(primitives) = &latest_primitives {
+                                draw(&display, &mut renderer, &image_map, primitives);
+                            }
                         }
+                        _ => {}
                     },
-                    _ => {},
-                },
-                glium::glutin::Event::Awakened => return glium::glutin::ControlFlow::Break,
-                _ => (),
+                    glium::glutin::event::Event::UserEvent(()) => {
+                        is_waken = true;
+                        // HACK: This triggers the `SetUi` request so that we can request a redraw.
+                        *should_update_ui = true;
+                    }
+                    _ => {}
+                }
             }
-
-            glium::glutin::ControlFlow::Continue
-        });
-
-        // Draw the most recently received `conrod_core::render::Primitives` sent from the `Ui`.
-        if let Some(primitives) = render_rx.try_iter().last() {
-            draw(&display.0, &mut renderer, &image_map, &primitives);
+            support::Request::SetUi { needs_redraw } => {
+                *needs_redraw = is_waken;
+                is_waken = false;
+            }
+            support::Request::Redraw => {
+                // Draw the most recently received `conrod_core::render::Primitives` sent from the `Ui`.
+                if let Some(primitives) = render_rx.try_iter().last() {
+                    latest_primitives = Some(primitives);
+                }
+                if let Some(primitives) = &latest_primitives {
+                    draw(&display, &mut renderer, &image_map, primitives);
+                }
+            }
         }
-
-        last_update = std::time::Instant::now();
-    }
+    })
 }

--- a/backends/conrod_glium/examples/canvas.rs
+++ b/backends/conrod_glium/examples/canvas.rs
@@ -16,15 +16,14 @@ fn main() {
     const HEIGHT: u32 = 600;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Canvas")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -36,56 +35,64 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
     // Instantiate the generated list of widget identifiers.
-    let ids = &mut Ids::new(ui.widget_id_generator());
+    let mut ids = Ids::new(ui.widget_id_generator());
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate all widgets in the GUI.
+                set_widgets(ui.set_widgets(), &mut ids);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Instantiate all widgets in the GUI.
-        set_widgets(ui.set_widgets(), ids);
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Draw the Ui.

--- a/backends/conrod_glium/examples/counter.rs
+++ b/backends/conrod_glium/examples/counter.rs
@@ -14,15 +14,14 @@ fn main() {
     const HEIGHT: u32 = 200;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Click me!")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -38,7 +37,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
@@ -46,60 +45,66 @@ fn main() {
     let mut count = 0;
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate all widgets in the GUI.
+                let ui = &mut ui.set_widgets();
+
+                // Create a background canvas upon which we'll place the button.
+                widget::Canvas::new().pad(40.0).set(ids.canvas, ui);
+
+                // Draw the button and increment `count` if pressed.
+                for _click in widget::Button::new()
+                    .middle_of(ids.canvas)
+                    .w_h(80.0, 80.0)
+                    .label(&count.to_string())
+                    .set(ids.counter, ui)
+                {
+                    count += 1;
+                }
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Instantiate all widgets in the GUI.
-        {
-            let ui = &mut ui.set_widgets();
-
-            // Create a background canvas upon which we'll place the button.
-            widget::Canvas::new().pad(40.0).set(ids.canvas, ui);
-
-            // Draw the button and increment `count` if pressed.
-            for _click in widget::Button::new()
-                .middle_of(ids.canvas)
-                .w_h(80.0, 80.0)
-                .label(&count.to_string())
-                .set(ids.counter, ui)
-            {
-                count += 1;
-            }
-        }
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }

--- a/backends/conrod_glium/examples/custom_widget.rs
+++ b/backends/conrod_glium/examples/custom_widget.rs
@@ -243,15 +243,14 @@ fn main() {
     const HEIGHT: u32 = 800;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Control Panel")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -274,71 +273,77 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate the widgets.
+                let ui = &mut ui.set_widgets();
+
+                // Sets a color to clear the background with before the Ui draws our widget.
+                widget::Canvas::new().color(conrod_core::color::DARK_RED).set(ids.background, ui);
+
+                // Instantiate of our custom widget.
+                for _click in CircularButton::new()
+                    .color(conrod_core::color::rgb(0.0, 0.3, 0.1))
+                    .middle_of(ids.background)
+                    .w_h(256.0, 256.0)
+                    .label_font_id(regular)
+                    .label_color(conrod_core::color::WHITE)
+                    .label("Circular Button")
+                    // Add the widget to the conrod_core::Ui. This schedules the widget it to be
+                    // drawn when we call Ui::draw.
+                    .set(ids.circle_button, ui)
+                {
+                    println!("Click!");
+                }
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Instantiate the widgets.
-        {
-            let ui = &mut ui.set_widgets();
-
-            // Sets a color to clear the background with before the Ui draws our widget.
-            widget::Canvas::new().color(conrod_core::color::DARK_RED).set(ids.background, ui);
-
-            // Instantiate of our custom widget.
-            for _click in CircularButton::new()
-                .color(conrod_core::color::rgb(0.0, 0.3, 0.1))
-                .middle_of(ids.background)
-                .w_h(256.0, 256.0)
-                .label_font_id(regular)
-                .label_color(conrod_core::color::WHITE)
-                .label("Circular Button")
-                // Add the widget to the conrod_core::Ui. This schedules the widget it to be
-                // drawn when we call Ui::draw.
-                .set(ids.circle_button, ui)
-            {
-                println!("Click!");
-            }
-        }
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }

--- a/backends/conrod_glium/examples/graph.rs
+++ b/backends/conrod_glium/examples/graph.rs
@@ -52,15 +52,14 @@ fn main() {
     let mut layout = Layout::from(layout_map);
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Conrod Graph Widget")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_multisampling(4)
         .with_vsync(true);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -75,54 +74,60 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
     // Begin the event loop.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            // Break from the loop upon `Escape` or closed window.
-            match event.clone() {
-                glium::glutin::Event::WindowEvent { event, .. } => {
-                    match event {
-                        glium::glutin::WindowEvent::CloseRequested |
-                        glium::glutin::WindowEvent::KeyboardInput {
-                            input: glium::glutin::KeyboardInput {
-                                virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
-                                ..
-                            },
-                            ..
-                        } => break 'main,
-                        _ => (),
-                    }
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
                 }
-                _ => (),
+
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Set the widgets.
+                set_widgets(&mut ui.set_widgets(), &ids, &mut graph, &mut layout);
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Draw the `Ui` if it has changed.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Set the widgets.
-        set_widgets(&mut ui.set_widgets(), &ids, &mut graph, &mut layout);
-
-        // Draw the `Ui` if it has changed.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 fn set_widgets(ui: &mut conrod_core::UiCell, ids: &Ids, graph: &mut MyGraph, layout: &mut Layout) {

--- a/backends/conrod_glium/examples/hello_world.rs
+++ b/backends/conrod_glium/examples/hello_world.rs
@@ -17,15 +17,14 @@ const HEIGHT: u32 = 200;
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Hello Conrod!")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -41,75 +40,68 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
-    let mut events = Vec::new();
-
-    'render: loop {
-        events.clear();
-
-        // Get all the new events since the last frame.
-        events_loop.poll_events(|event| { events.push(event); });
-
-        // If there are no new events, wait for one.
-        if events.is_empty() {
-            events_loop.run_forever(|event| {
-                events.push(event);
-                glium::glutin::ControlFlow::Break
-            });
-        }
-
-        // Process the events.
-        for event in events.drain(..) {
-
-            // Break from the loop upon `Escape` or closed window.
-            match event.clone() {
-                glium::glutin::Event::WindowEvent { event, .. } => {
-                    match event {
-                        glium::glutin::WindowEvent::CloseRequested |
-                        glium::glutin::WindowEvent::KeyboardInput {
-                            input: glium::glutin::KeyboardInput {
-                                virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
-                                ..
-                            },
+    let mut should_update_ui = true;
+    event_loop.run(move |event, _, control_flow| {
+        // Break from the loop upon `Escape` or closed window.
+        match &event {
+            glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                // Break from the loop upon `Escape`.
+                glium::glutin::event::WindowEvent::CloseRequested
+                | glium::glutin::event::WindowEvent::KeyboardInput {
+                    input:
+                        glium::glutin::event::KeyboardInput {
+                            virtual_keycode:
+                                Some(glium::glutin::event::VirtualKeyCode::Escape),
                             ..
-                        } => break 'render,
-                        _ => (),
-                    }
+                        },
+                    ..
+                } => *control_flow = glium::glutin::event_loop::ControlFlow::Exit,
+                _ => {}
+            },
+            _ => {}
+        }
+
+        // Use the `winit` backend feature to convert the winit event to a conrod one.
+        if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+            ui.handle_event(event);
+            should_update_ui = true;
+        }
+
+        match &event {
+            glium::glutin::event::Event::MainEventsCleared => {
+                if should_update_ui {
+                    should_update_ui = false;
+
+                    // Set the widgets.
+                    let ui = &mut ui.set_widgets();
+            
+                    // "Hello World!" in the middle of the screen.
+                    widget::Text::new("Hello World!")
+                        .middle_of(ui.window)
+                        .color(conrod_core::color::WHITE)
+                        .font_size(32)
+                        .set(ids.text, ui);
+                    
+                    // Request redraw if the `Ui` has changed.
+                    display.gl_window().window().request_redraw();
                 }
-                _ => (),
-            };
+            }
+            glium::glutin::event::Event::RedrawRequested(_) => {
+                // Draw the `Ui` if it has changed.
+                let primitives = ui.draw();
 
-            // Use the `winit` backend feature to convert the winit event to a conrod input.
-            let input = match support::convert_event(event, &display) {
-                None => continue,
-                Some(input) => input,
-            };
-
-            // Handle the input with the `Ui`.
-            ui.handle_event(input);
-
-            // Set the widgets.
-            let ui = &mut ui.set_widgets();
-
-            // "Hello World!" in the middle of the screen.
-            widget::Text::new("Hello World!")
-                .middle_of(ui.window)
-                .color(conrod_core::color::WHITE)
-                .font_size(32)
-                .set(ids.text, ui);
+                renderer.fill(&display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(&display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
+            }
+            _ => {}
         }
-
-        // Draw the `Ui` if it has changed.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }

--- a/backends/conrod_glium/examples/image.rs
+++ b/backends/conrod_glium/examples/image.rs
@@ -19,80 +19,86 @@ const HEIGHT: u32 = 600;
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Image Widget Demonstration")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The `WidgetId` for our background and `Image` widgets.
     widget_ids!(struct Ids { background, rust_logo });
     let ids = Ids::new(ui.widget_id_generator());
 
     // Create our `conrod_core::image::Map` which describes each of our widget->image mappings.
-    let rust_logo = load_rust_logo(&display.0);
+    let rust_logo = load_rust_logo(&display);
     let (w, h) = (rust_logo.get_width(), rust_logo.get_height().unwrap());
     let mut image_map = conrod_core::image::Map::new();
     let rust_logo = image_map.insert(rust_logo);
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate the widgets.
+                let ui = &mut ui.set_widgets();
+                // Draw a light blue background.
+                widget::Canvas::new().color(color::LIGHT_BLUE).set(ids.background, ui);
+                // Instantiate the `Image` at its full size in the middle of the window.
+                widget::Image::new(rust_logo).w_h(w as f64, h as f64).middle().set(ids.rust_logo, ui);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Instantiate the widgets.
-        {
-            let ui = &mut ui.set_widgets();
-            // Draw a light blue background.
-            widget::Canvas::new().color(color::LIGHT_BLUE).set(ids.background, ui);
-            // Instantiate the `Image` at its full size in the middle of the window.
-            widget::Image::new(rust_logo).w_h(w as f64, h as f64).middle().set(ids.rust_logo, ui);
-        }
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Load the Rust logo from our assets folder to use as an example image.

--- a/backends/conrod_glium/examples/image_button.rs
+++ b/backends/conrod_glium/examples/image_button.rs
@@ -25,15 +25,14 @@ const HEIGHT: u32 = 560;
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Image Button Demonstration")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -45,7 +44,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // Declare the ID for each of our widgets.
     widget_ids!(struct Ids { canvas, button, rust_logo });
@@ -62,79 +61,85 @@ fn main() {
 
     // Load the images into our `ImageIds` type for easy access.
     let image_path = assets.join("images");
-    let rust_logo = load_image(&display.0, image_path.join("rust.png"));
+    let rust_logo = load_image(&display, image_path.join("rust.png"));
     let (w, h) = (rust_logo.get_width(), rust_logo.get_height().unwrap());
     let image_ids = ImageIds {
         normal: image_map.insert(rust_logo),
-        hover: image_map.insert(load_image(&display.0, image_path.join("rust_hover.png"))),
-        press: image_map.insert(load_image(&display.0, image_path.join("rust_press.png"))),
+        hover: image_map.insert(load_image(&display, image_path.join("rust_hover.png"))),
+        press: image_map.insert(load_image(&display, image_path.join("rust_press.png"))),
     };
 
     // We'll change the background colour with the image button.
     let mut bg_color = conrod_core::color::LIGHT_BLUE;
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                let ui = &mut ui.set_widgets();
+
+                // We can use this `Canvas` as a parent Widget upon which we can place other widgets.
+                widget::Canvas::new()
+                    .pad(30.0)
+                    .color(bg_color)
+                    .set(ids.canvas, ui);
+
+                // Button widget example button.
+                if widget::Button::image(image_ids.normal)
+                    .hover_image(image_ids.hover)
+                    .press_image(image_ids.press)
+                    .w_h(w as conrod_core::Scalar, h as conrod_core::Scalar)
+                    .middle_of(ids.canvas)
+                    .border(0.0)
+                    .set(ids.button, ui)
+                    .was_clicked()
+                {
+                    bg_color = color::rgb(rand::random(), rand::random(), rand::random());
+                }
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        {
-            let ui = &mut ui.set_widgets();
-
-            // We can use this `Canvas` as a parent Widget upon which we can place other widgets.
-            widget::Canvas::new()
-                .pad(30.0)
-                .color(bg_color)
-                .set(ids.canvas, ui);
-
-            // Button widget example button.
-            if widget::Button::image(image_ids.normal)
-                .hover_image(image_ids.hover)
-                .press_image(image_ids.press)
-                .w_h(w as conrod_core::Scalar, h as conrod_core::Scalar)
-                .middle_of(ids.canvas)
-                .border(0.0)
-                .set(ids.button, ui)
-                .was_clicked()
-            {
-                bg_color = color::rgb(rand::random(), rand::random(), rand::random());
-            }
-        }
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Load an image from our assets folder as a texture we can draw to the screen.

--- a/backends/conrod_glium/examples/list.rs
+++ b/backends/conrod_glium/examples/list.rs
@@ -20,15 +20,14 @@ widget_ids! {
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("List Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -45,7 +44,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
@@ -53,45 +52,54 @@ fn main() {
     let mut list = vec![true; 16];
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested
-                    | glium::glutin::WindowEvent::KeyboardInput {
-                        input:
-                            glium::glutin::KeyboardInput {
-                                virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
-                                ..
-                            },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                set_ui(ui.set_widgets(), &mut list, &ids);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        set_ui(ui.set_widgets(), &mut list, &ids);
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Declare the `WidgetId`s and instantiate the widgets.

--- a/backends/conrod_glium/examples/list_select.rs
+++ b/backends/conrod_glium/examples/list_select.rs
@@ -17,15 +17,14 @@ widget_ids! {
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("ListSelect Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -40,7 +39,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
@@ -69,98 +68,104 @@ fn main() {
     let mut list_selected = std::collections::HashSet::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
-                            ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
-            }
-        }
-
-        // Instantiate the conrod widgets.
-        {
-            use conrod_core::{widget, Borderable, Colorable, Labelable, Positionable, Sizeable, Widget};
-
-            let ui = &mut ui.set_widgets();
-
-            widget::Canvas::new().color(conrod_core::color::BLUE).set(ids.canvas, ui);
-
-            // Instantiate the `ListSelect` widget.
-            let num_items = list_items.len();
-            let item_h = 30.0;
-            let font_size = item_h as conrod_core::FontSize / 2;
-            let (mut events, scrollbar) = widget::ListSelect::multiple(num_items)
-                .flow_down()
-                .item_size(item_h)
-                .scrollbar_next_to()
-                .w_h(400.0, 230.0)
-                .top_left_with_margins_on(ids.canvas, 40.0, 40.0)
-                .set(ids.list_select, ui);
-
-            // Handle the `ListSelect`s events.
-            while let Some(event) = events.next(ui, |i| list_selected.contains(&i)) {
-                use conrod_core::widget::list_select::Event;
                 match event {
-
-                    // For the `Item` events we instantiate the `List`'s items.
-                    Event::Item(item) => {
-                        let label = &list_items[item.i];
-                        let (color, label_color) = match list_selected.contains(&item.i) {
-                            true => (conrod_core::color::LIGHT_BLUE, conrod_core::color::YELLOW),
-                            false => (conrod_core::color::LIGHT_GREY, conrod_core::color::BLACK),
-                        };
-                        let button = widget::Button::new()
-                            .border(0.0)
-                            .color(color)
-                            .label(label)
-                            .label_font_size(font_size)
-                            .label_color(label_color);
-                        item.set(button, ui);
-                    }
-
-                    // The selection has changed.
-                    Event::Selection(selection) => {
-                        selection.update_index_set(&mut list_selected);
-                        println!("selected indices: {:?}", list_selected);
-                    }
-
-                    // The remaining events indicate interactions with the `ListSelect` widget.
-                    event => println!("{:?}", &event),
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
                 }
             }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate the conrod widgets.
+                use conrod_core::{widget, Borderable, Colorable, Labelable, Positionable, Sizeable, Widget};
 
-            // Instantiate the scrollbar for the list.
-            if let Some(s) = scrollbar { s.set(ui); }
-        }
+                let ui = &mut ui.set_widgets();
 
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
+                widget::Canvas::new().color(conrod_core::color::BLUE).set(ids.canvas, ui);
+
+                // Instantiate the `ListSelect` widget.
+                let num_items = list_items.len();
+                let item_h = 30.0;
+                let font_size = item_h as conrod_core::FontSize / 2;
+                let (mut events, scrollbar) = widget::ListSelect::multiple(num_items)
+                    .flow_down()
+                    .item_size(item_h)
+                    .scrollbar_next_to()
+                    .w_h(400.0, 230.0)
+                    .top_left_with_margins_on(ids.canvas, 40.0, 40.0)
+                    .set(ids.list_select, ui);
+
+                // Handle the `ListSelect`s events.
+                while let Some(event) = events.next(ui, |i| list_selected.contains(&i)) {
+                    use conrod_core::widget::list_select::Event;
+                    match event {
+
+                        // For the `Item` events we instantiate the `List`'s items.
+                        Event::Item(item) => {
+                            let label = &list_items[item.i];
+                            let (color, label_color) = match list_selected.contains(&item.i) {
+                                true => (conrod_core::color::LIGHT_BLUE, conrod_core::color::YELLOW),
+                                false => (conrod_core::color::LIGHT_GREY, conrod_core::color::BLACK),
+                            };
+                            let button = widget::Button::new()
+                                .border(0.0)
+                                .color(color)
+                                .label(label)
+                                .label_font_size(font_size)
+                                .label_color(label_color);
+                            item.set(button, ui);
+                        }
+
+                        // The selection has changed.
+                        Event::Selection(selection) => {
+                            selection.update_index_set(&mut list_selected);
+                            println!("selected indices: {:?}", list_selected);
+                        }
+
+                        // The remaining events indicate interactions with the `ListSelect` widget.
+                        event => println!("{:?}", &event),
+                    }
+                }
+
+                // Instantiate the scrollbar for the list.
+                if let Some(s) = scrollbar { s.set(ui); }
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
+            }
         }
-    }
+    })
 }

--- a/backends/conrod_glium/examples/old_demo.rs
+++ b/backends/conrod_glium/examples/old_demo.rs
@@ -100,15 +100,14 @@ fn main() {
     const HEIGHT: u32 = 560;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Widget Demonstration")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -123,7 +122,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
@@ -132,50 +131,56 @@ fn main() {
     let mut app = DemoApp::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // We'll set all our widgets in a single function called `set_widgets`.
+                let mut ui = ui.set_widgets();
+                set_widgets(&mut ui, &mut app, &mut ids);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // We'll set all our widgets in a single function called `set_widgets`.
-        {
-            let mut ui = ui.set_widgets();
-            set_widgets(&mut ui, &mut app, &mut ids);
-        }
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 

--- a/backends/conrod_glium/examples/plot_path.rs
+++ b/backends/conrod_glium/examples/plot_path.rs
@@ -18,15 +18,14 @@ widget_ids! {
 
 fn main() {
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("PlotPath Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -36,81 +35,88 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate the widgets.
+                use conrod_core::{color, widget, Colorable, Positionable, Sizeable, Widget};
+
+                let ui = &mut ui.set_widgets();
+
+                widget::Canvas::new().color(color::DARK_CHARCOAL).set(ids.canvas, ui);
+
+                let min_x = 0.0;
+                let max_x = std::f64::consts::PI * 2.0;
+                let min_y = -1.0;
+                let max_y = 1.0;
+
+                let quarter_lines = widget::grid::Lines::step(0.5_f64).thickness(2.0);
+                let sixteenth_lines = widget::grid::Lines::step(0.125_f64).thickness(1.0);
+                let lines = &[
+                    quarter_lines.x(),
+                    quarter_lines.y(),
+                    sixteenth_lines.x(),
+                    sixteenth_lines.y(),
+                ];
+
+                widget::Grid::new(min_x, max_x, min_y, max_y, lines.iter().cloned())
+                    .color(color::rgb(0.1, 0.12, 0.15))
+                    .wh_of(ids.canvas)
+                    .middle_of(ids.canvas)
+                    .set(ids.grid, ui);
+                widget::PlotPath::new(min_x, max_x, min_y, max_y, f64::sin)
+                    .color(color::LIGHT_BLUE)
+                    .thickness(2.0)
+                    .wh_of(ids.canvas)
+                    .middle_of(ids.canvas)
+                    .set(ids.plot, ui);
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Instantiate the widgets.
-        {
-            use conrod_core::{color, widget, Colorable, Positionable, Sizeable, Widget};
-
-            let ui = &mut ui.set_widgets();
-
-            widget::Canvas::new().color(color::DARK_CHARCOAL).set(ids.canvas, ui);
-
-            let min_x = 0.0;
-            let max_x = std::f64::consts::PI * 2.0;
-            let min_y = -1.0;
-            let max_y = 1.0;
-
-            let quarter_lines = widget::grid::Lines::step(0.5_f64).thickness(2.0);
-            let sixteenth_lines = widget::grid::Lines::step(0.125_f64).thickness(1.0);
-            let lines = &[
-                quarter_lines.x(),
-                quarter_lines.y(),
-                sixteenth_lines.x(),
-                sixteenth_lines.y(),
-            ];
-
-            widget::Grid::new(min_x, max_x, min_y, max_y, lines.iter().cloned())
-                .color(color::rgb(0.1, 0.12, 0.15))
-                .wh_of(ids.canvas)
-                .middle_of(ids.canvas)
-                .set(ids.grid, ui);
-            widget::PlotPath::new(min_x, max_x, min_y, max_y, f64::sin)
-                .color(color::LIGHT_BLUE)
-                .thickness(2.0)
-                .wh_of(ids.canvas)
-                .middle_of(ids.canvas)
-                .set(ids.plot, ui);
-        }
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }

--- a/backends/conrod_glium/examples/primitives.rs
+++ b/backends/conrod_glium/examples/primitives.rs
@@ -28,15 +28,14 @@ fn main() {
     const HEIGHT: u32 = 720;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Primitive Widgets Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -46,52 +45,60 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                set_ui(ui.set_widgets(), &ids);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        set_ui(ui.set_widgets(), &ids);
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 

--- a/backends/conrod_glium/examples/range_slider.rs
+++ b/backends/conrod_glium/examples/range_slider.rs
@@ -19,15 +19,14 @@ fn main() {
     const HEIGHT: u32 = 360;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("RangeSlider Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -42,7 +41,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
@@ -50,46 +49,54 @@ fn main() {
     let mut oval_range = (0.25, 0.75);
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                set_ui(ui.set_widgets(), &ids, &mut oval_range);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        set_ui(ui.set_widgets(), &ids, &mut oval_range);
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Declare the `WidgetId`s and instantiate the widgets.

--- a/backends/conrod_glium/examples/support/mod.rs
+++ b/backends/conrod_glium/examples/support/mod.rs
@@ -94,4 +94,4 @@ where
 
 // Conversion functions for converting between types from glium's version of `winit` and
 // `conrod_core`.
-conrod_winit::v022_conversion_fns!();
+conrod_winit::v023_conversion_fns!();

--- a/backends/conrod_glium/examples/support/mod.rs
+++ b/backends/conrod_glium/examples/support/mod.rs
@@ -1,77 +1,97 @@
 #![allow(dead_code)]
 
-use std;
-use glium;
+use glium::{
+    glutin::{event, event_loop},
+    Display,
+};
 
-pub struct GliumDisplayWinitWrapper(pub glium::Display);
-
-impl conrod_winit::WinitWindow for GliumDisplayWinitWrapper {
-    fn get_inner_size(&self) -> Option<(u32, u32)> {
-        self.0.gl_window().get_inner_size().map(Into::into)
-    }
-    fn hidpi_factor(&self) -> f32 {
-        self.0.gl_window().get_hidpi_factor() as _
-    }
+pub enum Request<'a, 'b: 'a> {
+    Event {
+        event: &'a event::Event<'b, ()>,
+        should_update_ui: &'a mut bool,
+        should_exit: &'a mut bool,
+    },
+    SetUi {
+        needs_redraw: &'a mut bool,
+    },
+    Redraw,
 }
 
 /// In most of the examples the `glutin` crate is used for providing the window context and
 /// events while the `glium` crate is used for displaying `conrod_core::render::Primitives` to the
 /// screen.
 ///
-/// This `Iterator`-like type simplifies some of the boilerplate involved in setting up a
-/// glutin+glium event loop that works efficiently with conrod.
-pub struct EventLoop {
-    ui_needs_update: bool,
-    last_update: std::time::Instant,
-}
-
-impl EventLoop {
-    pub fn new() -> Self {
-        EventLoop {
-            last_update: std::time::Instant::now(),
-            ui_needs_update: true,
-        }
-    }
-
-    /// Produce an iterator yielding all available events.
-    pub fn next(&mut self, events_loop: &mut glium::glutin::EventsLoop) -> Vec<glium::glutin::Event> {
-        // We don't want to loop any faster than 60 FPS, so wait until it has been at least 16ms
-        // since the last yield.
-        let last_update = self.last_update;
-        let sixteen_ms = std::time::Duration::from_millis(16);
-        let duration_since_last_update = std::time::Instant::now().duration_since(last_update);
-        if duration_since_last_update < sixteen_ms {
-            std::thread::sleep(sixteen_ms - duration_since_last_update);
-        }
-
-        // Collect all pending events.
-        let mut events = Vec::new();
-        events_loop.poll_events(|event| events.push(event));
-
-        // If there are no events and the `Ui` does not need updating, wait for the next event.
-        if events.is_empty() && !self.ui_needs_update {
-            events_loop.run_forever(|event| {
-                events.push(event);
-                glium::glutin::ControlFlow::Break
-            });
+/// This function simplifies some of the boilerplate involved in limiting the redraw rate in the
+/// glutin+glium event loop.
+pub fn run_loop<F>(display: Display, event_loop: event_loop::EventLoop<()>, mut callback: F) -> !
+where
+    F: 'static + FnMut(Request, &Display),
+{
+    let sixteen_ms = std::time::Duration::from_millis(16);
+    let mut next_update = None;
+    let mut ui_update_needed = false;
+    event_loop.run(move |event, _, control_flow| {
+        {
+            let mut should_update_ui = false;
+            let mut should_exit = false;
+            callback(
+                Request::Event {
+                    event: &event,
+                    should_update_ui: &mut should_update_ui,
+                    should_exit: &mut should_exit,
+                },
+                &display,
+            );
+            ui_update_needed |= should_update_ui;
+            if should_exit {
+                *control_flow = event_loop::ControlFlow::Exit;
+                return;
+            }
         }
 
-        self.ui_needs_update = false;
-        self.last_update = std::time::Instant::now();
+        // We don't want to draw any faster than 60 FPS, so set the UI only on every 16ms, unless:
+        // - this is the very first event, or
+        // - we didn't request update on the last event and new events have arrived since then.
+        let should_set_ui_on_main_events_cleared = next_update.is_none() && ui_update_needed;
+        match (&event, should_set_ui_on_main_events_cleared) {
+            (event::Event::NewEvents(event::StartCause::Init { .. }), _)
+            | (event::Event::NewEvents(event::StartCause::ResumeTimeReached { .. }), _)
+            | (event::Event::MainEventsCleared, true) => {
+                next_update = Some(std::time::Instant::now() + sixteen_ms);
+                ui_update_needed = false;
 
-        events
-    }
+                let mut needs_redraw = false;
+                callback(
+                    Request::SetUi {
+                        needs_redraw: &mut needs_redraw,
+                    },
+                    &display,
+                );
+                if needs_redraw {
+                    display.gl_window().window().request_redraw();
+                } else {
+                    // We don't need to redraw anymore until more events arrives.
+                    next_update = None;
+                }
+            }
+            _ => {}
+        }
+        if let Some(next_update) = next_update {
+            *control_flow = event_loop::ControlFlow::WaitUntil(next_update);
+        } else {
+            *control_flow = event_loop::ControlFlow::Wait;
+        }
 
-    /// Notifies the event loop that the `Ui` requires another update whether or not there are any
-    /// pending events.
-    ///
-    /// This is primarily used on the occasion that some part of the `Ui` is still animating and
-    /// requires further updates to do so.
-    pub fn needs_update(&mut self) {
-        self.ui_needs_update = true;
-    }
+        // Request redraw if needed.
+        match &event {
+            event::Event::RedrawRequested(_) => {
+                callback(Request::Redraw, &display);
+            }
+            _ => {}
+        }
+    })
 }
 
 // Conversion functions for converting between types from glium's version of `winit` and
 // `conrod_core`.
-conrod_winit::conversion_fns!();
+conrod_winit::v022_conversion_fns!();

--- a/backends/conrod_glium/examples/text.rs
+++ b/backends/conrod_glium/examples/text.rs
@@ -20,15 +20,14 @@ fn main() {
     const HEIGHT: u32 = 720;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Text Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -65,50 +64,60 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-            }
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested
-                    | glium::glutin::WindowEvent::KeyboardInput {
-                        input:
-                            glium::glutin::KeyboardInput {
-                                virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
-                                ..
-                            },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                set_ui(ui.set_widgets(), &ids, &fonts);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        set_ui(ui.set_widgets(), &ids, &fonts);
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Generate a unique const `WidgetId` for each widget.

--- a/backends/conrod_glium/examples/text_edit.rs
+++ b/backends/conrod_glium/examples/text_edit.rs
@@ -19,15 +19,14 @@ fn main() {
     const HEIGHT: u32 = 720;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("TextEdit Demo")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -42,7 +41,7 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
@@ -57,51 +56,59 @@ fn main() {
         magna est, efficitur suscipit dolor eu, consectetur consectetur urna.".to_owned();
 
     // Poll events from the window.
-    let mut event_loop = support::EventLoop::new();
-    'main: loop {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-        // Handle all events.
-        for event in event_loop.next(&mut events_loop) {
-
-            // Use the `winit` backend feature to convert the winit event to a conrod one.
-            if let Some(event) = support::convert_event(event.clone(), &display) {
-                ui.handle_event(event);
-                event_loop.needs_update();
-            }
-
-            match event {
-                glium::glutin::Event::WindowEvent { event, .. } => match event {
-                    // Break from the loop upon `Escape`.
-                    glium::glutin::WindowEvent::CloseRequested |
-                    glium::glutin::WindowEvent::KeyboardInput {
-                        input: glium::glutin::KeyboardInput {
-                            virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        },
-                        ..
-                    } => break 'main,
-                    _ => (),
-                },
-                _ => (),
+                        } => *should_exit = true,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Instantiate all widgets in the GUI.
+                set_ui(ui.set_widgets(), &ids, &mut demo_text);
+
+                // Get the underlying winit window and update the mouse cursor as set by conrod.
+                display.gl_window().window()
+                    .set_cursor_icon(support::convert_mouse_cursor(ui.mouse_cursor()));
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Render the `Ui` and then display it on the screen.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
             }
         }
-
-        // Instantiate all widgets in the GUI.
-        set_ui(ui.set_widgets(), &ids, &mut demo_text);
-
-        // Get the underlying winit window and update the mouse cursor as set by conrod.
-        display.0.gl_window().window()
-            .set_cursor(support::convert_mouse_cursor(ui.mouse_cursor()));
-
-        // Render the `Ui` and then display it on the screen.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-    }
+    })
 }
 
 // Declare the `WidgetId`s and instantiate the widgets.

--- a/backends/conrod_glium/examples/triangles.rs
+++ b/backends/conrod_glium/examples/triangles.rs
@@ -19,15 +19,14 @@ fn main() {
     const HEIGHT: u32 = 400;
 
     // Build the window.
-    let mut events_loop = glium::glutin::EventsLoop::new();
-    let window = glium::glutin::WindowBuilder::new()
+    let event_loop = glium::glutin::event_loop::EventLoop::new();
+    let window = glium::glutin::window::WindowBuilder::new()
         .with_title("Triangles!")
-        .with_dimensions((WIDTH, HEIGHT).into());
+        .with_inner_size(glium::glutin::dpi::LogicalSize::new(WIDTH, HEIGHT));
     let context = glium::glutin::ContextBuilder::new()
         .with_vsync(true)
         .with_multisampling(4);
-    let display = glium::Display::new(window, context, &events_loop).unwrap();
-    let display = support::GliumDisplayWinitWrapper(display);
+    let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     // construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIDTH as f64, HEIGHT as f64]).build();
@@ -43,65 +42,70 @@ fn main() {
 
     // A type used for converting `conrod_core::render::Primitives` into `Command`s that can be used
     // for drawing to the glium `Surface`.
-    let mut renderer = conrod_glium::Renderer::new(&display.0).unwrap();
+    let mut renderer = conrod_glium::Renderer::new(&display).unwrap();
 
     // The image map describing each of our widget->image mappings (in our case, none).
     let image_map = conrod_core::image::Map::<glium::texture::Texture2d>::new();
 
-    events_loop.run_forever(|event| {
-        match event.clone() {
-            glium::glutin::Event::WindowEvent { event, .. } => match event {
+    support::run_loop(display, event_loop, move |request, display| {
+        match request {
+            support::Request::Event {
+                event,
+                should_update_ui,
+                should_exit,
+            } => {
+                // Use the `winit` backend feature to convert the winit event to a conrod one.
+                if let Some(event) = support::convert_event(&event, &display.gl_window().window()) {
+                    ui.handle_event(event);
+                    *should_update_ui = true;
+                }
 
-                // Break from the loop upon `Escape` or closed window.
-                glium::glutin::WindowEvent::CloseRequested |
-                glium::glutin::WindowEvent::KeyboardInput {
-                    input: glium::glutin::KeyboardInput {
-                        virtual_keycode: Some(glium::glutin::VirtualKeyCode::Escape),
-                        ..
+                match event {
+                    glium::glutin::event::Event::WindowEvent { event, .. } => match event {
+                        // Break from the loop upon `Escape`.
+                        glium::glutin::event::WindowEvent::CloseRequested
+                        | glium::glutin::event::WindowEvent::KeyboardInput {
+                            input:
+                                glium::glutin::event::KeyboardInput {
+                                    virtual_keycode:
+                                        Some(glium::glutin::event::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        } => *should_exit = true,
+                        _ => {}
                     },
-                    ..
-                } => return glium::glutin::ControlFlow::Break,
+                    _ => {}
+                }
+            }
+            support::Request::SetUi { needs_redraw } => {
+                // Set the triangle widget.
+                let ui = &mut ui.set_widgets();
+                let rect = ui.rect_of(ui.window).unwrap();
+                let (l, r, b, t) = rect.l_r_b_t();
+                let (c1, c2, c3) = (color::RED.to_rgb(), color::GREEN.to_rgb(), color::BLUE.to_rgb());
 
-                _ => (),
-            },
-            _ => (),
+                let triangles = [
+                    Triangle([([l, b], c1), ([l, t], c2), ([r, t], c3)]),
+                    Triangle([([r, t], c1), ([r, b], c2), ([l, b], c3)]),
+                ];
+
+                widget::Triangles::multi_color(triangles.iter().cloned())
+                    .with_bounding_rect(rect)
+                    .set(ids.triangles, ui);
+
+                *needs_redraw = ui.has_changed();
+            }
+            support::Request::Redraw => {
+                // Draw the `Ui` if it has changed.
+                let primitives = ui.draw();
+
+                renderer.fill(display, primitives, &image_map);
+                let mut target = display.draw();
+                target.clear_color(0.0, 0.0, 0.0, 1.0);
+                renderer.draw(display, &mut target, &image_map).unwrap();
+                target.finish().unwrap();
+            }
         }
-
-        // Use the `winit` backend feature to convert the winit event to a conrod one.
-        let input = match support::convert_event(event, &display) {
-            None => return glium::glutin::ControlFlow::Continue,
-            Some(input) => input,
-        };
-
-        // Handle the input with the `Ui`.
-        ui.handle_event(input);
-
-        // Set the triangle widget.
-        {
-            let ui = &mut ui.set_widgets();
-            let rect = ui.rect_of(ui.window).unwrap();
-            let (l, r, b, t) = rect.l_r_b_t();
-            let (c1, c2, c3) = (color::RED.to_rgb(), color::GREEN.to_rgb(), color::BLUE.to_rgb());
-
-            let triangles = [
-                Triangle([([l, b], c1), ([l, t], c2), ([r, t], c3)]),
-                Triangle([([r, t], c1), ([r, b], c2), ([l, b], c3)]),
-            ];
-
-            widget::Triangles::multi_color(triangles.iter().cloned())
-                .with_bounding_rect(rect)
-                .set(ids.triangles, ui);
-        }
-
-        // Draw the `Ui` if it has changed.
-        if let Some(primitives) = ui.draw_if_changed() {
-            renderer.fill(&display.0, primitives, &image_map);
-            let mut target = display.0.draw();
-            target.clear_color(0.0, 0.0, 0.0, 1.0);
-            renderer.draw(&display.0, &mut target, &image_map).unwrap();
-            target.finish().unwrap();
-        }
-
-        glium::glutin::ControlFlow::Continue
-    });
+    })
 }

--- a/backends/conrod_glium/src/lib.rs
+++ b/backends/conrod_glium/src/lib.rs
@@ -443,7 +443,7 @@ impl Display for glium::Display {
     }
 
     fn hidpi_factor(&self) -> f64 {
-        self.gl_window().get_hidpi_factor()
+        self.gl_window().window().scale_factor()
     }
 }
 

--- a/backends/conrod_winit/src/lib.rs
+++ b/backends/conrod_winit/src/lib.rs
@@ -4,6 +4,7 @@ pub mod macros;
 pub mod v020;
 pub mod v021;
 pub mod v022;
+pub mod v023;
 
 /// Types that have access to a `winit::Window` and can provide the necessary dimensions and hidpi
 /// factor for converting `winit::Event`s to `conrod::event::Input`, as well as set the mouse

--- a/backends/conrod_winit/src/lib.rs
+++ b/backends/conrod_winit/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod macros;
 pub mod v020;
 pub mod v021;
+pub mod v022;
 
 /// Types that have access to a `winit::Window` and can provide the necessary dimensions and hidpi
 /// factor for converting `winit::Event`s to `conrod::event::Input`, as well as set the mouse

--- a/backends/conrod_winit/src/v022.rs
+++ b/backends/conrod_winit/src/v022.rs
@@ -1,0 +1,63 @@
+#[macro_export]
+macro_rules! v022_convert_key {
+    ($keycode:expr) => {{
+        $crate::v021_convert_key!($keycode)
+    }};
+}
+
+/// Maps winit's mouse button to conrod's mouse button.
+///
+/// Expects a `winit::MouseButton` as input and returns a `conrod_core::input::MouseButton` as
+/// output.
+///
+/// Requires that both the `conrod_core` and `winit` crates are in the crate root.
+#[macro_export]
+macro_rules! v022_convert_mouse_button {
+    ($mouse_button:expr) => {{
+        $crate::v021_convert_mouse_button!($mouse_button)
+    }};
+}
+
+/// A macro for converting a `winit::WindowEvent` to a `Option<conrod_core::event::Input>`.
+///
+/// Expects a `winit::WindowEvent` and a reference to a window implementing `WinitWindow`.
+/// Returns an `Option<conrod_core::event::Input>`.
+#[macro_export]
+macro_rules! v022_convert_window_event {
+    ($event:expr, $window:expr) => {{
+        $crate::v021_convert_window_event!($event, $window)
+    }};
+}
+
+/// A macro for converting a `winit::Event` to a `conrod_core::event::Input`.
+///
+/// Expects a `winit::Event` and a reference to a window implementing `WinitWindow`.
+/// Returns an `Option<conrod_core::event::Input>`.
+///
+/// Invocations of this macro require that a version of the `winit` and `conrod_core` crates are
+/// available in the crate root.
+#[macro_export]
+macro_rules! v022_convert_event {
+    ($event:expr, $window:expr) => {{
+        $crate::v021_convert_event!($event, $window)
+    }};
+}
+
+/// Convert a given conrod mouse cursor to the corresponding winit cursor type.
+///
+/// Expects a `conrod_core::cursor::MouseCursor`, returns a `winit::MouseCursor`.
+///
+/// Requires that both the `conrod_core` and `winit` crates are in the crate root.
+#[macro_export]
+macro_rules! v022_convert_mouse_cursor {
+    ($cursor:expr) => {{
+        $crate::v021_convert_mouse_cursor!($cursor)
+    }};
+}
+
+#[macro_export]
+macro_rules! v022_conversion_fns {
+    () => {
+        $crate::v021_conversion_fns!();
+    };
+}

--- a/backends/conrod_winit/src/v023.rs
+++ b/backends/conrod_winit/src/v023.rs
@@ -1,0 +1,326 @@
+#[macro_export]
+macro_rules! v023_convert_key {
+    ($keycode:expr) => {{
+        match $keycode {
+            winit::event::VirtualKeyCode::Key0 => conrod_core::input::keyboard::Key::D0,
+            winit::event::VirtualKeyCode::Key1 => conrod_core::input::keyboard::Key::D1,
+            winit::event::VirtualKeyCode::Key2 => conrod_core::input::keyboard::Key::D2,
+            winit::event::VirtualKeyCode::Key3 => conrod_core::input::keyboard::Key::D3,
+            winit::event::VirtualKeyCode::Key4 => conrod_core::input::keyboard::Key::D4,
+            winit::event::VirtualKeyCode::Key5 => conrod_core::input::keyboard::Key::D5,
+            winit::event::VirtualKeyCode::Key6 => conrod_core::input::keyboard::Key::D6,
+            winit::event::VirtualKeyCode::Key7 => conrod_core::input::keyboard::Key::D7,
+            winit::event::VirtualKeyCode::Key8 => conrod_core::input::keyboard::Key::D8,
+            winit::event::VirtualKeyCode::Key9 => conrod_core::input::keyboard::Key::D9,
+            winit::event::VirtualKeyCode::A => conrod_core::input::keyboard::Key::A,
+            winit::event::VirtualKeyCode::B => conrod_core::input::keyboard::Key::B,
+            winit::event::VirtualKeyCode::C => conrod_core::input::keyboard::Key::C,
+            winit::event::VirtualKeyCode::D => conrod_core::input::keyboard::Key::D,
+            winit::event::VirtualKeyCode::E => conrod_core::input::keyboard::Key::E,
+            winit::event::VirtualKeyCode::F => conrod_core::input::keyboard::Key::F,
+            winit::event::VirtualKeyCode::G => conrod_core::input::keyboard::Key::G,
+            winit::event::VirtualKeyCode::H => conrod_core::input::keyboard::Key::H,
+            winit::event::VirtualKeyCode::I => conrod_core::input::keyboard::Key::I,
+            winit::event::VirtualKeyCode::J => conrod_core::input::keyboard::Key::J,
+            winit::event::VirtualKeyCode::K => conrod_core::input::keyboard::Key::K,
+            winit::event::VirtualKeyCode::L => conrod_core::input::keyboard::Key::L,
+            winit::event::VirtualKeyCode::M => conrod_core::input::keyboard::Key::M,
+            winit::event::VirtualKeyCode::N => conrod_core::input::keyboard::Key::N,
+            winit::event::VirtualKeyCode::O => conrod_core::input::keyboard::Key::O,
+            winit::event::VirtualKeyCode::P => conrod_core::input::keyboard::Key::P,
+            winit::event::VirtualKeyCode::Q => conrod_core::input::keyboard::Key::Q,
+            winit::event::VirtualKeyCode::R => conrod_core::input::keyboard::Key::R,
+            winit::event::VirtualKeyCode::S => conrod_core::input::keyboard::Key::S,
+            winit::event::VirtualKeyCode::T => conrod_core::input::keyboard::Key::T,
+            winit::event::VirtualKeyCode::U => conrod_core::input::keyboard::Key::U,
+            winit::event::VirtualKeyCode::V => conrod_core::input::keyboard::Key::V,
+            winit::event::VirtualKeyCode::W => conrod_core::input::keyboard::Key::W,
+            winit::event::VirtualKeyCode::X => conrod_core::input::keyboard::Key::X,
+            winit::event::VirtualKeyCode::Y => conrod_core::input::keyboard::Key::Y,
+            winit::event::VirtualKeyCode::Z => conrod_core::input::keyboard::Key::Z,
+            winit::event::VirtualKeyCode::Apostrophe => conrod_core::input::keyboard::Key::Unknown,
+            winit::event::VirtualKeyCode::Backslash => conrod_core::input::keyboard::Key::Backslash,
+            winit::event::VirtualKeyCode::Back => conrod_core::input::keyboard::Key::Backspace,
+            // K::CapsLock => Key::CapsLock,
+            winit::event::VirtualKeyCode::Delete => conrod_core::input::keyboard::Key::Delete,
+            winit::event::VirtualKeyCode::Comma => conrod_core::input::keyboard::Key::Comma,
+            winit::event::VirtualKeyCode::Down => conrod_core::input::keyboard::Key::Down,
+            winit::event::VirtualKeyCode::End => conrod_core::input::keyboard::Key::End,
+            winit::event::VirtualKeyCode::Return => conrod_core::input::keyboard::Key::Return,
+            winit::event::VirtualKeyCode::Equals => conrod_core::input::keyboard::Key::Equals,
+            winit::event::VirtualKeyCode::Escape => conrod_core::input::keyboard::Key::Escape,
+            winit::event::VirtualKeyCode::F1 => conrod_core::input::keyboard::Key::F1,
+            winit::event::VirtualKeyCode::F2 => conrod_core::input::keyboard::Key::F2,
+            winit::event::VirtualKeyCode::F3 => conrod_core::input::keyboard::Key::F3,
+            winit::event::VirtualKeyCode::F4 => conrod_core::input::keyboard::Key::F4,
+            winit::event::VirtualKeyCode::F5 => conrod_core::input::keyboard::Key::F5,
+            winit::event::VirtualKeyCode::F6 => conrod_core::input::keyboard::Key::F6,
+            winit::event::VirtualKeyCode::F7 => conrod_core::input::keyboard::Key::F7,
+            winit::event::VirtualKeyCode::F8 => conrod_core::input::keyboard::Key::F8,
+            winit::event::VirtualKeyCode::F9 => conrod_core::input::keyboard::Key::F9,
+            winit::event::VirtualKeyCode::F10 => conrod_core::input::keyboard::Key::F10,
+            winit::event::VirtualKeyCode::F11 => conrod_core::input::keyboard::Key::F11,
+            winit::event::VirtualKeyCode::F12 => conrod_core::input::keyboard::Key::F12,
+            winit::event::VirtualKeyCode::F13 => conrod_core::input::keyboard::Key::F13,
+            winit::event::VirtualKeyCode::F14 => conrod_core::input::keyboard::Key::F14,
+            winit::event::VirtualKeyCode::F15 => conrod_core::input::keyboard::Key::F15,
+            winit::event::VirtualKeyCode::Numpad0 => conrod_core::input::keyboard::Key::NumPad0,
+            winit::event::VirtualKeyCode::Numpad1 => conrod_core::input::keyboard::Key::NumPad1,
+            winit::event::VirtualKeyCode::Numpad2 => conrod_core::input::keyboard::Key::NumPad2,
+            winit::event::VirtualKeyCode::Numpad3 => conrod_core::input::keyboard::Key::NumPad3,
+            winit::event::VirtualKeyCode::Numpad4 => conrod_core::input::keyboard::Key::NumPad4,
+            winit::event::VirtualKeyCode::Numpad5 => conrod_core::input::keyboard::Key::NumPad5,
+            winit::event::VirtualKeyCode::Numpad6 => conrod_core::input::keyboard::Key::NumPad6,
+            winit::event::VirtualKeyCode::Numpad7 => conrod_core::input::keyboard::Key::NumPad7,
+            winit::event::VirtualKeyCode::Numpad8 => conrod_core::input::keyboard::Key::NumPad8,
+            winit::event::VirtualKeyCode::Numpad9 => conrod_core::input::keyboard::Key::NumPad9,
+            winit::event::VirtualKeyCode::NumpadComma
+            | winit::event::VirtualKeyCode::NumpadDecimal => {
+                conrod_core::input::keyboard::Key::NumPadDecimal
+            }
+            winit::event::VirtualKeyCode::NumpadDivide => {
+                conrod_core::input::keyboard::Key::NumPadDivide
+            }
+            winit::event::VirtualKeyCode::NumpadMultiply => {
+                conrod_core::input::keyboard::Key::NumPadMultiply
+            }
+            winit::event::VirtualKeyCode::NumpadSubtract => {
+                conrod_core::input::keyboard::Key::NumPadMinus
+            }
+            winit::event::VirtualKeyCode::NumpadAdd => {
+                conrod_core::input::keyboard::Key::NumPadPlus
+            }
+            winit::event::VirtualKeyCode::NumpadEnter => {
+                conrod_core::input::keyboard::Key::NumPadEnter
+            }
+            winit::event::VirtualKeyCode::NumpadEquals => {
+                conrod_core::input::keyboard::Key::NumPadEquals
+            }
+            winit::event::VirtualKeyCode::LShift => conrod_core::input::keyboard::Key::LShift,
+            winit::event::VirtualKeyCode::LControl => conrod_core::input::keyboard::Key::LCtrl,
+            winit::event::VirtualKeyCode::LAlt => conrod_core::input::keyboard::Key::LAlt,
+            winit::event::VirtualKeyCode::RShift => conrod_core::input::keyboard::Key::RShift,
+            winit::event::VirtualKeyCode::RControl => conrod_core::input::keyboard::Key::RCtrl,
+            winit::event::VirtualKeyCode::RAlt => conrod_core::input::keyboard::Key::RAlt,
+            winit::event::VirtualKeyCode::Home => conrod_core::input::keyboard::Key::Home,
+            winit::event::VirtualKeyCode::Insert => conrod_core::input::keyboard::Key::Insert,
+            winit::event::VirtualKeyCode::Left => conrod_core::input::keyboard::Key::Left,
+            winit::event::VirtualKeyCode::LBracket => {
+                conrod_core::input::keyboard::Key::LeftBracket
+            }
+            winit::event::VirtualKeyCode::Minus => conrod_core::input::keyboard::Key::Minus,
+            winit::event::VirtualKeyCode::Numlock => {
+                conrod_core::input::keyboard::Key::NumLockClear
+            }
+            winit::event::VirtualKeyCode::PageDown => conrod_core::input::keyboard::Key::PageDown,
+            winit::event::VirtualKeyCode::PageUp => conrod_core::input::keyboard::Key::PageUp,
+            winit::event::VirtualKeyCode::Pause => conrod_core::input::keyboard::Key::Pause,
+            winit::event::VirtualKeyCode::Period => conrod_core::input::keyboard::Key::Period,
+            winit::event::VirtualKeyCode::Right => conrod_core::input::keyboard::Key::Right,
+            winit::event::VirtualKeyCode::RBracket => {
+                conrod_core::input::keyboard::Key::RightBracket
+            }
+            winit::event::VirtualKeyCode::Semicolon => conrod_core::input::keyboard::Key::Semicolon,
+            winit::event::VirtualKeyCode::Slash => conrod_core::input::keyboard::Key::Slash,
+            winit::event::VirtualKeyCode::Space => conrod_core::input::keyboard::Key::Space,
+            winit::event::VirtualKeyCode::Tab => conrod_core::input::keyboard::Key::Tab,
+            winit::event::VirtualKeyCode::Up => conrod_core::input::keyboard::Key::Up,
+            _ => conrod_core::input::keyboard::Key::Unknown,
+        }
+    }};
+}
+
+/// Maps winit's mouse button to conrod's mouse button.
+///
+/// Expects a `winit::MouseButton` as input and returns a `conrod_core::input::MouseButton` as
+/// output.
+///
+/// Requires that both the `conrod_core` and `winit` crates are in the crate root.
+#[macro_export]
+macro_rules! v023_convert_mouse_button {
+    ($mouse_button:expr) => {{
+        $crate::v021_convert_mouse_button!($mouse_button)
+    }};
+}
+
+/// A macro for converting a `winit::WindowEvent` to a `Option<conrod_core::event::Input>`.
+///
+/// Expects a `winit::WindowEvent` and a reference to a window implementing `WinitWindow`.
+/// Returns an `Option<conrod_core::event::Input>`.
+#[macro_export]
+macro_rules! v023_convert_window_event {
+    ($event:expr, $window:expr) => {{
+        // The window size in points.
+        let scale_factor: f64 = $window.scale_factor();
+        let (win_w, win_h): (f64, f64) = $window.inner_size().to_logical::<f64>(scale_factor).into();
+
+        // Translate the coordinates from top-left-origin-with-y-down to centre-origin-with-y-up.
+        let tx = |x: conrod_core::Scalar| x - win_w / 2.0;
+        let ty = |y: conrod_core::Scalar| -(y - win_h / 2.0);
+
+        // Functions for converting keys and mouse buttons.
+        let map_key = |key: winit::event::VirtualKeyCode| $crate::v023_convert_key!(key);
+        let map_mouse = |button: winit::event::MouseButton| $crate::v023_convert_mouse_button!(button);
+
+        match $event {
+            winit::event::WindowEvent::Resized(physical_size) => {
+                let winit::dpi::LogicalSize { width, height } = physical_size.to_logical(scale_factor);
+                Some(conrod_core::event::Input::Resize(width, height).into())
+            },
+
+            winit::event::WindowEvent::ReceivedCharacter(ch) => {
+                let string = match ch {
+                    // Ignore control characters and return ascii for Text event (like sdl2).
+                    '\u{7f}' | // Delete
+                    '\u{1b}' | // Escape
+                    '\u{8}'  | // Backspace
+                    '\r' | '\n' | '\t' => "".to_string(),
+                    _ => ch.to_string()
+                };
+                Some(conrod_core::event::Input::Text(string).into())
+            },
+
+            winit::event::WindowEvent::Focused(focused) =>
+                Some(conrod_core::event::Input::Focus(focused.clone()).into()),
+
+            winit::event::WindowEvent::KeyboardInput { input, .. } => {
+                input.virtual_keycode.map(|key| {
+                    match input.state {
+                        winit::event::ElementState::Pressed =>
+                            conrod_core::event::Input::Press(conrod_core::input::Button::Keyboard(map_key(key))).into(),
+                        winit::event::ElementState::Released =>
+                            conrod_core::event::Input::Release(conrod_core::input::Button::Keyboard(map_key(key))).into(),
+                    }
+                })
+            },
+
+            winit::event::WindowEvent::Touch(winit::event::Touch { phase, location, id, .. }) => {
+                let winit::dpi::LogicalPosition { x, y } = location.to_logical::<f64>(scale_factor);
+                let phase = match phase {
+                    winit::event::TouchPhase::Started => conrod_core::input::touch::Phase::Start,
+                    winit::event::TouchPhase::Moved => conrod_core::input::touch::Phase::Move,
+                    winit::event::TouchPhase::Cancelled => conrod_core::input::touch::Phase::Cancel,
+                    winit::event::TouchPhase::Ended => conrod_core::input::touch::Phase::End,
+                };
+                let xy = [tx(x), ty(y)];
+                let id = conrod_core::input::touch::Id::new(id.clone());
+                let touch = conrod_core::input::Touch { phase: phase, id: id, xy: xy };
+                Some(conrod_core::event::Input::Touch(touch).into())
+            }
+
+            winit::event::WindowEvent::CursorMoved { position, .. } => {
+                let winit::dpi::LogicalPosition { x, y } = position.to_logical::<f64>(scale_factor);
+                let x = tx(x as conrod_core::Scalar);
+                let y = ty(y as conrod_core::Scalar);
+                let motion = conrod_core::input::Motion::MouseCursor { x: x, y: y };
+                Some(conrod_core::event::Input::Motion(motion).into())
+            },
+
+            winit::event::WindowEvent::MouseWheel { delta, .. } => match delta {
+                winit::event::MouseScrollDelta::PixelDelta(delta) => {
+                    let winit::dpi::LogicalPosition { x, y } = delta.to_logical::<f64>(scale_factor);
+                    let x = x as conrod_core::Scalar;
+                    let y = -y as conrod_core::Scalar;
+                    let motion = conrod_core::input::Motion::Scroll { x: x, y: y };
+                    Some(conrod_core::event::Input::Motion(motion).into())
+                },
+
+                winit::event::MouseScrollDelta::LineDelta(x, y) => {
+                    // This should be configurable (we should provide a LineDelta event to allow for this).
+                    const ARBITRARY_POINTS_PER_LINE_FACTOR: conrod_core::Scalar = 10.0;
+                    let x = ARBITRARY_POINTS_PER_LINE_FACTOR * x.clone() as conrod_core::Scalar;
+                    let y = ARBITRARY_POINTS_PER_LINE_FACTOR * -y.clone() as conrod_core::Scalar;
+                    Some(conrod_core::event::Input::Motion(conrod_core::input::Motion::Scroll { x: x, y: y }).into())
+                },
+            },
+
+            winit::event::WindowEvent::MouseInput { state, button, .. } => match state {
+                winit::event::ElementState::Pressed =>
+                    Some(conrod_core::event::Input::Press(conrod_core::input::Button::Mouse(map_mouse(button.clone()))).into()),
+                winit::event::ElementState::Released =>
+                    Some(conrod_core::event::Input::Release(conrod_core::input::Button::Mouse(map_mouse(button.clone()))).into()),
+            },
+
+            _ => None,
+        }
+    }};
+}
+
+/// A macro for converting a `winit::Event` to a `conrod_core::event::Input`.
+///
+/// Expects a `winit::Event` and a reference to a window implementing `WinitWindow`.
+/// Returns an `Option<conrod_core::event::Input>`.
+///
+/// Invocations of this macro require that a version of the `winit` and `conrod_core` crates are
+/// available in the crate root.
+#[macro_export]
+macro_rules! v023_convert_event {
+    ($event:expr, $window:expr) => {{
+        match $event {
+            winit::event::Event::WindowEvent { event, .. } => {
+                $crate::v023_convert_window_event!(event, $window)
+            }
+            _ => None,
+        }
+    }};
+}
+
+/// Convert a given conrod mouse cursor to the corresponding winit cursor type.
+///
+/// Expects a `conrod_core::cursor::MouseCursor`, returns a `winit::MouseCursor`.
+///
+/// Requires that both the `conrod_core` and `winit` crates are in the crate root.
+#[macro_export]
+macro_rules! v023_convert_mouse_cursor {
+    ($cursor:expr) => {{
+        $crate::v021_convert_mouse_cursor!($cursor)
+    }};
+}
+
+#[macro_export]
+macro_rules! v023_conversion_fns {
+    () => {
+        /// Generate a set of conversion functions for converting between types of the crate's versions of
+        /// `winit` and `conrod_core`.
+        /// Maps winit's key to a conrod `Key`.
+        ///
+        /// Expects a `winit::VirtualKeyCode` as input and returns a `conrod_core::input::keyboard::Key`.
+        ///
+        /// Requires that both the `winit` and `conrod_core` crates exist within the crate root.
+        pub fn convert_key(
+            keycode: winit::event::VirtualKeyCode,
+        ) -> conrod_core::input::keyboard::Key {
+            $crate::v023_convert_key!(keycode)
+        }
+
+        /// Convert a `winit::MouseButton` to a `conrod_core::input::MouseButton`.
+        pub fn convert_mouse_button(
+            mouse_button: winit::event::MouseButton,
+        ) -> conrod_core::input::MouseButton {
+            $crate::v023_convert_mouse_button!(mouse_button)
+        }
+
+        /// Convert a given conrod mouse cursor to the corresponding winit cursor type.
+        pub fn convert_mouse_cursor(
+            cursor: conrod_core::cursor::MouseCursor,
+        ) -> winit::window::CursorIcon {
+            $crate::v023_convert_mouse_cursor!(cursor)
+        }
+
+        /// A function for converting a `winit::WindowEvent` to a `conrod_core::event::Input`.
+        pub fn convert_window_event(
+            event: &winit::event::WindowEvent,
+            window: &winit::window::Window,
+        ) -> Option<conrod_core::event::Input> {
+            $crate::v023_convert_window_event!(event, window)
+        }
+
+        /// A function for converting a `winit::Event` to a `conrod_core::event::Input`.
+        pub fn convert_event<T>(
+            event: &winit::event::Event<T>,
+            window: &winit::window::Window,
+        ) -> Option<conrod_core::event::Input> {
+            $crate::v023_convert_event!(event, window)
+        }
+    };
+}


### PR DESCRIPTION
This updates the glium backend to use glium 0.28 with winit 0.23.

The examples are also updated to use the new `EventLoop::run` idiom as the polling method previously used is no longer available. This results in some radical changes in the example codes.

I have checked that all the examples works as expected (except for the tutorial code).

I added the winit 0.22 conversion functions (`v022_conversion_fns`) just forwards to the v021 ones as there doesn't seem to be any breaking changes. The 0.23 ones needs some changes though.
