### PR TITLE
Remove 'build project' instruction from guide

### DIFF
--- a/conrod_core/src/guide/chapter_2.rs
+++ b/conrod_core/src/guide/chapter_2.rs
@@ -29,7 +29,7 @@ with the above steps.
 
 ## Running the Conrod Examples
 
-We can test that everything is working by cloning the github repository and running the examples.
+You can view the examples by cloning the github repository and running the examples.
 First, open up the command line on your system and follow these steps:
 
 1. Clone the repo
@@ -44,19 +44,13 @@ First, open up the command line on your system and follow these steps:
   cd conrod
   ```
 
-3. Test that conrod builds without problems
-
-  ```txt
-  cargo build --release
-  ```
-
-4. Change to the `conrod_glium` backend directory (it has the most examples)
+3. Change to the `conrod_glium` backend directory (it has the most examples)
 
   ```txt
   cd backends/conrod_glium
   ```
 
-5. Build and run the examples (with --release optimisations turned on)!
+4. Build and run the examples (with --release optimisations turned on)!
 
   ```txt
   cargo run --release --example all_winit_glium

--- a/conrod_core/src/guide/chapter_2.rs
+++ b/conrod_core/src/guide/chapter_2.rs
@@ -44,19 +44,19 @@ First, open up the command line on your system and follow these steps:
   cd conrod
   ```
 
-3. Change to the `conrod_glium` backend directory (it has the most examples)
-
-  ```txt
-  cd backends/conrod_glium
-  ```
-
-4. Build and run the examples (with --release optimisations turned on)!
+3. Build and run an example (with --release optimisations turned on)!
 
   ```txt
   cargo run --release --example all_winit_glium
   cargo run --release --example canvas
   cargo run --release --example primitives
   cargo run --release --example text
+  ```
+
+  Hint: You can get a list of all available examples by running:
+
+  ```txt
+  cargo run --example
   ```
 
 If you ran into any issues with these steps, please let us know by filing an issue at the Conrod


### PR DESCRIPTION
## Don't advise to build the entire project to run the examples.

### What?
This PR removes the step to run `cargo build --release` on the main project.

### Why?

The guide should be written for newcomers. Newcomers would usually want to check out
the examples to decide for or against this framework. They should not have to care if the
project builds or not (issue trackers are for that).

So I removed step 3 because it is not needed for running the examples. I also changed the
wording of the introduction of the section, because the goal is not to test if everything works
correctly, but to view the examples.

---
See also the discussion on Issue #1350.