### PR TITLE
Remove documentation links in Cargo.toml

### DIFF
--- a/backends/conrod_example_shared/Cargo.toml
+++ b/backends/conrod_example_shared/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "http://docs.rs/conrod"
 categories = ["gui"]
 
 [dependencies]

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 
 [lib]

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 
 [lib]

--- a/backends/conrod_piston/Cargo.toml
+++ b/backends/conrod_piston/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 
 [package.metadata.docs.rs]

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 edition = "2018"
 

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 edition = "2018"
 

--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 edition = "2018"
 

--- a/backends/conrod_winit/Cargo.toml
+++ b/backends/conrod_winit/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod"
 categories = ["gui"]
 
 [lib]

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/pistondevelopers/conrod.git"
 homepage = "https://github.com/pistondevelopers/conrod"
-documentation = "https://docs.rs/conrod_core/latest"
 categories = ["gui"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Most of them were incorrect and crates.io will automatically link to
the corresponding docs.rs page anyway, therefore it makes sense to just
remove them.

Closes #1387