### PR TITLE
Update to rusttype 0.8.3

### DIFF
--- a/backends/conrod_glium/src/lib.rs
+++ b/backends/conrod_glium/src/lib.rs
@@ -46,6 +46,7 @@ pub struct Renderer {
     glyph_cache: GlyphCache,
     commands: Vec<PreparedCommand>,
     vertices: Vec<Vertex>,
+    positioned_glyphs: Vec<text::PositionedGlyph>,
 }
 
 /// An iterator yielding `Command`s, produced by the `Renderer::commands` method.
@@ -481,6 +482,7 @@ impl Renderer {
             glyph_cache: gc,
             commands: Vec::new(),
             vertices: Vec::new(),
+            positioned_glyphs: Vec::new(),
         })
     }
 
@@ -508,6 +510,7 @@ impl Renderer {
             ref mut commands,
             ref mut vertices,
             ref mut glyph_cache,
+            ref mut positioned_glyphs,
             ..
         } = *self;
 
@@ -694,7 +697,8 @@ impl Renderer {
                 } => {
                     switch_to_plain_state!();
 
-                    let positioned_glyphs = text.positioned_glyphs(dpi_factor as f32);
+                    positioned_glyphs.clear();
+                    positioned_glyphs.extend(text.positioned_glyphs(dpi_factor as f32));
 
                     let GlyphCache {
                         ref mut cache,
@@ -765,8 +769,8 @@ impl Renderer {
                             )) * 2.0,
                     };
 
-                    for g in positioned_glyphs {
-                        if let Ok(Some((uv_rect, screen_rect))) = cache.rect_for(cache_id, g) {
+                    for g in positioned_glyphs.drain(..) {
+                        if let Ok(Some((uv_rect, screen_rect))) = cache.rect_for(cache_id, &g) {
                             let gl_rect = to_gl_rect(screen_rect);
                             let v = |p, t| Vertex {
                                 position: p,

--- a/backends/conrod_piston/src/draw.rs
+++ b/backends/conrod_piston/src/draw.rs
@@ -142,7 +142,7 @@ pub fn primitive<'a, Img, G, T, C, F>(
                 .viewport
                 .map(|v| v.draw_size[0] as f32 / v.window_size[0] as f32)
                 .unwrap_or(1.0);
-            let positioned_glyphs = text.positioned_glyphs(dpi_factor);
+            let positioned_glyphs: Vec<_> = text.positioned_glyphs(dpi_factor).collect();
             // Re-orient the context to top-left origin with *y* facing downwards, as the
             // `positioned_glyphs` yield pixel positioning.
             let context = context
@@ -167,7 +167,7 @@ pub fn primitive<'a, Img, G, T, C, F>(
 
             let rectangles = positioned_glyphs
                 .into_iter()
-                .filter_map(|g| glyph_cache.rect_for(cache_id, g).ok().unwrap_or(None))
+                .filter_map(|g| glyph_cache.rect_for(cache_id, &g).ok().unwrap_or(None))
                 .map(|(uv_rect, screen_rect)| {
                     let rectangle = {
                         let div_dpi_factor = |s| (s as f32 / dpi_factor as f32) as f64;

--- a/backends/conrod_wgpu/examples/all_winit_wgpu.rs
+++ b/backends/conrod_wgpu/examples/all_winit_wgpu.rs
@@ -84,7 +84,7 @@ fn main() {
     let logo_path = assets.join("images/rust.png");
     let rgba_logo_image = image::open(logo_path)
         .expect("Couldn't load logo")
-        .to_rgba();
+        .to_rgba8();
 
     // Create the GPU texture and upload the image data.
     let (logo_w, logo_h) = rgba_logo_image.dimensions();

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -26,6 +26,7 @@ daggy = "0.5"
 fnv = "1.0"
 num = "0.3"
 pistoncore-input = "1.0.0"
-rusttype = { version = "0.8", features = ["gpu_cache"] }
+#rusttype = { version = "0.9.2", features = ["gpu_cache"] }
+rusttype = { path = "../../rusttype", features = ["gpu_cache"] }
 instant = "0.1"
 copypasta = "0.6"

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -26,7 +26,6 @@ daggy = "0.5"
 fnv = "1.0"
 num = "0.3"
 pistoncore-input = "1.0.0"
-#rusttype = { version = "0.9.2", features = ["gpu_cache"] }
-rusttype = { path = "../../rusttype", features = ["gpu_cache"] }
+rusttype = { version = "0.8.3", features = ["gpu_cache"] }
 instant = "0.1"
 copypasta = "0.6"

--- a/conrod_core/src/render.rs
+++ b/conrod_core/src/render.rs
@@ -231,8 +231,10 @@ impl<'a> Text<'a> {
     /// out text. This is because conrod positioning uses a "pixel-agnostic" `Scalar` value
     /// representing *perceived* distances for its positioning and layout, rather than pixel
     /// values. During rendering however, the pixel density must be known
-    pub fn positioned_glyphs(self, dpi_factor: f32)
-        -> impl 'a + Iterator<Item = rusttype::PositionedGlyph<'static>> {
+    pub fn positioned_glyphs(
+        self,
+        dpi_factor: f32,
+    ) -> impl 'a + Iterator<Item = rusttype::PositionedGlyph<'static>> {
         let Text {
             window_dim,
             text,
@@ -258,16 +260,14 @@ impl<'a> Text<'a> {
 
         // Clear the existing glyphs and fill the buffer with glyphs for this Text.
         let scale = text::f32_pt_to_scale(font_size as f32 * dpi_factor);
-        lines
-            .zip(line_rects)
-            .flat_map(move |(line, line_rect)| {
-                let (x, y) = (
-                    trans_x(line_rect.left()) as f32,
-                    trans_y(line_rect.bottom()) as f32,
-                );
-                let point = text::rt::Point { x: x, y: y };
-                font.layout(line, scale, point)
-            })
+        lines.zip(line_rects).flat_map(move |(line, line_rect)| {
+            let (x, y) = (
+                trans_x(line_rect.left()) as f32,
+                trans_y(line_rect.bottom()) as f32,
+            );
+            let point = text::rt::Point { x: x, y: y };
+            font.layout(line, scale, point)
+        })
     }
 }
 

--- a/conrod_core/src/render.rs
+++ b/conrod_core/src/render.rs
@@ -36,8 +36,6 @@ pub struct Primitives<'a> {
     window_rect: Rect,
     /// A buffer to use for triangulating polygons and lines for the `Triangles`.
     triangles: Vec<Triangle<Point>>,
-    /// The slice of rusttype `PositionedGlyph`s to re-use for the `Text` primitive.
-    positioned_glyphs: Vec<text::PositionedGlyph>,
 }
 
 /// An owned alternative to the `Primitives` type.
@@ -50,7 +48,6 @@ pub struct OwnedPrimitives {
     primitives: Vec<OwnedPrimitive>,
     triangles_single_color: Vec<Triangle<Point>>,
     triangles_multi_color: Vec<Triangle<ColoredPoint>>,
-    max_glyphs: usize,
     line_infos: Vec<text::line::Info>,
     texts_string: String,
 }
@@ -157,7 +154,6 @@ pub enum PrimitiveKind<'a> {
 /// We produce this type rather than the `&[PositionedGlyph]`s directly so that we can properly
 /// handle "HiDPI" scales when caching glyphs.
 pub struct Text<'a> {
-    positioned_glyphs: &'a mut Vec<text::PositionedGlyph>,
     window_dim: Dimensions,
     text: &'a str,
     line_infos: &'a [text::line::Info],
@@ -221,7 +217,6 @@ pub struct WalkOwnedPrimitives<'a> {
     triangles_multi_color: &'a [Triangle<ColoredPoint>],
     line_infos: &'a [text::line::Info],
     texts_str: &'a str,
-    positioned_glyphs: Vec<text::PositionedGlyph>,
 }
 
 impl<'a> Text<'a> {
@@ -236,9 +231,9 @@ impl<'a> Text<'a> {
     /// out text. This is because conrod positioning uses a "pixel-agnostic" `Scalar` value
     /// representing *perceived* distances for its positioning and layout, rather than pixel
     /// values. During rendering however, the pixel density must be known
-    pub fn positioned_glyphs(self, dpi_factor: f32) -> &'a [text::PositionedGlyph] {
+    pub fn positioned_glyphs(self, dpi_factor: f32)
+        -> impl 'a + Iterator<Item = rusttype::PositionedGlyph<'static>> {
         let Text {
-            positioned_glyphs,
             window_dim,
             text,
             line_infos,
@@ -248,31 +243,31 @@ impl<'a> Text<'a> {
             justify,
             y_align,
             line_spacing,
+            ..
         } = self;
 
         // Convert conrod coordinates to pixel coordinates.
-        let trans_x = |x: Scalar| (x + window_dim[0] / 2.0) * dpi_factor as Scalar;
-        let trans_y = |y: Scalar| ((-y) + window_dim[1] / 2.0) * dpi_factor as Scalar;
+        let trans_x = move |x: Scalar| (x + window_dim[0] / 2.0) * dpi_factor as Scalar;
+        let trans_y = move |y: Scalar| ((-y) + window_dim[1] / 2.0) * dpi_factor as Scalar;
 
         // Produce the text layout iterators.
         let line_infos = line_infos.iter().cloned();
-        let lines = line_infos.clone().map(|info| &text[info.byte_range()]);
+        let lines = line_infos.clone().map(move |info| &text[info.byte_range()]);
         let line_rects =
             text::line::rects(line_infos, font_size, rect, justify, y_align, line_spacing);
 
         // Clear the existing glyphs and fill the buffer with glyphs for this Text.
-        positioned_glyphs.clear();
         let scale = text::f32_pt_to_scale(font_size as f32 * dpi_factor);
-        for (line, line_rect) in lines.zip(line_rects) {
-            let (x, y) = (
-                trans_x(line_rect.left()) as f32,
-                trans_y(line_rect.bottom()) as f32,
-            );
-            let point = text::rt::Point { x: x, y: y };
-            positioned_glyphs.extend(font.layout(line, scale, point).map(|g| g.standalone()));
-        }
-
-        positioned_glyphs
+        lines
+            .zip(line_rects)
+            .flat_map(move |(line, line_rect)| {
+                let (x, y) = (
+                    trans_x(line_rect.left()) as f32,
+                    trans_y(line_rect.bottom()) as f32,
+                );
+                let point = text::rt::Point { x: x, y: y };
+                font.layout(line, scale, point)
+            })
     }
 }
 
@@ -293,7 +288,6 @@ impl<'a> Primitives<'a> {
             fonts: fonts,
             window_rect: Rect::from_xy_dim([0.0, 0.0], window_dim),
             triangles: Vec::new(),
-            positioned_glyphs: Vec::new(),
         }
     }
 
@@ -303,7 +297,6 @@ impl<'a> Primitives<'a> {
             ref mut crop_stack,
             ref mut depth_order,
             ref mut triangles,
-            ref mut positioned_glyphs,
             graph,
             theme,
             fonts,
@@ -598,7 +591,6 @@ impl<'a> Primitives<'a> {
                     let y_align = Align::End;
 
                     let text = Text {
-                        positioned_glyphs: positioned_glyphs,
                         window_dim: window_rect.dim(),
                         text: &state.string,
                         line_infos: &state.line_infos,
@@ -652,7 +644,6 @@ impl<'a> Primitives<'a> {
         let mut primitive_triangles_single_color = Vec::new();
         let mut primitive_line_infos = Vec::new();
         let mut texts_string = String::new();
-        let mut max_glyphs = 0;
 
         while let Some(Primitive {
             id,
@@ -726,10 +717,6 @@ impl<'a> Primitives<'a> {
                         ..
                     } = text;
 
-                    // Keep a rough estimate of the maximum number of glyphs so that we know what
-                    // capacity we should allocate the `PositionedGlyph` buffer with.
-                    max_glyphs = std::cmp::max(max_glyphs, text.len());
-
                     // Pack the `texts_string`.
                     let start_str_byte = texts_string.len();
                     texts_string.push_str(text);
@@ -769,7 +756,6 @@ impl<'a> Primitives<'a> {
             primitives: primitives,
             triangles_single_color: primitive_triangles_single_color,
             triangles_multi_color: primitive_triangles_multi_color,
-            max_glyphs: max_glyphs,
             line_infos: primitive_line_infos,
             texts_string: texts_string,
         }
@@ -785,7 +771,6 @@ impl OwnedPrimitives {
             ref triangles_multi_color,
             ref line_infos,
             ref texts_string,
-            max_glyphs,
         } = *self;
         WalkOwnedPrimitives {
             primitives: primitives.iter(),
@@ -793,7 +778,6 @@ impl OwnedPrimitives {
             triangles_multi_color: triangles_multi_color,
             line_infos: line_infos,
             texts_str: texts_string,
-            positioned_glyphs: Vec::with_capacity(max_glyphs),
         }
     }
 }
@@ -803,7 +787,6 @@ impl<'a> WalkOwnedPrimitives<'a> {
     pub fn next(&mut self) -> Option<Primitive> {
         let WalkOwnedPrimitives {
             ref mut primitives,
-            ref mut positioned_glyphs,
             triangles_single_color,
             triangles_multi_color,
             line_infos,
@@ -869,7 +852,6 @@ impl<'a> WalkOwnedPrimitives<'a> {
                         let line_infos = &line_infos[line_infos_range.clone()];
 
                         let text = Text {
-                            positioned_glyphs: positioned_glyphs,
                             window_dim: window_dim,
                             text: text_str,
                             line_infos: line_infos,

--- a/conrod_core/src/widget/grid.rs
+++ b/conrod_core/src/widget/grid.rs
@@ -272,7 +272,7 @@ where
                     line_num += 1;
                 }
             }};
-        };
+        }
 
         for axis in lines {
             match axis {


### PR DESCRIPTION
Also removes some unnecessary buffering of positioned glyphs.

*Edit: For context on the following, this PR originally tried updating to 0.9.2*.

Landing this is blocked on a patch that exists on rusttype master but has not yet been released:

https://gitlab.redox-os.org/redox-os/rusttype/-/merge_requests/158

Unfortunately, rusttype is currently lacking a maintainer and as a result it's hard to say when/if we'll be able to land this:

https://gitlab.redox-os.org/redox-os/rusttype/-/issues/148