### PR TITLE
Update `conrod_wgpu` to wgpu 0.7 and winit 0.24 (yutannihilation's PR with patches)

### DIFF
--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.71" }
-wgpu = "0.6"
+wgpu = "0.7"
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }

--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -23,4 +23,4 @@ conrod_winit = { path = "../conrod_winit", version = "0.71" }
 find_folder = "0.3"
 futures = "0.3"
 image = "0.23"
-winit = "0.23"
+winit = "0.24"

--- a/backends/conrod_wgpu/examples/all_winit_wgpu.rs
+++ b/backends/conrod_wgpu/examples/all_winit_wgpu.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // Select an adapter and gpu device.
     let adapter_opts = wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::Default,
+        power_preference: wgpu::PowerPreference::default(),
         compatible_surface: Some(&surface),
     };
     let adapter = futures::executor::block_on(instance.request_adapter(&adapter_opts)).unwrap();

--- a/backends/conrod_wgpu/examples/all_winit_wgpu.rs
+++ b/backends/conrod_wgpu/examples/all_winit_wgpu.rs
@@ -42,9 +42,9 @@ fn main() {
     let adapter = futures::executor::block_on(instance.request_adapter(&adapter_opts)).unwrap();
     let limits = wgpu::Limits::default();
     let device_desc = wgpu::DeviceDescriptor {
+        label: Some("conrod_device_descriptor"),
         features: wgpu::Features::empty(),
         limits,
-        shader_validation: true,
     };
     let device_request = adapter.request_device(&device_desc, None);
     let (device, mut queue) = futures::executor::block_on(device_request).unwrap();
@@ -52,7 +52,7 @@ fn main() {
     // Create the swapchain.
     let format = wgpu::TextureFormat::Bgra8UnormSrgb;
     let mut swap_chain_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         format,
         width: size.width,
         height: size.height,
@@ -84,7 +84,7 @@ fn main() {
     let logo_path = assets.join("images/rust.png");
     let rgba_logo_image = image::open(logo_path)
         .expect("Couldn't load logo")
-        .to_rgba();
+        .to_rgba8();
 
     // Create the GPU texture and upload the image data.
     let (logo_w, logo_h) = rgba_logo_image.dimensions();
@@ -212,6 +212,7 @@ fn main() {
                     };
 
                     let render_pass_desc = wgpu::RenderPassDescriptor {
+                        label: Some("conrod_render_pass_descriptor"),
                         color_attachments: &[color_attachment_desc],
                         depth_stencil_attachment: None,
                     };
@@ -270,7 +271,7 @@ fn create_multisampled_framebuffer(
         sample_count: sample_count,
         dimension: wgpu::TextureDimension::D2,
         format: sc_desc.format,
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
     };
     device
         .create_texture(multisampled_frame_descriptor)

--- a/backends/conrod_wgpu/src/lib.rs
+++ b/backends/conrod_wgpu/src/lib.rs
@@ -162,8 +162,8 @@ impl Renderer {
         let mesh = Mesh::with_glyph_cache_dimensions(glyph_cache_dims);
 
         // Load shader modules.
-        let vs_mod = device.create_shader_module(wgpu::include_spirv!("shaders/vert.spv"));
-        let fs_mod = device.create_shader_module(wgpu::include_spirv!("shaders/frag.spv"));
+        let vs_mod = device.create_shader_module(&wgpu::include_spirv!("shaders/vert.spv"));
+        let fs_mod = device.create_shader_module(&wgpu::include_spirv!("shaders/frag.spv"));
 
         // Create the glyph cache texture.
         let glyph_cache_tex_desc = glyph_cache_tex_desc(glyph_cache_dims);

--- a/backends/conrod_wgpu/src/lib.rs
+++ b/backends/conrod_wgpu/src/lib.rs
@@ -646,7 +646,7 @@ fn pipeline_layout(
     device.create_pipeline_layout(&desc)
 }
 
-fn vertex_attrs() -> [wgpu::VertexAttributeDescriptor; 4] {
+fn vertex_attrs() -> [wgpu::VertexAttribute; 4] {
     let position_offset = 0;
     let position_size = std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress;
     let tex_coords_offset = position_offset + position_size;
@@ -656,25 +656,25 @@ fn vertex_attrs() -> [wgpu::VertexAttributeDescriptor; 4] {
     let mode_offset = rgba_offset + rgba_size;
     [
         // position
-        wgpu::VertexAttributeDescriptor {
+        wgpu::VertexAttribute {
             format: wgpu::VertexFormat::Float2,
             offset: position_offset,
             shader_location: 0,
         },
         // tex_coords
-        wgpu::VertexAttributeDescriptor {
+        wgpu::VertexAttribute {
             format: wgpu::VertexFormat::Float2,
             offset: tex_coords_offset,
             shader_location: 1,
         },
         // rgba
-        wgpu::VertexAttributeDescriptor {
+        wgpu::VertexAttribute {
             format: wgpu::VertexFormat::Float4,
             offset: rgba_offset,
             shader_location: 2,
         },
         // mode
-        wgpu::VertexAttributeDescriptor {
+        wgpu::VertexAttribute {
             format: wgpu::VertexFormat::Uint,
             offset: mode_offset,
             shader_location: 3,

--- a/backends/conrod_wgpu/src/lib.rs
+++ b/backends/conrod_wgpu/src/lib.rs
@@ -111,7 +111,8 @@ pub enum RenderPassCommand<'a> {
 }
 
 const GLYPH_TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;
-const GLYPH_TEX_COMPONENT_TY: wgpu::TextureSampleType = wgpu::TextureSampleType::Uint;
+const GLYPH_TEX_COMPONENT_TY: wgpu::TextureSampleType =
+    wgpu::TextureSampleType::Float { filterable: true };
 const DEFAULT_IMAGE_TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;
 
 impl mesh::ImageDimensions for Image {

--- a/backends/conrod_wgpu/src/lib.rs
+++ b/backends/conrod_wgpu/src/lib.rs
@@ -64,10 +64,10 @@ pub struct Renderer {
     // In order to support a dynamic number of images we maintain a unique bind group for each.
     bind_groups: HashMap<image::Id, wgpu::BindGroup>,
     // We also need a unique
-    render_pipelines: HashMap<wgpu::TextureComponentType, Pipeline>,
+    render_pipelines: HashMap<wgpu::TextureSampleType, Pipeline>,
 }
 
-/// Data that must be unique per `wgpu::TextureComponentType`, i.e. bind group layout and render
+/// Data that must be unique per `wgpu::TextureSampleType`, i.e. bind group layout and render
 /// pipeline.
 struct Pipeline {
     bind_group_layout: wgpu::BindGroupLayout,
@@ -111,7 +111,7 @@ pub enum RenderPassCommand<'a> {
 }
 
 const GLYPH_TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;
-const GLYPH_TEX_COMPONENT_TY: wgpu::TextureComponentType = wgpu::TextureComponentType::Uint;
+const GLYPH_TEX_COMPONENT_TY: wgpu::TextureSampleType = wgpu::TextureSampleType::Uint;
 const DEFAULT_IMAGE_TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;
 
 impl mesh::ImageDimensions for Image {
@@ -121,7 +121,7 @@ impl mesh::ImageDimensions for Image {
 }
 
 impl Image {
-    pub fn texture_component_type(&self) -> wgpu::TextureComponentType {
+    pub fn texture_component_type(&self) -> wgpu::TextureSampleType {
         self.texture_format.into()
     }
 }
@@ -557,7 +557,7 @@ fn sampler_desc() -> wgpu::SamplerDescriptor<'static> {
 
 fn bind_group_layout(
     device: &wgpu::Device,
-    img_tex_component_ty: wgpu::TextureComponentType,
+    img_tex_component_ty: wgpu::TextureSampleType,
 ) -> wgpu::BindGroupLayout {
     let glyph_cache_texture_binding = wgpu::BindGroupLayoutEntry {
         binding: 0,

--- a/backends/conrod_wgpu/src/lib.rs
+++ b/backends/conrod_wgpu/src/lib.rs
@@ -111,8 +111,6 @@ pub enum RenderPassCommand<'a> {
 }
 
 const GLYPH_TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;
-const GLYPH_TEX_COMPONENT_TY: wgpu::TextureSampleType =
-    wgpu::TextureSampleType::Float { filterable: true };
 const DEFAULT_IMAGE_TEX_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R8Unorm;
 
 impl mesh::ImageDimensions for Image {
@@ -551,7 +549,7 @@ fn sampler_desc() -> wgpu::SamplerDescriptor<'static> {
         mipmap_filter: wgpu::FilterMode::Linear,
         lod_min_clamp: -100.0,
         lod_max_clamp: 100.0,
-        compare: Some(wgpu::CompareFunction::Always),
+        compare: None,
         anisotropy_clamp: None,
         ..Default::default()
     }
@@ -566,7 +564,7 @@ fn bind_group_layout(
         visibility: wgpu::ShaderStage::FRAGMENT,
         ty: wgpu::BindingType::Texture {
             multisampled: false,
-            sample_type: GLYPH_TEX_COMPONENT_TY,
+            sample_type: GLYPH_TEX_FORMAT.describe().sample_type,
             view_dimension: wgpu::TextureViewDimension::D2,
         },
         count: None,
@@ -575,8 +573,8 @@ fn bind_group_layout(
         binding: 1,
         visibility: wgpu::ShaderStage::FRAGMENT,
         ty: wgpu::BindingType::Sampler {
-            filtering: false,
-            comparison: true,
+            filtering: true,
+            comparison: false,
         },
         count: None,
     };


### PR DESCRIPTION
This is @yutannihilation's awesome work in #1410 but with a couple of small patches in a final commit.

Both the `all_winit_wgpu` example as well as nannou's downstream UI examples appear to work nicely with these changes.

Closes #1410.