### PR TITLE
Publish version 0.72

### DIFF
--- a/backends/conrod_example_shared/Cargo.toml
+++ b/backends/conrod_example_shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_example_shared"
-version = "0.71.0"
+version = "0.72.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "A small crate for sharing common code between conrod examples."
@@ -11,5 +11,5 @@ homepage = "https://github.com/pistondevelopers/conrod"
 categories = ["gui"]
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = { path = "../../conrod_core", version = "0.72" }
 rand = "0.7"

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_gfx"
-version = "0.71.0"
+version = "0.72.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -15,13 +15,13 @@ name = "conrod_gfx"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = { path = "../../conrod_core", version = "0.72" }
 gfx = { version = "0.18" }
 gfx_core = { version = "0.9" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
-conrod_winit = { path = "../conrod_winit", version = "0.71" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.72" }
+conrod_winit = { path = "../conrod_winit", version = "0.72" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_glium"
-version = "0.71.0"
+version = "0.72.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -15,12 +15,12 @@ name = "conrod_glium"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = { path = "../../conrod_core", version = "0.72" }
 glium = "0.28"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
-conrod_winit = { path = "../conrod_winit", version = "0.71" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.72" }
+conrod_winit = { path = "../conrod_winit", version = "0.72" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_piston/Cargo.toml
+++ b/backends/conrod_piston/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_piston"
-version = "0.71.0"
+version = "0.72.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -21,12 +21,12 @@ name = "conrod_piston"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = { path = "../../conrod_core", version = "0.72" }
 piston2d-graphics = { version = "0.37" }
 pistoncore-input = "1.0.0"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.72" }
 find_folder = "0.3.0"
 image = "0.23"
 petgraph = "0.4"

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_rendy"
-version = "0.71.0"
+version = "0.72.0"
 authors = [
     "David Partouche <david@kaligs.com>",
     "mitchmindtree <mitchell.nordine@gmail.com>",
@@ -15,7 +15,7 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = { path = "../../conrod_core", version = "0.72" }
 lazy_static = "1.4.0"
 rendy = { version = "0.5.1", default-features = false, features = ["base", "texture"] }
 
@@ -30,8 +30,8 @@ no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 profiler = ["rendy/profiler"]
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
-conrod_winit = { path = "../conrod_winit", version = "0.71" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.72" }
+conrod_winit = { path = "../conrod_winit", version = "0.72" }
 find_folder = "0.3.0"
 image = "0.22"
 

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -16,13 +16,16 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+#conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = "0.71"
 vulkano = "0.16"
 vulkano-shaders = "0.16"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
-conrod_winit = { path = "../conrod_winit", version = "0.71" }
+#conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
+conrod_example_shared = "0.71"
+#conrod_winit = { path = "../conrod_winit", version = "0.71" }
+conrod_winit = "0.71"
 find_folder = "0.3"
 image = "0.22"
 vulkano-win = "0.16"

--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_wgpu"
-version = "0.71.0"
+version = "0.72.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
 ]
@@ -14,12 +14,12 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.71" }
+conrod_core = { path = "../../conrod_core", version = "0.72" }
 wgpu = "0.7"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
-conrod_winit = { path = "../conrod_winit", version = "0.71" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.72" }
+conrod_winit = { path = "../conrod_winit", version = "0.72" }
 find_folder = "0.3"
 futures = "0.3"
 image = "0.23"

--- a/backends/conrod_winit/Cargo.toml
+++ b/backends/conrod_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_winit"
-version = "0.71.0"
+version = "0.72.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_core"
-version = "0.71.0"
+version = "0.72.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -21,7 +21,7 @@ stdweb = [ "instant/stdweb" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 
 [dependencies]
-conrod_derive = { path = "../conrod_derive", version = "0.71" }
+conrod_derive = { path = "../conrod_derive", version = "0.72" }
 daggy = "0.5"
 fnv = "1.0"
 num = "0.3"

--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_derive"
-version = "0.71.0"
+version = "0.72.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A crate providing procedural macros for the conrod library"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Changes include:

- Update to rusttype 0.8.3 with more efficient text rendering #1411.
  This includes a **breaking change** that slightly affects how the `Text` render primitive is handled.
  Folks with custom conrod backends may want to take a peak at this PR
  to see how to update.
- Update to wgpu 0.7 and winit 0.24 in `conrod_wgpu`. #1413
- Reduce deps by updating to `num` 0.3. #1395

NOTE: `conrod_vulkano` will be excluded from this version update due to
`vk-sys` publishing a breaking change not too long ago. See #1409.