### PR TITLE
Bump webgpu to 0.8

### DIFF
--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -18,8 +18,8 @@ edition = "2018"
 [dependencies]
 #conrod_core = { path = "../../conrod_core", version = "0.71" }
 conrod_core = "0.71"
-vulkano = "0.17"
-vulkano-shaders = "0.17"
+vulkano = "0.22"
+vulkano-shaders = "0.22"
 
 [dev-dependencies]
 #conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
@@ -28,5 +28,5 @@ conrod_example_shared = "0.71"
 conrod_winit = "0.71"
 find_folder = "0.3"
 image = "0.22"
-vulkano-win = "0.17"
+vulkano-win = "0.22"
 winit = "0.19"

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -18,8 +18,8 @@ edition = "2018"
 [dependencies]
 #conrod_core = { path = "../../conrod_core", version = "0.71" }
 conrod_core = "0.71"
-vulkano = "0.16"
-vulkano-shaders = "0.16"
+vulkano = "0.17"
+vulkano-shaders = "0.17"
 
 [dev-dependencies]
 #conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
@@ -28,5 +28,5 @@ conrod_example_shared = "0.71"
 conrod_winit = "0.71"
 find_folder = "0.3"
 image = "0.22"
-vulkano-win = "0.16"
+vulkano-win = "0.17"
 winit = "0.19"

--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 conrod_core = { path = "../../conrod_core", version = "0.72" }
-wgpu = "0.7"
+wgpu = "0.8"
 
 [dev-dependencies]
 conrod_example_shared = { path = "../conrod_example_shared", version = "0.72" }

--- a/backends/conrod_wgpu/examples/all_winit_wgpu.rs
+++ b/backends/conrod_wgpu/examples/all_winit_wgpu.rs
@@ -202,8 +202,8 @@ fn main() {
                         1 => (&frame.output.view, None),
                         _ => (&multisampled_framebuffer, Some(&frame.output.view)),
                     };
-                    let color_attachment_desc = wgpu::RenderPassColorAttachmentDescriptor {
-                        attachment,
+                    let color_attachment_desc = wgpu::RenderPassColorAttachment {
+                        view: attachment,
                         resolve_target,
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
@@ -262,7 +262,7 @@ fn create_multisampled_framebuffer(
     let multisampled_texture_extent = wgpu::Extent3d {
         width: sc_desc.width,
         height: sc_desc.height,
-        depth: 1,
+        depth_or_array_layers: 1,
     };
     let multisampled_frame_descriptor = &wgpu::TextureDescriptor {
         label: Some("conrod_msaa_texture"),
@@ -288,7 +288,7 @@ fn create_logo_texture(
     let logo_tex_extent = wgpu::Extent3d {
         width,
         height,
-        depth: 1,
+        depth_or_array_layers: 1,
     };
     let logo_tex = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("conrod_rust_logo_texture"),
@@ -305,12 +305,12 @@ fn create_logo_texture(
 
     // Submit command for copying pixel data to the texture.
     let pixel_size_bytes = 4; // Rgba8, as above.
-    let data_layout = wgpu::TextureDataLayout {
+    let data_layout = wgpu::ImageDataLayout {
         offset: 0,
-        bytes_per_row: width * pixel_size_bytes,
-        rows_per_image: height,
+        bytes_per_row: std::num::NonZeroU32::new(width * pixel_size_bytes),
+        rows_per_image: std::num::NonZeroU32::new(height),
     };
-    let texture_copy_view = wgpu::TextureCopyView {
+    let texture_copy_view = wgpu::ImageCopyTexture {
         texture: &logo_tex,
         mip_level: 0,
         origin: wgpu::Origin3d::ZERO,
@@ -318,7 +318,7 @@ fn create_logo_texture(
     let extent = wgpu::Extent3d {
         width: width,
         height: height,
-        depth: 1,
+        depth_or_array_layers: 1,
     };
     let cmd_encoder_desc = wgpu::CommandEncoderDescriptor {
         label: Some("conrod_upload_image_command_encoder"),


### PR DESCRIPTION
I've upgraded webgpu. I can't run all the tests as I'm on windows and don't have `ninja` installed. Hopefully if there's anything wrong the CI will pick it up.

I did run the webgpu backend tests and those were fine.