### PR TITLE
fix for  "panic message is not a string literal".

### DIFF
--- a/conrod_core/src/tests/ui.rs
+++ b/conrod_core/src/tests/ui.rs
@@ -42,11 +42,9 @@ fn assert_event_was_pushed(ui: &Ui, event: event::Event) {
     let found = ui.global_input().events().find(|evt| **evt == event);
     assert!(
         found.is_some(),
-        format!(
             "expected to find event: {:?} in: \nevents: {:?}",
             event,
             ui.global_input().events().collect::<Vec<&event::Event>>()
-        )
     );
 }
 


### PR DESCRIPTION
Fixed "panic message is not a string literal".
format!() macro is not needed, removed for compatibility with Rust 2021 edition.