### PR TITLE
add editable text widgets into conrod examples

### DIFF
--- a/backends/conrod_example_shared/src/lib.rs
+++ b/backends/conrod_example_shared/src/lib.rs
@@ -95,13 +95,19 @@ widget_ids! {
         dialer_title,
         number_dialer,
         plot_path,
+        //user_input
+        text_edit_title,
+        text_box,
+        text_edit,
         // Scrollbar
         canvas_scrollbar,
     }
 }
 
 /// Instantiate a GUI demonstrating every widget available in conrod.
-pub fn gui(ui: &mut conrod_core::UiCell, ids: &Ids, app: &mut DemoApp) {
+pub fn gui(ui: &mut conrod_core::UiCell, ids: &Ids, app: &mut DemoApp,  demo_text:  &String,  demo_text_block:  &String) -> (String, String) {
+    let mut textbox_string = demo_text.to_string();
+    let mut textedit_string = demo_text_block.to_string();
     use conrod_core::{widget, Colorable, Labelable, Positionable, Sizeable, Widget};
     use std::iter::once;
 
@@ -348,6 +354,37 @@ pub fn gui(ui: &mut conrod_core::UiCell, ids: &Ids, app: &mut DemoApp) {
         .align_middle_x_of(ids.canvas)
         .set(ids.plot_path, ui);
 
+    ///////////////////////////
+    ///// user text input /////
+    ///////////////////////////
+    
+    widget::Text::new("Editable text widgets")
+        .down_from(ids.plot_path, 50.0)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.text_edit_title, ui);    
+
+    for text_box in conrod_core::widget::text_box::TextBox::new(&demo_text)
+        .down_from(ids.text_edit_title, 20.0)
+        .center_justify()
+        .set(ids.text_box, ui)
+        {
+                textbox_string = match &text_box{
+                    conrod_core::widget::text_box::Event::Update(textbox_string) => textbox_string.to_string(),
+                    _none => {demo_text.to_string()}
+                };
+        }
+
+    for text_edit in widget::TextEdit::new(&demo_text_block)
+        .center_justify()
+        //.line_spacing(2.5)
+        .restrict_to_height(false)
+        .down_from(ids.text_box, 50.0)
+        .set(ids.text_edit, ui)
+        {
+            textedit_string = text_edit;
+        }
+
     /////////////////////
     ///// Scrollbar /////
     /////////////////////
@@ -355,4 +392,6 @@ pub fn gui(ui: &mut conrod_core::UiCell, ids: &Ids, app: &mut DemoApp) {
     widget::Scrollbar::y_axis(ids.canvas)
         .auto_hide(true)
         .set(ids.canvas_scrollbar, ui);
+
+(textbox_string.to_string(), textedit_string.to_string())
 }

--- a/backends/conrod_gfx/examples/all_winit_gfx.rs
+++ b/backends/conrod_gfx/examples/all_winit_gfx.rs
@@ -50,6 +50,7 @@ fn main() {
         .with_inner_size(glutin::dpi::Size::new(glutin::dpi::PhysicalSize::new(
             WIN_W, WIN_H,
         )));
+    let mut user_input =("Editable text!".to_string(),"Multiple lines of \neditable text!".to_string());
 
     let context = glutin::ContextBuilder::new().with_multisampling(4);
 
@@ -192,7 +193,7 @@ fn main() {
         // Update widgets if any event has happened
         if ui.global_input().events().next().is_some() {
             let mut ui = ui.set_widgets();
-            conrod_example_shared::gui(&mut ui, &ids, &mut app);
+            user_input = conrod_example_shared::gui(&mut ui, &ids, &mut app, &mut user_input.0, &mut user_input.1);
         }
     });
 }

--- a/backends/conrod_glium/examples/all_winit_glium.rs
+++ b/backends/conrod_glium/examples/all_winit_glium.rs
@@ -24,6 +24,8 @@ fn main() {
         .with_multisampling(4);
     let display = glium::Display::new(window, context, &event_loop).unwrap();
 
+    let mut user_input =("Editable text!".to_string(),"Multiple lines of \neditable text!".to_string());
+
     // Construct our `Ui`.
     let mut ui = conrod_core::UiBuilder::new([WIN_W as f64, WIN_H as f64])
         .theme(conrod_example_shared::theme())
@@ -111,7 +113,7 @@ fn main() {
             }
             support::Request::SetUi { needs_redraw } => {
                 // Instantiate a GUI demonstrating every widget type provided by conrod.
-                conrod_example_shared::gui(&mut ui.set_widgets(), &ids, &mut app);
+                user_input = conrod_example_shared::gui(&mut ui.set_widgets(), &ids, &mut app, &mut user_input.0, &mut user_input.1);
 
                 *needs_redraw = ui.has_changed();
             }

--- a/backends/conrod_glium/examples/all_winit_glium_threaded.rs
+++ b/backends/conrod_glium/examples/all_winit_glium_threaded.rs
@@ -71,6 +71,7 @@ fn main() {
         render_tx: std::sync::mpsc::Sender<conrod_core::render::OwnedPrimitives>,
         events_loop_proxy: glium::glutin::event_loop::EventLoopProxy<()>,
     ) {
+        let mut user_input =("Editable text!".to_string(),"Multiple lines of \neditable text!".to_string());
         // Construct our `Ui`.
         let mut ui = conrod_core::UiBuilder::new([WIN_W as f64, WIN_H as f64])
             .theme(conrod_example_shared::theme())
@@ -116,7 +117,7 @@ fn main() {
             }
 
             // Instantiate a GUI demonstrating every widget type provided by conrod.
-            conrod_example_shared::gui(&mut ui.set_widgets(), &ids, &mut app);
+            user_input = conrod_example_shared::gui(&mut ui.set_widgets(), &ids, &mut app, &mut user_input.0, &mut user_input.1);
 
             // Render the `Ui` to a list of primitives that we can send to the main thread for
             // display. Wakeup `winit` for rendering.

--- a/backends/conrod_piston/examples/all_piston_window.rs
+++ b/backends/conrod_piston/examples/all_piston_window.rs
@@ -14,6 +14,7 @@ use self::piston_window::{PistonWindow, UpdateEvent, Window, WindowSettings};
 pub fn main() {
     const WIDTH: u32 = conrod_example_shared::WIN_W;
     const HEIGHT: u32 = conrod_example_shared::WIN_H;
+    let mut user_input =("Editable text!".to_string(),"Multiple lines of \neditable text!".to_string());
 
     // Construct the window.
     let mut window: PistonWindow =
@@ -93,7 +94,7 @@ pub fn main() {
 
         event.update(|_| {
             let mut ui = ui.set_widgets();
-            conrod_example_shared::gui(&mut ui, &ids, &mut app);
+            user_input = conrod_example_shared::gui(&mut ui, &ids, &mut app, &mut user_input.0, &mut user_input.1);
         });
 
         window.draw_2d(&event, |context, graphics, device| {

--- a/backends/conrod_wgpu/examples/all_winit_wgpu.rs
+++ b/backends/conrod_wgpu/examples/all_winit_wgpu.rs
@@ -14,6 +14,7 @@ const MSAA_SAMPLES: u32 = 4;
 
 fn main() {
     let event_loop = EventLoop::new();
+    let mut user_input =("Editable text!".to_string(),"Multiple lines of \neditable text!".to_string());
 
     let backends = wgpu::BackendBit::PRIMARY;
     let instance = wgpu::Instance::new(backends);
@@ -153,7 +154,7 @@ fn main() {
                 ui_update_needed = false;
 
                 // Instantiate a GUI demonstrating every widget type provided by conrod.
-                conrod_example_shared::gui(&mut ui.set_widgets(), &ids, &mut app);
+                user_input = conrod_example_shared::gui(&mut ui.set_widgets(), &ids, &mut app, &mut user_input.0, &mut user_input.1);
 
                 if ui.has_changed() {
                     // If the view has changed at all, request a redraw.


### PR DESCRIPTION
This pull request adds TextEdit and TextBox widgets to the conrod examples. Purpose of this change is to expose inconsistency of handling text input widgets under some backends(for example piston_window backend). 

I am hoping to write a bug report based on this soon.