### PR TITLE
Publish version 0.75.0

### DIFF
--- a/backends/conrod_example_shared/Cargo.toml
+++ b/backends/conrod_example_shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_example_shared"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "A small crate for sharing common code between conrod examples."
@@ -11,5 +11,5 @@ homepage = "https://github.com/pistondevelopers/conrod"
 categories = ["gui"]
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.74" }
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 rand = "0.7"

--- a/backends/conrod_gfx/Cargo.toml
+++ b/backends/conrod_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_gfx"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -15,13 +15,13 @@ name = "conrod_gfx"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.74" }
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 gfx = { version = "0.18" }
 gfx_core = { version = "0.9" }
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.74" }
-conrod_winit = { path = "../conrod_winit", version = "0.74" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.75" }
+conrod_winit = { path = "../conrod_winit", version = "0.75" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_gfx/src/lib.rs
+++ b/backends/conrod_gfx/src/lib.rs
@@ -815,13 +815,7 @@ impl From<gfx::PipelineStateError<String>> for RendererCreationError {
     }
 }
 
-impl std::error::Error for RendererCreationError {
-    fn description(&self) -> &str {
-        match *self {
-            RendererCreationError::PipelineState(ref e) => std::error::Error::description(e),
-        }
-    }
-}
+impl std::error::Error for RendererCreationError {}
 
 impl std::fmt::Display for RendererCreationError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {

--- a/backends/conrod_glium/Cargo.toml
+++ b/backends/conrod_glium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_glium"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 keywords = ["ui", "widgets", "gui", "interface", "graphics"]
 description = "An easy-to-use, 100% Rust, extensible 2D GUI library."
@@ -15,12 +15,12 @@ name = "conrod_glium"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.74" }
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 glium = "0.28"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.74" }
-conrod_winit = { path = "../conrod_winit", version = "0.74" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.75" }
+conrod_winit = { path = "../conrod_winit", version = "0.75" }
 find_folder = "0.3.0"
 image = "0.22"
 petgraph = "0.4"

--- a/backends/conrod_glium/src/lib.rs
+++ b/backends/conrod_glium/src/lib.rs
@@ -1020,14 +1020,7 @@ impl From<glium::program::ProgramChooserCreationError> for RendererCreationError
     }
 }
 
-impl std::error::Error for RendererCreationError {
-    fn description(&self) -> &str {
-        match *self {
-            RendererCreationError::Texture(ref e) => std::error::Error::description(e),
-            RendererCreationError::Program(ref e) => std::error::Error::description(e),
-        }
-    }
-}
+impl std::error::Error for RendererCreationError {}
 
 impl std::fmt::Display for RendererCreationError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
@@ -1050,14 +1043,7 @@ impl From<glium::DrawError> for DrawError {
     }
 }
 
-impl std::error::Error for DrawError {
-    fn description(&self) -> &str {
-        match *self {
-            DrawError::Buffer(ref e) => std::error::Error::description(e),
-            DrawError::Draw(ref e) => std::error::Error::description(e),
-        }
-    }
-}
+impl std::error::Error for DrawError {}
 
 impl std::fmt::Display for DrawError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {

--- a/backends/conrod_piston/Cargo.toml
+++ b/backends/conrod_piston/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_piston"
-version = "0.74.0"
+version = "0.75.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -21,12 +21,12 @@ name = "conrod_piston"
 path = "./src/lib.rs"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.74" }
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 piston2d-graphics = { version = "0.40" }
 pistoncore-input = "1.0.0"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.74" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.75" }
 find_folder = "0.3.0"
 image = "0.23"
 petgraph = "0.4"

--- a/backends/conrod_rendy/Cargo.toml
+++ b/backends/conrod_rendy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_rendy"
-version = "0.74.0"
+version = "0.75.0"
 authors = [
     "David Partouche <david@kaligs.com>",
     "mitchmindtree <mitchell.nordine@gmail.com>",
@@ -15,7 +15,7 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.74" }
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 lazy_static = "1.4.0"
 rendy = { version = "0.5.1", default-features = false, features = ["base", "texture"] }
 
@@ -30,8 +30,8 @@ no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 profiler = ["rendy/profiler"]
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.74" }
-conrod_winit = { path = "../conrod_winit", version = "0.74" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.75" }
+conrod_winit = { path = "../conrod_winit", version = "0.75" }
 find_folder = "0.3.0"
 image = "0.22"
 

--- a/backends/conrod_vulkano/Cargo.toml
+++ b/backends/conrod_vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_vulkano"
-version = "0.74.0"
+version = "0.75.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "Kurble",
@@ -16,15 +16,12 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-#conrod_core = { path = "../../conrod_core", version = "0.71" }
-conrod_core = "0.74"
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 vulkano = "0.24"
 
 [dev-dependencies]
-#conrod_example_shared = { path = "../conrod_example_shared", version = "0.71" }
-conrod_example_shared = "0.74"
-#conrod_winit = { path = "../conrod_winit", version = "0.71" }
-conrod_winit = "0.74"
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.75" }
+conrod_winit = { path = "../conrod_winit", version = "0.75" }
 find_folder = "0.3"
 image = "0.23"
 vulkano-win = "0.24"

--- a/backends/conrod_wgpu/Cargo.toml
+++ b/backends/conrod_wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_wgpu"
-version = "0.74.0"
+version = "0.75.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
 ]
@@ -14,12 +14,12 @@ categories = ["gui"]
 edition = "2018"
 
 [dependencies]
-conrod_core = { path = "../../conrod_core", version = "0.74" }
+conrod_core = { path = "../../conrod_core", version = "0.75" }
 wgpu = "0.10"
 
 [dev-dependencies]
-conrod_example_shared = { path = "../conrod_example_shared", version = "0.74" }
-conrod_winit = { path = "../conrod_winit", version = "0.74" }
+conrod_example_shared = { path = "../conrod_example_shared", version = "0.75" }
+conrod_winit = { path = "../conrod_winit", version = "0.75" }
 find_folder = "0.3"
 futures = "0.3"
 image = "0.23"

--- a/backends/conrod_winit/Cargo.toml
+++ b/backends/conrod_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_winit"
-version = "0.74.0"
+version = "0.75.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"

--- a/conrod_core/Cargo.toml
+++ b/conrod_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_core"
-version = "0.74.0"
+version = "0.75.0"
 authors = [
     "Mitchell Nordine <mitchell.nordine@gmail.com>",
     "Sven Nilsen <bvssvni@gmail.com>"
@@ -21,7 +21,7 @@ stdweb = [ "instant/stdweb" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 
 [dependencies]
-conrod_derive = { path = "../conrod_derive", version = "0.74" }
+conrod_derive = { path = "../conrod_derive", version = "0.75" }
 daggy = "0.5"
 fnv = "1.0"
 num = "0.3"

--- a/conrod_core/src/position/mod.rs
+++ b/conrod_core/src/position/mod.rs
@@ -145,10 +145,10 @@ pub enum Dimension {
 /// Thus, **Positionable** can be implemented for *all* types that implement **Widget**.
 pub trait Positionable: Sized {
     /// Build with the given **Position** along the *x* axis.
-    fn x_position(self, Position) -> Self;
+    fn x_position(self, x: Position) -> Self;
 
     /// Build with the given **Position** along the *y* axis.
-    fn y_position(self, Position) -> Self;
+    fn y_position(self, y: Position) -> Self;
 
     /// Get the **Position** along the *x* axis.
     fn get_x_position(&self, ui: &Ui) -> Position;

--- a/conrod_core/src/widget/list.rs
+++ b/conrod_core/src/widget/list.rs
@@ -61,10 +61,10 @@ pub trait Direction {
     type Axis: widget::scrollbar::Axis;
 
     /// For some given `Rect`, returns the parallel and perpendicular ranges respectively.
-    fn ranges(Rect) -> (Range, Range);
+    fn ranges(r: Rect) -> (Range, Range);
 
     /// Begin building the scrollbar for the `List`.
-    fn scrollbar(widget::Id) -> widget::Scrollbar<Self::Axis>;
+    fn scrollbar(id: widget::Id) -> widget::Scrollbar<Self::Axis>;
 
     /// Borrow the scroll state associated with this `Direction`'s axis.
     fn common_scroll(common: &widget::CommonBuilder) -> Option<&widget::scroll::Scroll>;
@@ -105,8 +105,8 @@ pub trait Direction {
 pub trait ItemSize: Sized + Clone + Copy {
     /// Update the `List` widget.
     fn update_list<D>(
-        List<D, Self>,
-        widget::UpdateArgs<List<D, Self>>,
+        list: List<D, Self>,
+        args: widget::UpdateArgs<List<D, Self>>,
     ) -> <List<D, Self> as Widget>::Event
     where
         D: Direction;

--- a/conrod_core/src/widget/list_select.rs
+++ b/conrod_core/src/widget/list_select.rs
@@ -48,24 +48,24 @@ pub trait Mode {
     /// Update the `PendingEvents` in accordance with the given `Click` event.
     fn click_selection<F, D, S>(
         &self,
-        event::Click,
+        click: event::Click,
         i: usize,
         num_items: usize,
-        &State,
+        state: &State,
         is_selected: F,
-        &mut PendingEvents<Self::Selection, D, S>,
+        events: &mut PendingEvents<Self::Selection, D, S>,
     ) where
         F: Fn(usize) -> bool;
 
     /// Update the `PendingEvents` in accordance with the given `KeyPress` event.
     fn key_selection<F, D, S>(
         &self,
-        event::KeyPress,
+        key_press: event::KeyPress,
         i: usize,
         num_items: usize,
-        &State,
+        state: &State,
         is_selected: F,
-        &mut PendingEvents<Self::Selection, D, S>,
+        events: &mut PendingEvents<Self::Selection, D, S>,
     ) where
         F: Fn(usize) -> bool,
         D: Direction;

--- a/conrod_core/src/widget/mod.rs
+++ b/conrod_core/src/widget/mod.rs
@@ -606,7 +606,7 @@ pub trait Widget: Common + Sized {
     ///
     /// The `Ui` will only call this once, immediately prior to the first time that
     /// **Widget::update** is first called.
-    fn init_state(&self, id::Generator) -> Self::State;
+    fn init_state(&self, id_gen: id::Generator) -> Self::State;
 
     /// Return the styling of the widget.
     ///

--- a/conrod_core/src/widget/primitive/shape/triangles.rs
+++ b/conrod_core/src/widget/primitive/shape/triangles.rs
@@ -26,7 +26,7 @@ pub trait Vertex: Clone + Copy + PartialEq {
     /// The x y location of the vertex.
     fn point(&self) -> Point;
     /// Add the given vector onto the position of self and return the result.
-    fn add(self, Point) -> Self;
+    fn add(self, p: Point) -> Self;
 }
 
 /// Unique styling types for `Triangles`.

--- a/conrod_core/src/widget/scroll.rs
+++ b/conrod_core/src/widget/scroll.rs
@@ -36,11 +36,11 @@ pub struct State<A> {
 /// Methods for distinguishing behaviour between both scroll axes at compile-time.
 pub trait Axis {
     /// The range of the given `Rect` that is parallel with this `Axis`.
-    fn parallel_range(Rect) -> Range;
+    fn parallel_range(r: Rect) -> Range;
     /// The range of the given `Rect` that is perpendicular with this `Axis`.
-    fn perpendicular_range(Rect) -> Range;
+    fn perpendicular_range(r: Rect) -> Range;
     /// Given some rectangular `Padding`, return the `Range` that corresponds with this `Axis`.
-    fn padding_range(Padding) -> Range;
+    fn padding_range(p: Padding) -> Range;
     /// The coordinate of the given mouse position that corresponds with this `Axis`.
     fn mouse_scalar(mouse_xy: Point) -> Scalar;
     /// A `Scalar` multiplier representing the direction in which positive offset shifts the
@@ -141,14 +141,14 @@ where
     ///                         |   |                       |
     ///          >   scrollable |   =========================
     ///          ^      range y |
-    ///          ^              |    
-    ///          ^              |    
-    ///   offset ^              |    
-    ///   bounds ^              |    
-    ///     .end ^              |    
-    ///          ^              |    
-    ///          ^              |    
-    ///          +              >    
+    ///          ^              |
+    ///          ^              |
+    ///   offset ^              |
+    ///   bounds ^              |
+    ///     .end ^              |
+    ///          ^              |
+    ///          ^              |
+    ///          +              >
     ///
     /// ```
     pub fn update(

--- a/conrod_derive/Cargo.toml
+++ b/conrod_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conrod_derive"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A crate providing procedural macros for the conrod library"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Includes:

- Update to `conrod_wgpu` for `wgpu` `0.10.0` #1436
- Fix scizzor behaviour #1437
- Addresses some warnings introduced in recent versions of Rust.